### PR TITLE
Make is_argument search kwonlyargs.

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -963,7 +963,8 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
             return True
         if name == self.kwarg:
             return True
-        return self.find_argname(name, True)[1] is not None
+        return (self.find_argname(name, True)[1] is not None or
+                self.kwonlyargs and _find_arg(name, self.kwonlyargs, True)[1] is not None)
 
     def find_argname(self, argname, rec=False):
         """return index and Name node with given name"""

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -483,6 +483,15 @@ class ArgumentsNodeTC(unittest.TestCase):
             self.skipTest('FIXME  http://bugs.python.org/issue10445 '
                           '(no line number on function args)')
 
+    @test_utils.require_version(minver='3.0')
+    def test_kwoargs(self):
+        ast = builder.parse('''
+            def func(*, x):
+                pass
+        ''')
+        args = ast['func'].args
+        self.assertTrue(args.is_argument('x'))
+
 
 class UnboundMethodNodeTest(unittest.TestCase):
 


### PR DESCRIPTION
### Fixes / new features
- Makes is_argument search key word only arguments.
  Fixes PyCQA/pylint#1135
