### PR TITLE
Introduce a special attributes model

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,14 @@ Change log for the astroid package (used to be astng)
 
       Closes issue #322
 
+    * Introduce a special attributes model
+
+      Through this model, astroid starts knowing special attributes of certain Python objects,
+      such as functions, classes, super objects and so on. This was previously possible before,
+      but now the lookup and the attributes themselves are separated into a new module,
+      objectmodel.py, which describes, in a more comprehensive way, the data model of each
+      object.
+
     * Changed the way how parameters are being built
 
       The old way consisted in having the parameter names, their

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -1,0 +1,514 @@
+# copyright 2003-2016 LOGILAB S.A. (Paris, FRANCE), all rights reserved.
+# contact http://www.logilab.fr/ -- mailto:contact@logilab.fr
+#
+# This file is part of astroid.
+#
+# astroid is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 2.1 of the License, or (at your
+# option) any later version.
+#
+# astroid is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with astroid. If not, see <http://www.gnu.org/licenses/>.
+#
+# The code in this file was originally part of logilab-common, licensed under
+# the same license.
+
+"""
+Data object model, as per https://docs.python.org/3/reference/datamodel.html.
+
+This module describes, at least partially, a data object model for some
+of astroid's nodes. The model contains special attributes that nodes such
+as functions, classes, modules etc have, such as __doc__, __class__,
+__module__ etc, being used when doing attribute lookups over nodes.
+
+For instance, inferring `obj.__class__` will first trigger an inference
+of the `obj` variable. If it was succesfully inferred, then an attribute
+`__class__ will be looked for in the inferred object. This is the part
+where the data model occurs. The model is attached to those nodes
+and the lookup mechanism will try to see if attributes such as
+`__class__` are defined by the model or not. If they are defined,
+the model will be requested to return the corresponding value of that
+attribute. Thus the model can be viewed as a special part of the lookup
+mechanism.
+"""
+
+import itertools
+import pprint
+import os
+
+import six
+
+import astroid
+from astroid import context as contextmod
+from astroid import exceptions
+from astroid.interpreter import util
+from astroid.tree import node_classes
+from astroid.tree import treeabc
+from astroid.util import lazy_import
+
+objects = lazy_import('interpreter.objects')
+
+
+def _dunder_dict(instance, attributes):
+    obj = node_classes.Dict(parent=instance)
+
+    # Convert the keys to node strings
+    keys = [node_classes.Const(value=value, parent=obj)
+            for value in list(attributes.keys())]
+
+    # The original attribute has a list of elements for each key,
+    # but that is not useful for retrieving the special attribute's value.
+    # In this case, we're picking the last value from each list.
+    values = [elem[-1] for elem in attributes.values()]
+
+    obj.postinit(keys=keys, values=values)
+    return obj
+
+
+class ObjectModel(object):
+
+    def __repr__(self):
+        result = []
+        cname = type(self).__name__
+        string = '%(cname)s(%(fields)s)'
+        alignment = len(cname) + 1
+        for field in sorted(self.attributes()):
+            width = 80 - len(field) - alignment
+            lines = pprint.pformat(field, indent=2,
+                                   width=width).splitlines(True)
+
+            inner = [lines[0]]
+            for line in lines[1:]:
+                inner.append(' ' * alignment + line)
+            result.append(field)
+
+        return string % {'cname': cname,
+                         'fields': (',\n' + ' ' * alignment).join(result)}
+
+    def __call__(self, instance):
+        self._instance = instance
+        return self
+
+    def __get__(self, instance, cls=None):
+        # ObjectModel needs to be a descriptor so that just doing
+        # `special_attributes = SomeObjectModel` should be enough in the body of a node.
+        # But at the same time, node.special_attributes should return an object
+        # which can be used for manipulating the special attributes. That's the reason
+        # we pass the instance through which it got accessed to ObjectModel.__call__,
+        # returning itself afterwards, so we can still have access to the
+        # underlying data model and to the instance for which it got accessed.
+        return self(instance)
+
+    def __contains__(self, name):
+        return name in self.attributes()
+
+    def attributes(self):
+        """Get the attributes which are exported by this object model."""
+        return [obj[2:] for obj in dir(self) if obj.startswith('py')]
+
+    def lookup(self, name):
+        """Look up the given *name* in the current model
+
+        It should return an AST or an interpreter object,
+        but if the name is not found, then an AttributeInferenceError will be raised.
+        """
+
+        if name in self.attributes():
+            return getattr(self, "py" + name)
+        raise exceptions.AttributeInferenceError(target=self._instance, attribute=name)
+
+
+class ModuleModel(ObjectModel):
+
+    def _builtins(self):
+        builtins = astroid.MANAGER.builtins()
+        return builtins.special_attributes.lookup('__dict__')
+
+    if six.PY3:
+        @property
+        def pybuiltins(self):
+            return self._builtins()
+
+    else:
+        @property
+        def py__builtin__(self):
+            return self._builtins()
+
+    # __path__ is a standard attribute on *packages* not
+    # non-package modules.  The only mention of it in the
+    # official 2.7 documentation I can find is in the
+    # tutorial.
+
+    @property
+    def py__path__(self):
+        if not self._instance.package:
+            raise exceptions.AttributeInferenceError(target=self._instance,
+                                                     attribute='__path__')
+
+        path = os.path.dirname(self._instance.source_file)
+        path_obj = node_classes.Const(value=path, parent=self._instance)
+
+        container = node_classes.List(parent=self._instance)
+        container.postinit([path_obj])
+
+        return container
+
+    @property
+    def py__name__(self):
+        return node_classes.Const(value=self._instance.name,
+                                  parent=self._instance)
+
+    @property
+    def py__doc__(self):
+        return node_classes.Const(value=self._instance.doc,
+                                  parent=self._instance)
+
+    @property
+    def py__file__(self):
+        return node_classes.Const(value=self._instance.source_file,
+                                  parent=self._instance)
+
+    @property
+    def py__dict__(self):
+        return _dunder_dict(self._instance, self._instance.globals)
+
+    # __package__ isn't mentioned anywhere outside a PEP:
+    # https://www.python.org/dev/peps/pep-0366/
+    @property
+    def py__package__(self):
+        if not self._instance.package:
+            value = ''
+        else:
+            value = self._instance.name
+
+        return node_classes.Const(value=value, parent=self._instance)
+
+    # These are related to the Python 3 implementation of the
+    # import system,
+    # https://docs.python.org/3/reference/import.html#import-related-module-attributes
+
+    @property
+    def py__spec__(self):
+        # No handling for now.
+        return node_classes.Unknown()
+
+    @property
+    def py__loader__(self):
+        # No handling for now.
+        return node_classes.Unknown()
+
+    @property
+    def py__cached__(self):
+        # No handling for now.
+        return node_classes.Unknown()
+
+
+class FunctionModel(ObjectModel):
+
+    @property
+    def py__name__(self):
+        return node_classes.Const(value=self._instance.name,
+                                  parent=self._instance)
+
+    @property
+    def py__doc__(self):
+        return node_classes.Const(value=self._instance.doc,
+                                  parent=self._instance)
+
+    @property
+    def py__qualname__(self):
+        return node_classes.Const(value=self._instance.qname(),
+                                  parent=self._instance)
+
+    @property
+    def py__defaults__(self):
+        func = self._instance
+        defaults = [arg.default for arg in func.args.args if arg.default]
+
+        if not defaults:
+            return node_classes.Const(value=None, parent=func)
+
+        defaults_obj = node_classes.Tuple(parent=func)
+        defaults_obj.postinit(defaults)
+        return defaults_obj
+
+    @property
+    def py__annotations__(self):
+        obj = node_classes.Dict(parent=self._instance)
+
+        if not self._instance.returns:
+            returns = node_classes.Empty
+        else:
+            returns = self._instance.returns
+
+        args = itertools.chain(self._instance.args.positional_and_keyword,
+                               (self._instance.args.vararg, ),
+                               (self._instance.args.kwarg, ),
+                               self._instance.args.keyword_only)
+        annotations = {arg.name: arg.annotation for arg in args
+                       if arg and arg.annotation}
+        annotations['return'] = returns
+
+        keys = [node_classes.Const(key, parent=obj)
+                for key in annotations.keys()]
+
+        obj.postinit(keys=keys, values=list(annotations.values()))
+        return obj
+
+    @property
+    def py__dict__(self):
+        return node_classes.Dict(parent=self._instance)
+
+    py__globals__ = py__dict__
+
+    @property
+    def py__kwdefaults__(self):
+        defaults = {arg.name: arg.default for arg in self._instance.args.keyword_only
+                    if arg.default}
+
+        obj = node_classes.Dict(parent=self._instance)
+        keys = [node_classes.Const(key, parent=obj) for key in defaults.keys()]
+        obj.postinit(keys=keys, values=list(defaults.values()))
+        return obj
+
+    @property
+    def py__module__(self):
+        return node_classes.Const(self._instance.root().qname())
+
+    @property
+    def py__get__(self):
+        func = self._instance
+
+        class DescriptorBoundMethod(objects.BoundMethod):
+            """Bound method which knows how to understand calling descriptor binding."""
+            def infer_call_result(self, caller, context=None):
+                if len(caller.args) != 2:
+                    raise exceptions.InferenceError(
+                        "Invalid arguments for descriptor binding",
+                        target=self, context=context)
+
+                context = contextmod.copy_context(context)
+                cls = next(caller.args[0].infer(context=context))
+
+                # Rebuild the original value, but with the parent set as the
+                # class where it will be bound.
+                new_func = func.__class__(name=func.name, doc=func.doc,
+                                          lineno=func.lineno, col_offset=func.col_offset,
+                                          parent=cls)
+                new_func.postinit(func.args, func.body,
+                                  func.decorators, func.returns)
+
+                # Build a proper bound method that points to our newly built function.
+                proxy = objects.UnboundMethod(new_func)
+                yield objects.BoundMethod(proxy=proxy, bound=cls)
+
+        return DescriptorBoundMethod(proxy=self._instance, bound=self._instance)
+
+    # These are here just for completion.
+    @property
+    def py__ne__(self):
+        return node_classes.Unknown()
+
+    py__subclasshook__ = py__ne__
+    py__str__ = py__ne__
+    py__sizeof__ = py__ne__
+    py__setattr__ = py__ne__
+    py__repr__ = py__ne__
+    py__reduce__ = py__ne__
+    py__reduce_ex__ = py__ne__
+    py__new__ = py__ne__
+    py__lt__ = py__ne__
+    py__eq__ = py__ne__
+    py__gt__ = py__ne__
+    py__format__ = py__ne__
+    py__delattr__ = py__ne__
+    py__getattribute__ = py__ne__
+    py__hash__ = py__ne__
+    py__init__ = py__ne__
+    py__dir__ = py__ne__
+    py__call__ = py__ne__
+    py__class__ = py__ne__
+    py__closure__ = py__ne__
+    py__code__ = py__ne__
+
+
+class ClassModel(ObjectModel):
+
+    @property
+    def py__module__(self):
+        return node_classes.Const(self._instance.root().qname())
+
+    @property
+    def py__name__(self):
+        return node_classes.Const(self._instance.name)
+
+    @property
+    def py__qualname__(self):
+        return node_classes.Const(self._instance.qname())
+
+    @property
+    def py__doc__(self):
+        return node_classes.Const(self._instance.doc)
+
+    @property
+    def py__mro__(self):
+        if not self._instance.newstyle:
+            raise exceptions.AttributeInferenceError(target=self._instance,
+                                                     attribute='__mro__')
+
+        mro = self._instance.mro()
+        obj = node_classes.Tuple(parent=self._instance)
+        obj.postinit(mro)
+        return obj
+
+    @property
+    def pymro(self):
+        other_self = self
+
+        # Cls.mro is a method and we need to return one in order to have a proper inference.
+        # The method we're returning is capable of inferring the underlying MRO though.
+        class MroBoundMethod(objects.BoundMethod):
+            def infer_call_result(self, caller, context=None):
+                yield other_self.py__mro__
+        return MroBoundMethod(proxy=self._instance, bound=self._instance)
+
+    @property
+    def py__bases__(self):
+        obj = node_classes.Tuple()
+        context = contextmod.InferenceContext()
+        elts = list(self._instance._inferred_bases(context))
+        obj.postinit(elts=elts)
+        return obj
+
+    @property
+    def py__class__(self):
+        return util.object_type(self._instance)
+
+    @property
+    def py__subclasses__(self):
+        """Get the subclasses of the underlying class
+
+        This looks only in the current module for retrieving the subclasses,
+        thus it might miss a couple of them.
+        """
+
+        if not self._instance.newstyle:
+            raise exceptions.AttributeInferenceError(target=self._instance,
+                                                     attribute='__subclasses__')
+
+        qname = self._instance.qname()
+        root = self._instance.root()
+        classes = [cls for cls in root.nodes_of_class(treeabc.ClassDef)
+                   if cls != self._instance and cls.is_subtype_of(qname)]
+
+        obj = node_classes.List(parent=self._instance)
+        obj.postinit(classes)
+
+        class SubclassesBoundMethod(objects.BoundMethod):
+            def infer_call_result(self, caller, context=None):
+                yield obj
+
+        return SubclassesBoundMethod(proxy=self._instance, bound=self._instance)
+
+    @property
+    def py__dict__(self):
+        return node_classes.Dict(parent=self._instance)
+
+
+class SuperModel(ObjectModel):
+
+    @property
+    def py__thisclass__(self):
+        return self._instance.mro_pointer
+
+    @property
+    def py__self_class__(self):
+        return self._instance._self_class
+
+    @property
+    def py__self__(self):
+        return self._instance.type
+
+    @property
+    def py__class__(self):
+        return self._instance._proxied
+
+
+class UnboundMethodModel(ObjectModel):
+
+    @property
+    def py__class__(self):
+        return util.object_type(self._instance)
+
+    @property
+    def py__func__(self):
+        return self._instance._proxied
+
+    @property
+    def py__self__(self):
+        return node_classes.Const(value=None, parent=self._instance)
+
+    pyim_func = py__func__
+    pyim_class = py__class__
+    pyim_self = py__self__
+
+
+class BoundMethodModel(FunctionModel):
+
+    @property
+    def py__func__(self):
+        return self._instance._proxied._proxied
+
+    @property
+    def py__self__(self):
+        return self._instance.bound
+
+
+class GeneratorModel(FunctionModel):
+
+    def __new__(self, *args, **kwargs):
+        # Append the values from the GeneratorType unto this object.
+        cls = super(GeneratorModel, self).__new__(self, *args, **kwargs)
+        generator = astroid.MANAGER.builtins()['generator']
+        for name, values in generator.locals.items():
+            method = values[0]
+            patched = lambda self, meth=method: meth
+
+            setattr(type(cls), 'py' + name, property(patched))
+
+        return cls
+
+    @property
+    def py__name__(self):
+        return node_classes.Const(value=self._instance.parent.name,
+                                  parent=self._instance)
+
+    @property
+    def py__doc__(self):
+        return node_classes.Const(value=self._instance.parent.doc,
+                                  parent=self._instance)
+
+
+class InstanceModel(ObjectModel):
+
+    @property
+    def py__class__(self):
+        return self._instance._proxied
+
+    @property
+    def py__module__(self):
+        return node_classes.Const(self._instance.root().qname())
+
+    @property
+    def py__doc__(self):
+        return node_classes.Const(self._instance.doc)
+
+    @property
+    def py__dict__(self):
+        return _dunder_dict(self._instance, self._instance.instance_attrs)

