### PR TITLE
Add /usr/lib and /usr/lib64 to the list of stdlib paths

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -54,12 +54,7 @@ else:
     PY_SOURCE_EXTS = ('py',)
     PY_COMPILED_EXTS = ('so',)
 
-# Notes about STD_LIB_DIRS
-# Consider arch-specific installation for STD_LIB_DIRS definition
-# :mod:`distutils.sysconfig` contains to much hardcoded values to rely on
-#
-# :see: `Problems with /usr/lib64 builds <http://bugs.python.org/issue1294959>`_
-# :see: `FHS <http://www.pathname.com/fhs/pub/fhs-2.3.html#LIBLTQUALGTALTERNATEFORMATESSENTIAL>`_
+
 try:
     # The explicit sys.prefix is to work around a patch in virtualenv that
     # replaces the 'real' sys.prefix (i.e. the location of the binary)
@@ -92,6 +87,28 @@ if platform.python_implementation() == 'PyPy':
     except AttributeError:
         pass
     del _root
+if os.name == 'posix':
+    # Need the real prefix is we're under a virtualenv, otherwise
+    # the usual one will do.
+    try:
+        prefix = sys.real_prefix
+    except AttributeError:
+        prefix = sys.prefix
+
+    def _posix_path(path):
+        base_python = 'python%d.%d' % sys.version_info[:2]
+        return os.path.join(prefix, path, base_python)
+
+    STD_LIB_DIRS.add(_posix_path('lib'))
+    if sys.maxsize > 2**32:
+        # This tries to fix a problem with /usr/lib64 builds,
+        # where systems are running both 32-bit and 64-bit code
+        # on the same machine, which reflects into the places where
+        # standard library could be found. More details can be found
+        # here http://bugs.python.org/issue1294959.
+        # An easy reproducing case would be
+        # https://github.com/PyCQA/pylint/issues/712#issuecomment-163178753
+        STD_LIB_DIRS.add(_posix_path('lib64'))
 
 EXT_LIB_DIR = get_python_lib()
 IS_JYTHON = platform.python_implementation() == 'Jython'


### PR DESCRIPTION
This patch adds /usr/lib/python{ver} and /usr/lib64/python{ver} to the list of places where a standard module library could be found.  Issues such as https://github.com/PyCQA/pylint/issues/725 are occurring because those modules are found in /usr/lib64/python2.7, which were not looked before by modutils.is_standard_module. @The-Compiler since you're more familiar with Unix systems that me, do you find this approach safe? Can there be extension packages installed there instead of /usr/local/lib/python{ver} on other OSes? The idea is to have a list of standard library places, so that is_standard_module(module_name) returns true for them, which in certain cases could lead to importing those modules if they are C extensions, so this might not be safe if third party modules get installed there.