### PR TITLE
Add pytest 3 compatibility in brain_pytest

### DIFF
--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -18,19 +18,29 @@ try:
     import _pytest.recwarn
     import _pytest.runner
     import _pytest.python
+    import _pytest.freeze_support
+    import _pytest.skipping
+    import _pytest.assertion
+    import _pytest.debugging
+    import _pytest.fixtures
 except ImportError:
     pass
 else:
     deprecated_call = _pytest.recwarn.deprecated_call
+    warns = _pytest.recwarn.warns
+    xfail = _pytest.skipping.xfail
     exit = _pytest.runner.exit
     fail = _pytest.runner.fail
-    fixture = _pytest.python.fixture
+    fixture = _pytest.fixtures.fixture
     importorskip = _pytest.runner.importorskip
     mark = _pytest.mark.MarkGenerator()
     raises = _pytest.python.raises
+    approx = _pytest.python.approx
     skip = _pytest.runner.skip
-    yield_fixture = _pytest.python.yield_fixture
-
+    freeze_includes = _pytest.freeze_support.freeze_includes
+    yield_fixture = _pytest.fixtures.yield_fixture
+    register_assert_rewrite = _pytest.assertion.register_assert_rewrite
+    set_trace = _pytest.debugging.pytestPDB().set_trace
 ''')
 
 register_module_extender(MANAGER, 'pytest', pytest_transform)

--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -18,11 +18,8 @@ try:
     import _pytest.recwarn
     import _pytest.runner
     import _pytest.python
-    import _pytest.freeze_support
     import _pytest.skipping
     import _pytest.assertion
-    import _pytest.debugging
-    import _pytest.fixtures
 except ImportError:
     pass
 else:
@@ -31,16 +28,52 @@ else:
     xfail = _pytest.skipping.xfail
     exit = _pytest.runner.exit
     fail = _pytest.runner.fail
-    fixture = _pytest.fixtures.fixture
     importorskip = _pytest.runner.importorskip
     mark = _pytest.mark.MarkGenerator()
     raises = _pytest.python.raises
-    approx = _pytest.python.approx
     skip = _pytest.runner.skip
+
+    # New in pytest 3.0
+    try:
+        approx = _pytest.python.approx
+        register_assert_rewrite = _pytest.assertion.register_assert_rewrite
+    except AttributeError:
+        pass
+
+
+# Moved in pytest 3.0
+
+try:
+    import _pytest.freeze_support
     freeze_includes = _pytest.freeze_support.freeze_includes
-    yield_fixture = _pytest.fixtures.yield_fixture
-    register_assert_rewrite = _pytest.assertion.register_assert_rewrite
+except ImportError:
+    try:
+        import _pytest.genscript
+        freeze_includes = _pytest.genscript.freeze_includes
+    except ImportError:
+        pass
+
+try:
+    import _pytest.debugging
     set_trace = _pytest.debugging.pytestPDB().set_trace
+except ImportError:
+    try:
+        import _pytest.pdb
+        set_trace = _pytest.pdb.pytestPDB().set_trace
+    except ImportError:
+        pass
+
+try:
+    import _pytest.fixtures
+    fixture = _pytest.fixtures.fixture
+    yield_fixture = _pytest.fixtures.yield_fixture
+except ImportError:
+    try:
+        import _pytest.python
+        fixture = _pytest.python.fixture
+        yield_fixture = _pytest.python.yield_fixture
+    except ImportError:
+        pass
 ''')
 
 register_module_extender(MANAGER, 'pytest', pytest_transform)

--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -25,13 +25,15 @@ except ImportError:
 else:
     deprecated_call = _pytest.recwarn.deprecated_call
     warns = _pytest.recwarn.warns
-    xfail = _pytest.skipping.xfail
+
     exit = _pytest.runner.exit
     fail = _pytest.runner.fail
+    skip = _pytest.runner.skip
     importorskip = _pytest.runner.importorskip
+
+    xfail = _pytest.skipping.xfail
     mark = _pytest.mark.MarkGenerator()
     raises = _pytest.python.raises
-    skip = _pytest.runner.skip
 
     # New in pytest 3.0
     try:

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -499,11 +499,14 @@ class PytestBrainTest(unittest.TestCase):
         pytest #@
         ''')
         module = next(ast_node.infer())
-        self.assertIn('deprecated_call', module)
-        self.assertIn('exit', module)
-        self.assertIn('fail', module)
-        self.assertIn('fixture', module)
-        self.assertIn('mark', module)
+        attrs = ['deprecated_call', 'warns', 'exit', 'fail', 'skip',
+                 'importorskip', 'xfail', 'mark', 'raises', 'freeze_includes',
+                 'set_trace', 'fixture', 'yield_fixture']
+        if pytest.__version__.split('.')[0] == '3':
+            attrs += ['approx', 'register_assert_rewrite']
+
+        for attr in attrs:
+            self.assertIn(attr, module)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds compatibility with pytest 3.0 to `brain_pytest.py`, where some attributes were added and others moved.

It also adds some failing attributes which are already present in older pytest versions, like `pytest.xfail` which existed for a long time.

In the second commit, I also re-added pytest 2.9 support (and it also seems to work fine with 2.7 still, didn't test older versions) as 3.0 is quite a big update and I don't expect everyone to upgrade immediately.