### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -38,7 +38,7 @@ class CallSite(object):
         ]
         self.keyword_arguments = dict(
             (key, value) for (key, value) in self._unpacked_kwargs.items()
-            if value is not util.YES
+            if value is not util.Uninferable
         )
 
     @classmethod

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -36,10 +36,10 @@ class CallSite(object):
             arg for arg in self._unpacked_args
             if arg is not util.Uninferable
         ]
-        self.keyword_arguments = {
-            key: value for key, value in self._unpacked_kwargs.items()
-            if value is not util.Uninferable
-        }
+        self.keyword_arguments = dict(
+            (key, value) for (key, value) in self._unpacked_kwargs.items()
+            if value is not util.YES
+        )
 
     @classmethod
     def from_call(cls, call_node):
@@ -163,10 +163,10 @@ class CallSite(object):
         vararg = self.positional_arguments[len(funcnode.args.args):]
         argindex = funcnode.args.find_argname(name)[0]
         kwonlyargs = set(arg.name for arg in funcnode.args.kwonlyargs)
-        kwargs = {
-            key: value for key, value in self.keyword_arguments.items()
+        kwargs = dict(
+            (key, value) for (key, value) in self.keyword_arguments.items()
             if key not in kwonlyargs
-        }
+        )
         # If there are too few positionals compared to
         # what the function expects to receive, check to see
         # if the missing positional arguments were passed

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -30,7 +30,7 @@ if sys.version_info >= (3, 0):
 else:
     BUILTINS = '__builtin__'
     BOOL_SPECIAL_METHOD = '__nonzero__'
-PROPERTIES = {BUILTINS + '.property', 'abc.abstractproperty'}
+PROPERTIES = set([BUILTINS + '.property', 'abc.abstractproperty'])
 # List of possible property names. We use this list in order
 # to see if a method is a property or not. This should be
 # pretty reliable and fast, the alternative being to check each
@@ -40,17 +40,17 @@ PROPERTIES = {BUILTINS + '.property', 'abc.abstractproperty'}
 # define them, we shouldn't expect to know every possible
 # property-like decorator!
 # TODO(cpopa): just implement descriptors already.
-POSSIBLE_PROPERTIES = {"cached_property", "cachedproperty",
-                       "lazyproperty", "lazy_property", "reify",
-                       "lazyattribute", "lazy_attribute",
-                       "LazyProperty", "lazy"}
+POSSIBLE_PROPERTIES = set(["cached_property", "cachedproperty",
+                           "lazyproperty", "lazy_property", "reify",
+                           "lazyattribute", "lazy_attribute",
+                           "LazyProperty", "lazy"])
 
 
 def _is_property(meth):
     if PROPERTIES.intersection(meth.decoratornames()):
         return True
-    stripped = {name.split(".")[-1] for name in meth.decoratornames()
-                if name is not util.Uninferable}
+    stripped = set([name.split(".")[-1] for name in meth.decoratornames()
+                   if name is not util.Uninferable])
     return any(name in stripped for name in POSSIBLE_PROPERTIES)
 
 

--- a/astroid/brain/brain_io.py
+++ b/astroid/brain/brain_io.py
@@ -8,7 +8,7 @@
 import astroid
 
 
-BUFFERED = {'BufferedWriter', 'BufferedReader'}
+BUFFERED = set(['BufferedWriter', 'BufferedReader'])
 TextIOWrapper = 'TextIOWrapper'
 FileIO = 'FileIO'
 BufferedWriter = 'BufferedWriter'

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -232,7 +232,7 @@ else:
 def six_moves_transform():
     code = dedent('''
     class Moves(object):
-    {}
+    {0}
     moves = Moves()
     ''').format(_indent(_IMPORTS, "    "))
     module = AstroidBuilder(MANAGER).string_build(code)

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -223,9 +223,10 @@ class FunctionModel(ObjectModel):
             returns = self._instance.returns
 
         args = self._instance.args
-        annotations = {arg.name: annotation
-                       for (arg, annotation) in zip(args.args, args.annotations)
-                       if annotation}
+        annotations = dict(
+            (arg.name, annotation)
+            for (arg, annotation) in zip(args.args, args.annotations)
+            if annotation)
         if args.varargannotation:
             annotations[args.vararg] = args.varargannotation
         if args.kwargannotation:

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -52,14 +52,14 @@ BIN_OP_METHOD = {'+':  '__add__',
                  '@': '__matmul__'
                 }
 
