### PR TITLE
Port .hgignore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.svn/
+.hg/
+.hgtags/
+*.py[cod]
+log
+build
+dist/
+astroid.egg-info/
+.tox

--- a/.hgignore
+++ b/.hgignore
@@ -1,9 +1,0 @@
-(^|/)\.svn($|/)
-(^|/)\.hg($|/)
-(^|/)\.hgtags($|/)
-\.pyc$
-^log$
-^doc/build$
-^dist/
-^astroid\.egg-info/
-^\.tox/


### PR DESCRIPTION
For future iterations, we should switch to using pre-canned ignore lists
from https://gitignore.io.