### PR TITLE
Implement __getitem__ inference for classes (using the metaclass)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ Change log for the astroid package (used to be astng)
 =====================================================
 
 --
+    * ClassDef now supports __getitem__ inference through the metaclass.
+
     * getitem() method accepts nodes now, instead of Python objects.
 
     * Add support for explicit namespace packages, created with pkg_resources.

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -2531,6 +2531,22 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         for node in ast_nodes:
             self.assertEqual(next(node.infer()), util.Uninferable)
 
+    def test_metaclass__getitem__(self):
+        ast_node = extract_node('''
+        class Meta(type):
+            def __getitem__(cls, arg):
+                return 24
+        import six
+        @six.add_metaclass(Meta)
+        class A(object):
+            pass
+
+        A['Awesome'] #@
+        ''')
+        inferred = next(ast_node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertEqual(inferred.value, 24)
+
     def test_bin_op_classes(self):
         ast_node = extract_node('''
         class Meta(type):


### PR DESCRIPTION
Essentially, implement the getitem method in ClassDef which returns the correct value.

Fixes #348
