### PR TITLE
fix delayed_asattr when proxy is uninferrable

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -237,6 +237,8 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 try:
                     if inferred.__class__ is bases.Instance:
                         inferred = inferred._proxied
+                        if inferred is util.Uninferable:
+                            continue
                         iattrs = inferred.instance_attrs
                         if not _can_assign_attr(inferred, node.attrname):
                             continue


### PR DESCRIPTION
Without this extra check, the following tests fail on python 3.6b1:

testExtensionModules
test_multiprocessing_manager
test_from_self_resolve
test_metaclass_generator_hack
test_lru_cache
test_namedtuple_advanced_inference
test_attribute_access