-REFLECTED_BIN_OP_METHOD = {
-    key: _reflected_name(value)
+REFLECTED_BIN_OP_METHOD = dict(
+    (key, _reflected_name(value))
     for (key, value) in BIN_OP_METHOD.items()
-}
-AUGMENTED_OP_METHOD = {
-    key + "=": _augmented_name(value)
+)
+AUGMENTED_OP_METHOD = dict(
+    (key + "=", _augmented_name(value))
     for (key, value) in BIN_OP_METHOD.items()
-}
+)
 
 UNARY_OP_METHOD = {'+': '__pos__',
                    '-': '__neg__',

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1419,7 +1419,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         attrs = set()
         implicit_meta = self.implicit_metaclass()
         metaclass = self.metaclass()
-        for cls in {implicit_meta, metaclass}:
+        for cls in set([implicit_meta, metaclass]):
             if cls and cls != self and isinstance(cls, ClassDef):
                 cls_attributes = self._get_attribute_from_metaclass(
                     cls, name, context)

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -773,7 +773,7 @@ class FunctionDef(node_classes.Statement, Lambda):
 
         Possible values are: method, function, staticmethod, classmethod.
         """
-        builtin_descriptors = {'classmethod', 'staticmethod'}
+        builtin_descriptors = set(['classmethod', 'staticmethod'])
 
         for decorator in self.extra_decorators:
             if decorator.func.name in builtin_descriptors:

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -512,7 +512,7 @@ class IOBrainTest(unittest.TestCase):
 
     @unittest.skipUnless(six.PY3, 'Needs Python 3 io model')
     def test_sys_streams(self):
-        for name in {'stdout', 'stderr', 'stdin'}:
+        for name in set(['stdout', 'stderr', 'stdin']):
             node = astroid.extract_node('''
             import sys
             sys.{}

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -104,7 +104,7 @@ class NamedTupleTest(unittest.TestCase):
         """)
         base = next(base for base in klass.ancestors()
                     if base.name == 'X')
-        self.assertSetEqual({"a", "b", "c"}, set(base.instance_attrs))
+        self.assertSetEqual(set(["a", "b", "c"]), set(base.instance_attrs))
 
     def test_namedtuple_inference_failure(self):
         klass = builder.extract_node("""

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -560,8 +560,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         '''
         ast = parse(code, __name__)
         xxx = ast['xxx']
-        self.assertSetEqual({n.__class__ for n in xxx.inferred()},
-                            {nodes.Const, util.Uninferable.__class__})
+        self.assertSetEqual(set([n.__class__ for n in xxx.inferred()]),
+                            set([nodes.Const, util.Uninferable.__class__]))
 
     def test_method_argument(self):
         code = '''
@@ -2036,7 +2036,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             __pos__ = lambda self: self.lala
             __neg__ = lambda self: self.lala + 1
             @property
-            def lala(self): return 24            
+            def lala(self): return 24
         instance = GoodInstance()
         lambda_instance = LambdaInstance()
         +instance #@
@@ -2775,7 +2775,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         a = [1, 2, 3, 4]
         a[Index()] #@
         a[LambdaIndex()] #@
-        a[NonIndex()] #@         
+        a[NonIndex()] #@
         ''')
         first = next(ast_nodes[0].infer())
         self.assertIsInstance(first, nodes.Const)
@@ -3155,7 +3155,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ast_node = extract_node('''
         class A(type):
             def test(cls):
-                return cls        
+                return cls
         import six
         @six.add_metaclass(A)
         class B(object):
@@ -3174,7 +3174,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
                 cls #@
         class B(object):
             def __call__(cls):
-                cls #@        
+                cls #@
         ''')
         first = next(ast_nodes[0].infer())
         self.assertIsInstance(first, nodes.ClassDef)

--- a/astroid/tests/unittest_modutils.py
+++ b/astroid/tests/unittest_modutils.py
@@ -237,7 +237,7 @@ class GetModuleFilesTest(unittest.TestCase):
         expected = ['__init__.py', 'module.py', 'module2.py',
                     'noendingnewline.py', 'nonregr.py']
         self.assertEqual(modules,
-                         {os.path.join(package, x) for x in expected})
+                         set([os.path.join(package, x) for x in expected]))
 
     def test_get_all_files(self):
         """test that list_all returns all Python files from given location

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -549,7 +549,7 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
                 def staticmethod_wrapped():
                     pass
                 @long_classmethod_decorator()
-                def long_classmethod(cls): 
+                def long_classmethod(cls):
                     pass
         """)
         node = astroid.locals['SomeClass'][0]
@@ -628,7 +628,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         node = builder.extract_node('''
         class A(object): pass
         class B(object): pass
-        class C(A, B): pass        
+        class C(A, B): pass
         ''')
         mro = node.getattr('__mro__')[0]
         self.assertIsInstance(mro, nodes.Tuple)
@@ -745,7 +745,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         self.assertRaises(StopIteration, partial(next, it))
 
     def test_methods(self):
-        expected_methods = {'__init__', 'class_method', 'method', 'static_method'}
+        expected_methods = set(['__init__', 'class_method', 'method', 'static_method'])
         klass2 = self.module['YOUPI']
         methods = {m.name for m in klass2.methods()}
         self.assertTrue(
@@ -1369,7 +1369,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             class Inner(OuterC.Inner, OuterB.Inner):
                 pass
         class Duplicates(str, str): pass
-        
+
         """)
         self.assertEqualMro(astroid['D'], ['D', 'dict', 'C', 'object'])
         self.assertEqualMro(astroid['D1'], ['D1', 'B1', 'C1', 'A1', 'object'])