--- a/astroid/tests/unittest_object_model.py
+++ b/astroid/tests/unittest_object_model.py
@@ -1,0 +1,432 @@
+# copyright 2003-2016 LOGILAB S.A. (Paris, FRANCE), all rights reserved.
+# contact http://www.logilab.fr/ -- mailto:contact@logilab.fr
+#
+# This file is part of astroid.
+#
+# astroid is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 2.1 of the License, or (at your
+# option) any later version.
+#
+# astroid is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with astroid. If not, see <http://www.gnu.org/licenses/>.
+#
+# The code in this file was originally part of logilab-common, licensed under
+# the same license.
+
+import unittest
+import types
+import xml
+
+import six
+
+import astroid
+from astroid import exceptions
+from astroid import MANAGER
+from astroid import test_utils
+
+
+BUILTINS = MANAGER.builtins()
+
+
+class InstanceModelTest(unittest.TestCase):
+
+    def test_instance_special_model(self):
+        ast_nodes = test_utils.extract_node('''
+        class A:
+            "test"
+            def __init__(self):
+                self.a = 42
+        a = A()
+        a.__class__ #@
+        a.__module__ #@
+        a.__doc__ #@
+        a.__dict__ #@
+        ''', module_name='collections')
+
+        cls = next(ast_nodes[0].infer())
+        self.assertIsInstance(cls, astroid.ClassDef)
+        self.assertEqual(cls.name, 'A')
+
+        module = next(ast_nodes[1].infer())
+        self.assertIsInstance(module, astroid.Const)
+        self.assertEqual(module.value, 'collections')
+        
+        doc = next(ast_nodes[2].infer())
+        self.assertIsInstance(doc, astroid.Const)
+        self.assertEqual(doc.value, 'test')
+
+        dunder_dict = next(ast_nodes[3].infer())
+        self.assertIsInstance(dunder_dict, astroid.Dict)
+        attr = next(dunder_dict.getitem('a').infer())          
+        self.assertIsInstance(attr, astroid.Const)
+        self.assertEqual(attr.value, 42)
+
+    @unittest.expectedFailure
+    def test_instance_local_attributes_overrides_object_model(self):
+        # The instance lookup needs to be changed in order for this to work.
+        ast_node = test_utils.extract_node('''
+        class A:
+            @property
+            def __dict__(self):
+                  return []
+        A().__dict__
+        ''')
+        inferred = next(ast_node.infer())
+        self.assertIsInstance(inferred, astroid.List)
+        self.assertEqual(inferred.elts, [])
+
+
+class BoundMethodModelTest(unittest.TestCase):
+
+    def test_bound_method_model(self):
+        ast_nodes = test_utils.extract_node('''
+        class A:
+            def test(self): pass
+        a = A()
+        a.test.__func__ #@
+        a.test.__self__ #@
+        ''')
+
+        func = next(ast_nodes[0].infer())
+        self.assertIsInstance(func, astroid.FunctionDef)
+        self.assertEqual(func.name, 'test')
+
+        self_ = next(ast_nodes[1].infer())
+        self.assertIsInstance(self_, astroid.Instance)
+        self.assertEqual(self_.name, 'A')
+
+
+class UnboundMethodModelTest(unittest.TestCase):
+
+    def test_unbound_method_model(self):
+        ast_nodes = test_utils.extract_node('''
+        class A:
+            def test(self): pass
+        t = A.test
+        t.__class__ #@
+        t.__func__ #@
+        t.__self__ #@
+        t.im_class #@
+        t.im_func #@
+        t.im_self #@
+        ''')
+
+        cls = next(ast_nodes[0].infer())
+        self.assertIsInstance(cls, astroid.ClassDef)
+        if six.PY2:
+            unbound = BUILTINS.locals[types.MethodType.__name__][0]
+        else:
+            unbound = BUILTINS.locals[types.FunctionType.__name__][0]
+        self.assertIs(cls, unbound)
+
+        func = next(ast_nodes[1].infer())
+        self.assertIsInstance(func, astroid.FunctionDef)
+        self.assertEqual(func.name, 'test')
+
+        self_ = next(ast_nodes[2].infer())
+        self.assertIsInstance(self_, astroid.Const)
+        self.assertIsNone(self_.value)
+
+        self.assertEqual(cls, next(ast_nodes[3].infer()))
+        self.assertEqual(func, next(ast_nodes[4].infer()))
+        self.assertIsNone(next(ast_nodes[5].infer()).value)
+
+
+class ClassModelTest(unittest.TestCase):
+
+    @test_utils.require_version(maxver='3.0')
+    def test__mro__old_style(self):
+        ast_node = test_utils.extract_node('''
+        class A:
+            pass
+        A.__mro__
+        ''')
+        with self.assertRaises(exceptions.InferenceError):
+            next(ast_node.infer())
+
+    @test_utils.require_version(maxver='3.0')
+    def test__subclasses__old_style(self):
+        ast_node = test_utils.extract_node('''
+        class A:
+            pass
+        A.__subclasses__
+        ''')
+        with self.assertRaises(exceptions.InferenceError):
+            next(ast_node.infer())
+        
+    def test_class_model(self):
+        ast_nodes = test_utils.extract_node('''
+        class A(object):
+            "test"
+
+        class B(A): pass
+        class C(A): pass
+
+        A.__module__ #@
+        A.__name__ #@
+        A.__qualname__ #@
+        A.__doc__ #@
+        A.__mro__ #@
+        A.mro() #@
+        A.__bases__ #@
+        A.__class__ #@
+        A.__dict__ #@
+        A.__subclasses__() #@
+        ''', module_name='collections')
+
+        module = next(ast_nodes[0].infer())
+        self.assertIsInstance(module, astroid.Const)
+        self.assertEqual(module.value, 'collections')
+
+        name = next(ast_nodes[1].infer())
+        self.assertIsInstance(name, astroid.Const)
+        self.assertEqual(name.value, 'A')
+
+        qualname = next(ast_nodes[2].infer())
+        self.assertIsInstance(qualname, astroid.Const)
+        self.assertEqual(qualname.value, 'collections.A')
+
+        doc = next(ast_nodes[3].infer())
+        self.assertIsInstance(doc, astroid.Const)
+        self.assertEqual(doc.value, 'test')
+
+        mro = next(ast_nodes[4].infer())
+        self.assertIsInstance(mro, astroid.Tuple)
+        self.assertEqual([cls.name for cls in mro.elts],
+                         ['A', 'object'])
+
+        called_mro = next(ast_nodes[5].infer())
+        self.assertEqual(called_mro.elts, mro.elts)
+
+        bases = next(ast_nodes[6].infer())
+        self.assertIsInstance(bases, astroid.Tuple)
+        self.assertEqual([cls.name for cls in bases.elts],
+                         ['object'])
+
+        cls = next(ast_nodes[7].infer())
+        self.assertIsInstance(cls, astroid.ClassDef)
+        self.assertEqual(cls.name, 'type')
+
+        cls_dict = next(ast_nodes[8].infer())
+        self.assertIsInstance(cls_dict, astroid.Dict)
+
+        subclasses = next(ast_nodes[9].infer())
+        self.assertIsInstance(subclasses, astroid.List)
+        self.assertEqual([cls.name for cls in subclasses.elts], ['B', 'C'])
+
+
+class ModuleModelTest(unittest.TestCase):
+
+    def test__path__not_a_package(self):
+        ast_node = test_utils.extract_node('''
+        import sys
+        sys.__path__ #@
+        ''')
+        with self.assertRaises(exceptions.InferenceError):
+            next(ast_node.infer())
+
+    def test_module_model(self):
+        ast_nodes = test_utils.extract_node('''
+        import xml
+        xml.__path__ #@
+        xml.__name__ #@
+        xml.__doc__ #@
+        xml.__file__ #@
+        xml.__spec__ #@
+        xml.__loader__ #@
+        xml.__cached__ #@
+        xml.__package__ #@
+        xml.__dict__ #@
+        ''')
+
+        path = next(ast_nodes[0].infer())
+        self.assertIsInstance(path, astroid.List)
+        self.assertIsInstance(path.elts[0], astroid.Const)
+        self.assertEqual(path.elts[0].value, xml.__path__[0])
+
+        name = next(ast_nodes[1].infer())
+        self.assertIsInstance(name, astroid.Const)
+        self.assertEqual(name.value, 'xml')
+
+        doc = next(ast_nodes[2].infer())
+        self.assertIsInstance(doc, astroid.Const)
+        self.assertEqual(doc.value, xml.__doc__)
+
+        file_ = next(ast_nodes[3].infer())
+        self.assertIsInstance(file_, astroid.Const)
+        self.assertEqual(file_.value, xml.__file__.replace(".pyc", ".py"))
+
+        for ast_node in ast_nodes[4:7]:
+            inferred = next(ast_node.infer())
+            self.assertIs(inferred, astroid.Uninferable)
+
+        package = next(ast_nodes[7].infer())
+        self.assertIsInstance(package, astroid.Const)
+        self.assertEqual(package.value, 'xml')
+
+        dict_ = next(ast_nodes[8].infer())
+        self.assertIsInstance(dict_, astroid.Dict)
+
+
+class FunctionModelTest(unittest.TestCase):
+
+    def test_partial_descriptor_support(self):
+        bound, result = test_utils.extract_node('''
+        class A(object): pass
+        def test(self): return 42
+        f = test.__get__(A(), A)
+        f #@
+        f() #@
+        ''')
+        bound = next(bound.infer())
+        self.assertIsInstance(bound, astroid.BoundMethod)
+        self.assertEqual(bound._proxied._proxied.name, 'test')
+        result = next(result.infer())
+        self.assertIsInstance(result, astroid.Const)
+        self.assertEqual(result.value, 42)
+
+    @unittest.expectedFailure
+    def test_descriptor_not_inferrring_self(self):
+        # We can't infer __get__(X, Y)() when the bounded function
+        # uses self, because of the tree's parent not being propagating good enough.
+        result = test_utils.extract_node('''
+        class A(object):
+            x = 42
+        def test(self): return self.x
+        f = test.__get__(A(), A)
+        f() #@
+        ''')
+        result = next(result.infer())
+        self.assertIsInstance(result, astroid.Const)
+        self.assertEqual(result.value, 42)
+
+    def test_descriptors_binding_invalid(self):
+        ast_nodes = test_utils.extract_node('''
+        class A: pass
+        def test(self): return 42
+        test.__get__()() #@
+        test.__get__(1)() #@
+        test.__get__(2, 3, 4) #@
+        ''')
+        for node in ast_nodes:
+            with self.assertRaises(exceptions.InferenceError):
+                next(node.infer())
+
+    def test_function_model(self):
+        ast_nodes = test_utils.extract_node('''
+        def func(a=1, b=2):
+            """test"""
+        func.__name__ #@
+        func.__doc__ #@
+        func.__qualname__ #@
+        func.__module__  #@
+        func.__defaults__ #@
+        func.__dict__ #@
+        func.__globals__ #@
+        func.__code__ #@
+        func.__closure__ #@
+        ''', module_name='collections')
+
+        name = next(ast_nodes[0].infer())
+        self.assertIsInstance(name, astroid.Const)
+        self.assertEqual(name.value, 'func')
+
+        doc = next(ast_nodes[1].infer())
+        self.assertIsInstance(doc, astroid.Const)
+        self.assertEqual(doc.value, 'test')
+
+        qualname = next(ast_nodes[2].infer())
+        self.assertIsInstance(qualname, astroid.Const)
+        self.assertEqual(qualname.value, 'collections.func')
+
+        module = next(ast_nodes[3].infer())
+        self.assertIsInstance(module, astroid.Const)
+        self.assertEqual(module.value, 'collections')
+
+        defaults = next(ast_nodes[4].infer())
+        self.assertIsInstance(defaults, astroid.Tuple)
+        self.assertEqual([default.value for default in defaults.elts], [1, 2])
+
+        dict_ = next(ast_nodes[5].infer())
+        self.assertIsInstance(dict_, astroid.Dict)
+
+        globals_ = next(ast_nodes[6].infer())
+        self.assertIsInstance(globals_, astroid.Dict)
+
+        for ast_node in ast_nodes[7:9]:
+            self.assertIs(next(ast_node.infer()), astroid.Uninferable)
+
+    @test_utils.require_version(minver='3.0')
+    def test_empty_return_annotation(self):
+        ast_node = test_utils.extract_node('''
+        def test(): pass
+        test.__annotations__
+        ''')
+        annotations = next(ast_node.infer())
+        self.assertIsInstance(annotations, astroid.Dict)
+        self.assertIs(annotations.getitem('return'), astroid.Empty)
+
+    @test_utils.require_version(minver='3.0')
+    def test_annotations_kwdefaults(self):
+        ast_node = test_utils.extract_node('''
+        def test(a: 1, *args: 2, f:4='lala', **kwarg:3)->2: pass
+        test.__annotations__ #@
+        test.__kwdefaults__ #@
+        ''')
+        annotations = next(ast_node[0].infer())
+        self.assertIsInstance(annotations, astroid.Dict)
+        self.assertIsInstance(annotations.getitem('return'), astroid.Const)
+        self.assertEqual(annotations.getitem('return').value, 2)
+        self.assertIsInstance(annotations.getitem('a'), astroid.Const)
+        self.assertEqual(annotations.getitem('a').value, 1)
+        self.assertEqual(annotations.getitem('args').value, 2)
+        self.assertEqual(annotations.getitem('kwarg').value, 3)
+        self.assertEqual(annotations.getitem('f').value, 4)
+
+        kwdefaults = next(ast_node[1].infer())
+        self.assertIsInstance(kwdefaults, astroid.Dict)
+        self.assertEqual(kwdefaults.getitem('f').value, 'lala')
+
+
+class GeneratorModelTest(unittest.TestCase):
+
+    def test_model(self):
+        ast_nodes = test_utils.extract_node('''
+        def test():
+           "a"
+           yield
+
+        gen = test()
+        gen.__name__ #@
+        gen.__doc__ #@
+        gen.gi_code #@
+        gen.gi_frame #@
+        gen.send #@
+        ''')
+
+        name = next(ast_nodes[0].infer())
+        self.assertEqual(name.value, 'test')
+
+        doc = next(ast_nodes[1].infer())
+        self.assertEqual(doc.value, 'a')
+
+        gi_code = next(ast_nodes[2].infer())
+        self.assertIsInstance(gi_code, astroid.Instance)
+        self.assertEqual(gi_code.name, 'member_descriptor')
+
+        gi_frame = next(ast_nodes[3].infer())
+        self.assertIsInstance(gi_frame, astroid.Instance)
+        self.assertEqual(gi_frame.name, 'member_descriptor')
+
+        send = next(ast_nodes[4].infer())
+        self.assertIsInstance(send, astroid.FunctionDef)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -636,12 +636,18 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         self.assertIsInstance(astroid['A'].getattr('__bases__')[1], nodes.AssignAttr)
 
     def test_instance_special_attributes(self):
