### PR TITLE
Fix metaclass infinite loop when a class is its own metaclass.

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -68,7 +68,7 @@ def _object_type(node, context=None):
     for inferred in node.infer(context=context):
         if isinstance(inferred, scoped_nodes.ClassDef):
             if inferred.newstyle:
-                metaclass = inferred.metaclass()
+                metaclass = inferred.metaclass(context=context)
                 if metaclass:
                     yield metaclass
                     continue

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1548,7 +1548,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
             return builtin_lookup('type')[1][0]
 
     _metaclass = None
-    def declared_metaclass(self):
+    def declared_metaclass(self, context=None):
         """Return the explicit declared metaclass for the current class.
 
         An explicit declared metaclass is defined
@@ -1591,35 +1591,35 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
             return None
 
         try:
-            inferred = next(assignment.infer())
+            inferred = next(assignment.infer(context=context))
         except exceptions.InferenceError:
             return
         if inferred is util.Uninferable: # don't expose this
             return None
         return inferred
 
-    def _find_metaclass(self, seen=None):
+    def _find_metaclass(self, seen=None, context=None):
         if seen is None:
             seen = set()
         seen.add(self)
 
-        klass = self.declared_metaclass()
+        klass = self.declared_metaclass(context=context)
         if klass is None:
             for parent in self.ancestors():
                 if parent not in seen:
-                    klass = parent._find_metaclass(seen)
+                    klass = parent._find_metaclass(seen, context=context)
                     if klass is not None:
                         break
         return klass
 
-    def metaclass(self):
+    def metaclass(self, context=None):
         """Return the metaclass of this class.
 
         If this class does not define explicitly a metaclass,
         then the first defined metaclass in ancestors will be used
         instead.
         """
-        return self._find_metaclass()
+        return self._find_metaclass(context=context)
 
     def has_metaclass_hack(self):
         return self._metaclass_hack

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -1093,6 +1093,15 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         for klass in ast_nodes:
             self.assertEqual(None, klass.metaclass())
 
+    def test_no_infinite_metaclass_loop_with_self_meta(self):
+        klass = test_utils.extract_node("""
+            class SSS(object):  #@
+              pass
+
+            SSS.__metaclass__ = type(SSS)
+        """)
+        self.assertEqual(None, klass.metaclass())
+
     def test_metaclass_generator_hack(self):
         klass = test_utils.extract_node("""
             import six


### PR DESCRIPTION
The unit test shows some very strange source code that can cause an infinite recursion in astroid.  It looks like the context normally provides protection against this sort of thing, but it isn't plumbed through to the check of the assignment.  Here's one possible fix.  I'm completely open to other solutions for fixing this since adding the context arg to a few methods does seem a bit invasive.  Maybe there's a cleaner solution.