### PR TITLE
Look under module.__path__ for finding submodules if it exists.

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -239,7 +239,10 @@ def load_module_from_modpath(parts, path=None, use_sys=1):
             continue
         if not _file and len(modpath) != len(parts):
             raise ImportError('no module in %s' % '.'.join(parts[len(modpath):]))
-        path = [os.path.dirname(_file)]
+        if hasattr(module, '__path__'):
+            path = module.__path__
+        else:
+            path = [os.path.dirname(_file)]
     return module
 
 


### PR DESCRIPTION
Need to test this a bit more, but I think we should look under module.`__path__`. I'll try to generate a reproducer and see if this is the same bug in the issue.

### Fixes / new features
-  #337 

