### PR TITLE
Fix unpack_infer() to fail if results are empty.

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -42,7 +42,7 @@ from astroid import util
 BUILTINS = six.moves.builtins.__name__
 MANAGER = manager.AstroidManager()
 
-
+@decorators.raise_if_nothing_inferred
 def unpack_infer(stmt, context=None):
     """recursively generate nodes inferred by the given statement.
     If the inferred value is a list or a tuple, recurse on the elements

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -42,6 +42,7 @@ from astroid import util
 BUILTINS = six.moves.builtins.__name__
 MANAGER = manager.AstroidManager()
 
+
 @decorators.raise_if_nothing_inferred
 def unpack_infer(stmt, context=None):
     """recursively generate nodes inferred by the given statement.

--- a/astroid/tests/unittest_utils.py
+++ b/astroid/tests/unittest_utils.py
@@ -18,6 +18,7 @@
 import unittest
 
 from astroid import builder
+from astroid import InferenceError
 from astroid import nodes
 from astroid import node_classes
 from astroid import test_utils
@@ -110,7 +111,14 @@ class InferenceUtil(unittest.TestCase):
         self.assertTrue(all(elt is astroid_util.Uninferable
                             for elt in unpacked))
 
+    def test_unpack_infer_empty_tuple(self):
+        node = test_utils.extract_node('''
+        ()
+        ''')
+        inferred = next(node.infer())
+        with self.assertRaises(InferenceError) as cm:
+          unpacked = list(node_classes.unpack_infer(inferred))
+
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
As expected, this will also fix pylint so that it correctly deals with "raise ()" in the python3 checker.