### PR TITLE
added 3 pkg_resources functions to brain

### DIFF
--- a/astroid/brain/brain_stdlib.py
+++ b/astroid/brain/brain_stdlib.py
@@ -150,6 +150,15 @@ class deque(object):
 
 def pkg_resources_transform():
     return AstroidBuilder(MANAGER).string_build('''
+def require(*requirements):
+    return pkg_resources.working_set.require(*requirements)
+
+def run_script(requires, script_name):
+    return pkg_resources.working_set.run_script(requires, script_name)
+
+def iter_entry_points(group, name=None):
+    return pkg_resources.working_set.iter_entry_points(group, name)
+
 def resource_exists(package_or_requirement, resource_name):
     return get_provider(package_or_requirement).has_resource(resource_name)
 


### PR DESCRIPTION
[Those 3 are] methods of WorkingSet objects [that] are also available
as module- level functions in pkg_resources that apply to the default
working_set instance. Thus, you can use e.g. pkg_resources.require()
as an abbreviation for pkg_resources.working_set.require()

above taken from:
https://pythonhosted.org/setuptools/pkg_resources.html#basic-workingset-methods

this fixes https://github.com/PyCQA/pylint/issues/780

Signed-off-by: Mateusz Bysiek <mb@mbdev.pl>