### PR TITLE
add format string support

### DIFF
--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -481,6 +481,19 @@ class AsStringVisitor3(AsStringVisitor):
     def visit_asyncfor(self, node):
         return 'async %s' % self.visit_for(node)
 
+    def visit_joinedstr(self, node):
+        # Special treatment for constants,
+        # as we want to join literals not reprs
+        string = ''.join(
+            value.value if type(value).__name__ == 'Const'
+            else value.accept(self)
+            for value in node.values
+        )
+        return "f'%s'" % string
+
+    def visit_formattedvalue(self, node):
+        return '{%s}' % node.value.accept(self)
+
 
 def _import_string(names):
     """return a list of (name, asname) formatted as a string"""
@@ -490,7 +503,7 @@ def _import_string(names):
             _names.append('%s as %s' % (name, asname))
         else:
             _names.append(name)
-    return  ', '.join(_names)
+    return ', '.join(_names)
 
 
 if sys.version_info >= (3, 0):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1863,6 +1863,28 @@ class DictUnpack(NodeNG):
     """Represents the unpacking of dicts into dicts using PEP 448."""
 
 
+class FormattedValue(NodeNG):
+    """Represents a PEP 498 format string."""
+    _astroid_fields = ('value', 'format_spec')
+    value = None
+    conversion = None
+    format_spec = None
+
+    def postinit(self, value, conversion=None, format_spec=None):
+        self.value = value
+        self.conversion = conversion
+        self.format_spec = format_spec
+
+
+class JoinedStr(NodeNG):
+    """Represents a list of string expressions to be joined."""
+    _astroid_fields = ('values',)
+    value = None
+
+    def postinit(self, values=None):
+        self.values = values
+
+
 class Unknown(NodeNG):
     '''This node represents a node in a constructed AST where
     introspection is not possible.  At the moment, it's only used in

--- a/astroid/nodes.py
+++ b/astroid/nodes.py
@@ -37,6 +37,7 @@ from astroid.node_classes import (
     TryExcept, TryFinally, Tuple, UnaryOp, While, With, Yield, YieldFrom,
     const_factory,
     AsyncFor, Await, AsyncWith,
+    FormattedValue, JoinedStr,
     # Backwards-compatibility aliases
     Backquote, Discard, AssName, AssAttr, Getattr, CallFunc, From,
     # Node not present in the builtin ast module.
@@ -75,4 +76,5 @@ ALL_NODE_CLASSES = (
     UnaryOp,
     While, With,
     Yield, YieldFrom,
+    FormattedValue, JoinedStr,
     )

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -869,6 +869,18 @@ class TreeRebuilder3(TreeRebuilder):
     def visit_asyncwith(self, node, parent):
         return self._visit_with(nodes.AsyncWith, node, parent)
 
+    def visit_joinedstr(self, node, parent):
+        newnode = nodes.JoinedStr(node.lineno, node.col_offset, parent)
+        newnode.postinit([self.visit(child, newnode)
+                          for child in node.values])
+        return newnode
+
+    def visit_formattedvalue(self, node, parent):
+        newnode = nodes.FormattedValue(node.lineno, node.col_offset, parent)
+        newnode.postinit(self.visit(node.value, newnode),
+                         node.conversion,
+                         _visit_or_none(node, 'format_spec', self, newnode))
+        return newnode
 
 if sys.version_info >= (3, 0):
     TreeRebuilder = TreeRebuilder3

--- a/astroid/tests/unittest_python3.py
+++ b/astroid/tests/unittest_python3.py
@@ -87,7 +87,7 @@ class Python3TC(unittest.TestCase):
     @require_version('3.0')
     def test_metaclass_imported(self):
         astroid = self.builder.string_build(dedent("""
-        from abc import ABCMeta 
+        from abc import ABCMeta
         class Test(metaclass=ABCMeta): pass"""))
         klass = astroid.body[1]
 
@@ -98,7 +98,7 @@ class Python3TC(unittest.TestCase):
     @require_version('3.0')
     def test_as_string(self):
         body = dedent("""
-        from abc import ABCMeta 
+        from abc import ABCMeta
         class Test(metaclass=ABCMeta): pass""")
         astroid = self.builder.string_build(body)
         klass = astroid.body[1]
@@ -238,6 +238,13 @@ class Python3TC(unittest.TestCase):
             value = node.getitem(key)
             self.assertIsInstance(value, nodes.Const)
             self.assertEqual(value.value, expected)
+
+    @require_version('3.6')
+    def test_format_string(self):
+        code = "f'{greetings} {person}'"
+        node = extract_node(code)
+        self.assertEqual(node.as_string(), code)
+
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, jython, pylint
+envlist = py27, py33, py34, py35, py36, pypy, jython, pylint
 skip_missing_interpreters = true
 
 [testenv:pylint]
@@ -10,7 +10,7 @@ deps =
   py27,py33,pypy,jython: enum34
   lazy-object-proxy
   nose
-  py27,py33,py34,py35: numpy
+  py27,py33,py34,py35,py36: numpy
   pytest
   python-dateutil
   py27,py33,pypy,jython: singledispatch


### PR DESCRIPTION
Apologies for taking a bit on this.

A problem with circular imports caused me to compare a class name to a string in the joinedstr as_string method. It's fixable, but also felt like another pull request worth of code surgery. 

Without the change to delay_asattr in the second pull request there are a bunch of failed tests with python 3.6b1, specifically:

testExtensionModules
test_multiprocessing_manager
test_from_self_resolve
test_metaclass_generator_hack
test_lru_cache
test_namedtuple_advanced_inference
test_attribute_access

There  are a few other tests that are already failing on my machine, test_namespace_package_pth_support
test_builtin_fromlineno_missing on python3.5+

I took some stabs in the dark at fixing them, and can open more pull requests if you would like. But they might be pretty crude.