### PR TITLE
[IMP] bumpversion: Add utility

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+current_version = 1.5.0
+commit = False
+tag = False
+
+[bumpversion:file:astroid/__init__.py]
+
+[bumpversion:file:astroid/__pkginfo__.py]
+

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -29,6 +29,9 @@ Main modules are:
 
 * builder contains the class responsible to build astroid trees
 """
+
+__version__ = '1.5.0'
+
 import os
 import sys
 import re

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -10,8 +10,8 @@ distname = 'astroid'
 
 modname = 'astroid'
 
-numversion = (1, 5, 0)
-version = '.'.join([str(num) for num in numversion])
+version = '1.5.0'
+numversion = tuple(map(int, version.split('.')))
 
 extras_require = {}
 install_requires = ['lazy_object_proxy', 'six', 'wrapt']


### PR DESCRIPTION
Add `__init__.__version__` [pep standard](https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names)
To run: `python -c "import astroid;print astroid.__version__"`

Add bumpversion utility to auto-change the standard version value `{major.minor.patch}` in `__version__py` and `__package__.py` files using the command:
`bumpversion [major | minor | patch]`

Example running `bumpversion patch` the diff is:

```patch
$ git diff
diff --git a/.bumpversion.cfg b/.bumpversion.cfg
index 35ab2ea..94f4554 100644
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.5.1
 commit = False
 tag = False
 
diff --git a/astroid/__init__.py b/astroid/__init__.py
index 61294e3..123710e 100644
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -30,7 +30,7 @@ Main modules are:
 * builder contains the class responsible to build astroid trees
 """
 
-__version__ = 1.5.0
+__version__ = 1.5.1
 
 import os
 import sys
diff --git a/astroid/__pkginfo__.py b/astroid/__pkginfo__.py
index ec0150b..c656692 100644
--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -10,7 +10,7 @@ distname = 'astroid'
 
 modname = 'astroid'
 
-version = '1.5.0'
+version = '1.5.1'
 numversion = tuple(map(int, version.split('.')))
 
 extras_require = {}

```