### PR TITLE
Add support for inference on threading.Lock

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@ Change log for the astroid package (used to be astng)
 =====================================================
 
 --
+    * Add support for inference on threading.Lock
+
+    As a matter of fact, astroid can infer on threading.RLock,
+    threading.Semaphore, but can't do it on threading.Lock (because it comes
+    from an extension module).
 
     * Some nodes got a new attribute, 'ctx', which tells in which context
       the said node was used.

--- a/astroid/brain/brain_stdlib.py
+++ b/astroid/brain/brain_stdlib.py
@@ -424,6 +424,15 @@ def multiprocessing_managers_transform():
             pass
     '''))
 
+def thread_transform():
+    return AstroidBuilder(MANAGER).string_build('''
+
+class Lock(object):
+    def acquire(self, blocking=True):
+        pass
+    def release(self):
+        pass
+''')
 
 MANAGER.register_transform(nodes.Call, inference_tip(infer_named_tuple),
                            _looks_like_namedtuple)
@@ -437,3 +446,4 @@ register_module_extender(MANAGER, 'subprocess', subprocess_transform)
 register_module_extender(MANAGER, 'multiprocessing.managers',
                          multiprocessing_managers_transform)
 register_module_extender(MANAGER, 'multiprocessing', multiprocessing_transform)
+register_module_extender(MANAGER, 'threading', thread_transform)

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -357,6 +357,21 @@ class MultiprocessingBrainTest(unittest.TestCase):
         self.assertTrue(manager.getattr('start'))
         self.assertTrue(manager.getattr('shutdown'))
 
+class ThreadingBrainTest(unittest.TestCase):
+    def test_threading(self):
+        module = test_utils.extract_node("""
+        import threading
+        threading.Lock()
+        """)
+        inferred = next(module.infer())
+        self.assertIsInstance(inferred.root(), astroid.Module)
+        self.assertEqual(inferred.root().name, 'threading')
+        self.assertEqual(inferred.pytype(), 'threading.Lock')
+        self.assertIsInstance(inferred.getattr('acquire')[0],
+                              astroid.FunctionDef)
+        self.assertIsInstance(inferred.getattr('release')[0],
+                              astroid.FunctionDef)
+
 
 @unittest.skipUnless(HAS_ENUM,
                      'The enum module was only added in Python 3.4. Support for '


### PR DESCRIPTION
For now the test fails, due to issue #265. Based on PR #296, everything is OK.