-        for inst in (Instance(self.module['YO']), nodes.List(), nodes.Const(1)):
+        instance = self.module['YO'].instantiate_class()
+        self.assertEqual(len(instance.getattr('__dict__')), 1)
+        self.assertEqual(len(instance.getattr('__doc__')), 1)
+
+        # Don't have these special attributes, because they belong to the Instance,
+        # not BaseInstance.         
+        for inst in (nodes.List(), nodes.Const(1)):
             self.assertRaises(AttributeInferenceError, inst.getattr, '__mro__')
             self.assertRaises(AttributeInferenceError, inst.getattr, '__bases__')
             self.assertRaises(AttributeInferenceError, inst.getattr, '__name__')
-            self.assertEqual(len(inst.getattr('__dict__')), 1)
-            self.assertEqual(len(inst.getattr('__doc__')), 1)
+            self.assertRaises(AttributeInferenceError, inst.getattr, '__doc__')
+            self.assertRaises(AttributeInferenceError, inst.getattr, '__dict__')
 
     def test_navigation(self):
         klass = self.module['YO']

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -49,6 +49,13 @@ def singledispatch(func):
     return new_generic_func
 
 
+def lazy_descriptor(obj):
+    class DescriptorProxy(lazy_object_proxy.Proxy):
+        def __get__(self, instance, owner=None):
+            return self.__class__.__get__(self, instance)
+    return DescriptorProxy(obj)
+
+
 def lazy_import(module_name):
     return lazy_object_proxy.Proxy(
         lambda: importlib.import_module('.' + module_name, 'astroid'))


### PR DESCRIPTION
Through this model, astroid starts knowing special attributes of certain Python objects, such as functions, classes, super objects and so on. This was previously possible before, but now the lookup and the attributes themselves are separated into a new module, objectmodel.py, which describes, in a more comprehensive way, the data model of each object.

@ceridwen let me know what you think. It's still not perfect, at some point I'd like to move out the lookup completely off the nodes into its separate domain, but that's a medium term plan, not necessarily for now.