### PR TITLE
Setup a basic AppVeyor deployment.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+version: '{branch}-{build}'
+build: off
+cache:
+  - 'C:\\tmp'
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27"
+
+    - PYTHON: "C:\\Python33"
+      TOXENV: "py33"
+
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34"
+
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35"
+
+init:
+  - ps: echo $env:TOXENV
+  - ps: ls C:\Python*
+install:
+  - 'powershell ./appveyor/install.ps1'
+  - "python -m pip install tox"
+  - 'python -m pip install wheel'
+  - 'python -m pip --version'
+  - 'python -m tox --version'
+
+test_script:
+  - 'python -m tox'
+
+on_failure:
+  - ps: dir "env:"
+  - ps: get-content .tox\*\log\*

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,27 @@
+# Sample script to install pip under Windows
+# Authors: Olivier Grisel, Jonathan Helmus and Kyle Kastner
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+$GET_PIP_PATH = "C:\get-pip.py"
+$ErrorActionPreference = "Stop"
+
+function InstallPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $python_path = $python_home + "\python.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+        Write-Host "Executing:" $python_path $GET_PIP_PATH
+        Start-Process -FilePath "$python_path" -ArgumentList "$GET_PIP_PATH" -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+function main () {
+    InstallPip $env:PYTHON
+}
+
+main


### PR DESCRIPTION
Hey folks,

Here's a basic setup of AppVeyor which I'd like to get into astroid as part of its testing suite. It kinda works so far, but depending on numpy takes its toll reflected on the unusual build run time (almost an hour for all the Python versions). I tried multiple solutions, but none worked so far. If you have any idea how we might improve things on this side, please tell me about it. 

cc @The-Compiler would you mind setting up an AppVeyor account for pylint-bot, when you'll get some time? Most probably using it is the best solution.