### PR TITLE
Force cast __path__ to a list

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -651,7 +651,7 @@ def _module_file(modpath, path=None):
         # setuptools has added into sys.modules a module object with proper
         # __path__, get back information from there
         module = sys.modules[modpath.pop(0)]
-        path = module.__path__
+        path = list(module.__path__)
         if not modpath:
             return imp.C_BUILTIN, None
     imported = []


### PR DESCRIPTION
Issue #378 

\_\_path__ can be an '_frozen_importlib_external._NamespacePath' object for a namespace module (declared by setuptools) with python 3.5+.