@@ -1459,7 +1459,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
     def test_metaclass_lookup_using_same_class(self):
         # Check that we don't have recursive attribute access for metaclass
         cls = builder.extract_node('''
-        class A(object): pass            
+        class A(object): pass
         ''')
         self.assertEqual(len(cls.getattr('mro')), 1)
 
@@ -1471,7 +1471,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             foo = lala
 
         @six.add_metaclass(Metaclass)
-        class B(object): pass 
+        class B(object): pass
         ''')
         cls = module['B']
         self.assertEqual(util.Uninferable, next(cls.igetattr('foo')))
@@ -1479,7 +1479,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
     def test_metaclass_lookup(self):
         module = builder.parse('''
         import six
-         
+
         class Metaclass(type):
             foo = 42
             @classmethod
@@ -1646,7 +1646,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
              def class_method(self): #@
                  pass
              class_method = classmethod(class_method)
-             static = staticmethod(static)              
+             static = staticmethod(static)
         ''')
         self.assertEqual(len(clsmethod.extra_decorators), 1)
         self.assertEqual(clsmethod.type, 'classmethod')
@@ -1666,7 +1666,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
                 # This is important, because it used to trigger
                 # a maximum recursion error.
                 bind = _bind(self)
-                return bind 
+                return bind
         A() #@
         ''')
         inferred = next(node.infer())

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -747,19 +747,19 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
     def test_methods(self):
         expected_methods = set(['__init__', 'class_method', 'method', 'static_method'])
         klass2 = self.module['YOUPI']
-        methods = {m.name for m in klass2.methods()}
+        methods = set([m.name for m in klass2.methods()])
         self.assertTrue(
             methods.issuperset(expected_methods))
-        methods = {m.name for m in klass2.mymethods()}
+        methods = set([m.name for m in klass2.mymethods()])
         self.assertSetEqual(expected_methods, methods)
         klass2 = self.module2['Specialization']
-        methods = {m.name for m in klass2.mymethods()}
+        methods = set([m.name for m in klass2.mymethods()])
         self.assertSetEqual(set([]), methods)
         method_locals = klass2.local_attr('method')
         self.assertEqual(len(method_locals), 1)
         self.assertEqual(method_locals[0].name, 'method')
         self.assertRaises(AttributeInferenceError, klass2.local_attr, 'nonexistent')
-        methods = {m.name for m in klass2.methods()}
+        methods = set([m.name for m in klass2.methods()])
         self.assertTrue(methods.issuperset(expected_methods))
 
     #def test_rhs(self):


### PR DESCRIPTION
### Fixes
- Add Python 2.6 compatibility

Justification: On Red Hat Enterprise Linux 6 the only available Python version is 2.6. The compatibility with this version is needed for running pylint as a part of CI tests.
Thanks @misli for help.
