### PR TITLE
Ignore PyGIWarning

### DIFF
--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -133,16 +133,17 @@ def _import_gi_module(modname):
             modcode = ''
             for m in itertools.chain(modnames, optional_modnames):
                 try:
-                    __import__(m)
                     with warnings.catch_warnings():
                         # Just inspecting the code can raise gi deprecation
                         # warnings, so ignore them.
                         try:
-                            from gi import PyGIDeprecationWarning
+                            from gi import PyGIDeprecationWarning, PyGIWarning
                             warnings.simplefilter("ignore", PyGIDeprecationWarning)
+                            warnings.simplefilter("ignore", PyGIWarning)
                         except Exception:
                             pass
 
+                        __import__(m)
                         modcode += _gi_build_stub(sys.modules[m])
                 except ImportError:
                     if m not in optional_modnames:


### PR DESCRIPTION
It solves this error when running PyLint on a file which uses gi introspection:

/usr/lib/python2.7/site-packages/astroid/brain/brain_gi.py:136: PyGIWarning: OSTree was \
imported without specifying a version first. Use gi.require_version('OSTree', '1.0') before \
import to ensure that the right version gets loaded.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>