### PR TITLE
[REF] package: Compatibility with old version of setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,9 @@ install:
   - $PYTHON_EXE -m easy_install --version
   - $PYTHON_EXE -m pip --version
   - $PYTHON_EXE -m tox --version
-  - $PYTHON_EXE -m pip install -U setuptools
 script:
+  - python -m tox -e coverage-erase,$TOXENV
+  - $PYTHON_EXE -m pip install -U setuptools
   - python -m tox -e coverage-erase,$TOXENV
 after_success:
   - tox -e coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ install:
   - $PYTHON_EXE -m pip --version
   - $PYTHON_EXE -m tox --version
 script:
-  - python -m tox -e coverage-erase,$TOXENV
+    # Test install with current version of setuptools
+  - $PYTHON_EXE -m pip install .
+    # Run the tests with newest version of setuptools
   - $PYTHON_EXE -m pip install -U setuptools
   - python -m tox -e coverage-erase,$TOXENV
 after_success:

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -30,10 +30,7 @@ def has_environment_marker_range_operators_support():
     The first known release to support environment marker with range operators
     it is 17.1, see: https://setuptools.readthedocs.io/en/latest/history.html#id113
     """
-    try:
-        return parse_version(setuptools_version) >= parse_version('17.1')
-    except Exception:
-        return False
+    return parse_version(setuptools_version) >= parse_version('17.1')
 
 
 if has_environment_marker_range_operators_support():

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -6,6 +6,12 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
 
 """astroid packaging information"""
+
+from sys import version_info as py_version
+
+from setuptools import __version__ as setuptools_version
+
+
 distname = 'astroid'
 
 modname = 'astroid'
@@ -15,7 +21,12 @@ version = '.'.join([str(num) for num in numversion])
 
 extras_require = {}
 install_requires = ['lazy_object_proxy', 'six', 'wrapt']
-extras_require[':python_version<"3.4"'] = ['enum34', 'singledispatch']
+
+if py_version < (3, 4) and setuptools_version < '21.0.0':
+    install_requires += ['enum34', 'singledispatch']
+else:
+    extras_require[':python_version<"3.4"'] = ['enum34', 'singledispatch']
+
 
 # pylint: disable=redefined-builtin; why license is a builtin anyway?
 license = 'LGPL'

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -23,17 +23,20 @@ extras_require = {}
 install_requires = ['lazy_object_proxy', 'six', 'wrapt']
 
 
-def has_environment_marker_support():
+def has_environment_marker_range_operators_support():
     """Code extracted from 'pytest/setup.py'
     https://github.com/pytest-dev/pytest/blob/7538680c/setup.py#L31
+
+    The first known release to support environment marker with range operators
+    it is 17.1, see: https://setuptools.readthedocs.io/en/latest/history.html#id113
     """
     try:
-        return parse_version(setuptools_version) >= parse_version('21.0.0')
+        return parse_version(setuptools_version) >= parse_version('17.1')
     except Exception:
         return False
 
 
-if has_environment_marker_support():
+if has_environment_marker_range_operators_support():
     extras_require[':python_version<"3.4"'] = ['enum34', 'singledispatch']
 elif py_version < (3, 4):
     install_requires.extend(['enum34', 'singledispatch'])

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -9,8 +9,8 @@
 
 from sys import version_info as py_version
 
+from pkg_resources import parse_version
 from setuptools import __version__ as setuptools_version
-
 
 distname = 'astroid'
 
@@ -22,10 +22,21 @@ version = '.'.join([str(num) for num in numversion])
 extras_require = {}
 install_requires = ['lazy_object_proxy', 'six', 'wrapt']
 
-if py_version < (3, 4) and setuptools_version < '21.0.0':
-    install_requires += ['enum34', 'singledispatch']
-else:
+
+def has_environment_marker_support():
+    """Code extracted from 'pytest/setup.py'
+    https://github.com/pytest-dev/pytest/blob/7538680c/setup.py#L31
+    """
+    try:
+        return parse_version(setuptools_version) >= parse_version('21.0.0')
+    except Exception:
+        return False
+
+
+if has_environment_marker_support():
     extras_require[':python_version<"3.4"'] = ['enum34', 'singledispatch']
+elif py_version < (3, 4):
+    install_requires.extend(['enum34', 'singledispatch'])
 
 
 # pylint: disable=redefined-builtin; why license is a builtin anyway?


### PR DESCRIPTION
### Fixes / new features
- https://github.com/PyCQA/astroid/issues/358

- old version of setuptools
  ```bash
$ python -c "from setuptools import __version__ as setuptools_version;from sys import version_info as py_version;print 'py_version', py_version;print 'setuptools_version', setuptools_version"
  py_version sys.version_info(major=2, minor=7, micro=10, releaselevel='final', serial=0)
  setuptools_version 1.1.6

$ pip install --upgrade git+https://github.com/moylop260/astroid.git@6760ea
  Successfully installed astroid-1.5.0
```

- new version of setuptools
  ```bash
$ python -c "from setuptools import __version__ as setuptools_version;from sys import version_info as py_version;print 'py_version', py_version;print 'setuptools_version', setuptools_version"
py_version sys.version_info(major=2, minor=7, micro=10, releaselevel='final', serial=0)
setuptools_version 26.0.0
  py_version sys.version_info(major=2, minor=7, micro=10, releaselevel='final', serial=0)
  setuptools_version 26.0.0

$ pip install --upgrade git+https://github.com/moylop260/astroid.git@6760ea
  Successfully installed astroid-1.5.0
```