### PR TITLE
Check for flags/enum types before checking for int

### DIFF
--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -47,13 +47,13 @@ def _gi_build_stub(parent):
         elif (inspect.ismethod(obj) or
               inspect.ismethoddescriptor(obj)):
             methods[name] = obj
-        elif isinstance(obj, (int, str)):
-            constants[name] = obj
         elif (str(obj).startswith("<flags") or
               str(obj).startswith("<enum ") or
               str(obj).startswith("<GType ") or
               inspect.isdatadescriptor(obj)):
             constants[name] = 0
+        elif isinstance(obj, (int, str)):
+            constants[name] = obj
         elif callable(obj):
             # Fall back to a function for anything callable
             functions[name] = obj


### PR DESCRIPTION
Running _import_gi_module('gi.repository.GLib') with astroid-1.4.1 fails with a syntax error while trying to parse the generated module stub, and I found that the modcode contained properties such as:

`IO_ERR = <flags G_IO_ERR of type GLib.IOCondition>`

This is due to the switch from `type(x) == y` to `isinstance(x, y)` in a079c3d4abecee064c3ab4c44f086b618f06fa8c. GLib.IO_ERR, for example, returns gi.repository.GLib.GIOCondition for type(), but also inherits from int.