### PR TITLE
RFC: Inject type comments 

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -103,8 +103,9 @@ def fill_scope_map(scope_map, node):
     """Fill in the scope_map so that we get a quick lookup table of line numbers to scopes."""
 
     if isinstance(node, nodes.FunctionDef):
-        # For functions we look at the first item in the body.
-        for line in range(node.fromlineno, node.body[0].fromlineno + 2):
+        # For functions we look until the first item in the body.
+        # Sadly the docstring doesn't count in the body so it's not perfect.
+        for line in range(node.fromlineno, node.body[0].fromlineno):
             scope_map[line] = node
     elif isinstance(node, (nodes.Assign, nodes.With, nodes.For)):
         for line in range(node.fromlineno, node.tolineno + 1):

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -18,6 +18,9 @@ import sys
 import textwrap
 import _ast
 
+import collections
+from six import StringIO
+
 from astroid import bases
 from astroid import exceptions
 from astroid import manager
@@ -40,6 +43,163 @@ _STATEMENT_SELECTOR = '#@'
 def _parse(string):
     return compile(string, "<string>", 'exec', _ast.PyCF_ONLY_AST)
 
+TYPE_ANNOTATION = re.compile(r'#\s*type:\s*(.*)')  # # type:
+IGNORE = re.compile(r'\s*ignore\b')
+FUNCTION_ANNOTATION = re.compile(r'(\(.*\))\s*->\s*(.*)')
+STAR_ARGS = re.compile(r'([(,]\s*)\*{1,2}')  # "(*Any" or "... , *Any" or "... , **Any" or
+EMPTY_ARGS = re.compile(r'\(\s*\)')  # ( any-whitespace )
+UNTYPED_ELLIPSIS_ARGS = re.compile(r'\(\s*\.{3}\s*\)')  # ( any-whitespace ... any-whitespace )
+
+TypeComment = collections.namedtuple('TypeComment', 'arg, vararg, kwarg, returns')
+
+def expr_for_comment(comment):
+    # type: (str) -> Optional[TypeComment]
+    """Return a compilable string to represent a type annotation."""
+
+    # Skip if the comment does not start with '# type:'.
+    m = TYPE_ANNOTATION.match(comment)
+    if not m:
+        return None
+    expr = m.group(1)  # Everything after '# type:'
+
+    # Skip if it's "# type: ignore"
+    if IGNORE.match(expr):
+        return None
+
+    # Does it look like a signature annotation?
+    m = FUNCTION_ANNOTATION.match(expr)
+    if m:
+        arg_types, return_type = m.groups()
+        if EMPTY_ARGS.match(arg_types) or UNTYPED_ELLIPSIS_ARGS.match(expr):
+            # `...` is not valid Python 2 syntax, so just return the return_type.
+            ret = TypeComment(None, None, None, return_type)
+        else:
+            rest, _, kwarg = arg_types.strip(" ()").partition("**")
+            rest, _, vararg = rest.strip(" ,").partition("*")
+            args = rest.strip(" ,")
+
+            ret = TypeComment(
+                ("(%s,)" % args) if args else "()",
+                vararg,
+                kwarg,
+                return_type
+            )
+    else:
+        ret = TypeComment(expr, None, None, None)
+
+    # Skip if expr can't be parsed using compile().
+    for expr in ret:
+        try:
+            if expr:
+                compile(expr, '<string>', 'eval')
+        except Exception as e:
+            return None
+
+    return ret
+
+def fill_scope_map(scope_map, node):
+    # type: (List[NodeNG], NodeNG) -> None
+    """Fill in the scope_map so that we get a quick lookup table of line numbers to scopes."""
+
+    if isinstance(node, nodes.FunctionDef):
+        for line in range(node.fromlineno, node.body[0].fromlineno + 2):
+            scope_map[line] = node
+    elif isinstance(node, (nodes.Assign, nodes.With, nodes.For)):
+        # We want our line numbers to be 1 indexed, however fromlineno and to lineno
+        # are 0 indexed so add 1, except fromlineno always starts one line after the
+        # def or class so just don't add 1 to that one.
+        for line in range(node.fromlineno, node.tolineno + 1):
+            scope_map[line] = node
+    for child in node.get_children():
+        fill_scope_map(scope_map, child)
+
+def inject_imports(data, module):
+    if not re.search(r'#\s*type:', data):
+        return
+
+    # Build a scope_map for faster lookups.
+    scope_map = [None] * (data.count("\n") + 2)
+    fill_scope_map(scope_map, module)
+
+    # Tokenize the file looking for those juicy # type: annotations.
+    import tokenize
+
+    module.injected_lines = []
+    tokens = tokenize.generate_tokens(StringIO(data).readline)
+    last_token = None
+    for tok_type, tok_val, (lineno, _), _, _ in tokens:
+        if tok_type == tokenize.COMMENT:
+            expr = expr_for_comment(tok_val)
+            if expr:
+                scope = scope_map[lineno]
+                if not scope:
+                    continue
+
+                arg, vararg, kwarg, returns = expr
+                if not returns:
+                    # This is a "type: arg" comment
+                    assert vararg is None
+                    assert kwarg is None
+
+                    annotation = extract_node("\n" * (lineno-1) + arg)
+                    if isinstance(scope, nodes.FunctionDef):
+                        for i, argument in enumerate(scope.args.args):
+                            if scope.args.args[i].lineno == lineno:
+                                annotation.parent = scope
+                                scope.args.annotations[i] = annotation
+                                break
+                        else:
+                            # Sadly, vararg and kwarg lose their line numbers.
+                            # So we'll use the last_name to approximate where we are
+                            if last_token == scope.args.vararg:
+                                annotation.parent = scope
+                                scope.args.varargannotation = annotation
+                            elif last_token == scope.args.kwarg:
+                                annotation.parent = scope
+                                scope.args.kwargannotation = annotation
+                    elif isinstance(scope, (nodes.Assign, nodes.With, nodes.For)):
+                        annotation.parent = scope
+                        scope.type_comment = annotation
+                else:
+                    # This is a "(arg, *vararg, *kwarg) -> returns" comment
+                    if isinstance(scope, nodes.FunctionDef):
+                        try:
+                            if arg:
+                                annotations = extract_node("\n" * (lineno-1) + arg).elts
+
+                                if len(annotations) == len(scope.args.annotations):
+                                    start = 0
+                                elif scope.is_method() and len(annotations) == len(scope.args.annotations) - 1:
+                                    # In methods you're allowed to not type `self`.
+                                    start = 1
+                                else:
+                                    raise Exception("Mismatch in args")
+
+                                for i, elt in enumerate(annotations):
+                                    elt.parent = scope
+                                    scope.args.annotations[i + start] = elt
+
+                            if vararg:
+                                varargannotation = extract_node("\n" * (lineno-1) + vararg)
+                                varargannotation.parent = scope
+                                scope.args.varargannotation = varargannotation
+
+                            if kwarg:
+                                kwargannotation = extract_node("\n" * (lineno - 1) + kwarg)
+                                kwargannotation.parent = scope
+                                scope.args.kwargannotation = kwargannotation
+
+                            return_type = extract_node("\n" * (lineno-1) + returns)
+                            return_type.parent = scope
+                            scope.returns = return_type
+                        except Exception:
+                            import pdb; pdb.set_trace()
+                            raise
+
+        if tok_type == tokenize.NAME:
+            last_token = tok_val
+
+    return module
 
 if sys.version_info >= (3, 0):
     from tokenize import detect_encoding
@@ -197,6 +357,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
         module = builder.visit_module(node, modname, node_file, package)
         module._import_from_nodes = builder._import_from_nodes
         module._delayed_assattr = builder._delayed_assattr
+        inject_imports(data, module)
         return module
 
     def add_from_names_to_locals(self, node):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -312,7 +312,9 @@ class NodeNG(object):
             if not attr: # None or empty listy / tuple
                 continue
             if isinstance(attr, (list, tuple)):
-                return attr[-1]
+                if attr[-1]:
+                    return attr[-1]
+                continue
 
             return attr
         return None

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -873,25 +873,22 @@ class Name(LookupMixIn, NodeNG):
 
 class Arguments(mixins.AssignTypeMixin, NodeNG):
     """class representing an Arguments node"""
-    if six.PY3:
-        # Python 3.4+ uses a different approach regarding annotations,
-        # each argument is a new class, _ast.arg, which exposes an
-        # 'annotation' attribute. In astroid though, arguments are exposed
-        # as is in the Arguments node and the only way to expose annotations
-        # is by using something similar with Python 3.3:
-        #  - we expose 'varargannotation' and 'kwargannotation' of annotations
-        #    of varargs and kwargs.
-        #  - we expose 'annotation', a list with annotations for
-        #    for each normal argument. If an argument doesn't have an
-        #    annotation, its value will be None.
+    # Python 3.4+ uses a different approach regarding annotations,
+    # each argument is a new class, _ast.arg, which exposes an
+    # 'annotation' attribute. In astroid though, arguments are exposed
+    # as is in the Arguments node and the only way to expose annotations
+    # is by using something similar with Python 3.3:
+    #  - we expose 'varargannotation' and 'kwargannotation' of annotations
+    #    of varargs and kwargs.
+    #  - we expose 'annotation', a list with annotations for
+    #    for each normal argument. If an argument doesn't have an
+    #    annotation, its value will be None.
 
-        _astroid_fields = ('args', 'defaults', 'kwonlyargs',
-                           'kw_defaults', 'annotations', 'varargannotation',
-                           'kwargannotation')
-        varargannotation = None
-        kwargannotation = None
-    else:
-        _astroid_fields = ('args', 'defaults', 'kwonlyargs', 'kw_defaults')
+    _astroid_fields = ('args', 'defaults', 'kwonlyargs',
+                       'kw_defaults', 'annotations', 'varargannotation',
+                       'kwargannotation')
+    varargannotation = None
+    kwargannotation = None
     _other_fields = ('vararg', 'kwarg')
 
     def __init__(self, vararg=None, kwarg=None, parent=None):
@@ -1042,13 +1039,15 @@ class Assert(Statement):
 
 class Assign(mixins.AssignTypeMixin, Statement):
     """class representing an Assign node"""
-    _astroid_fields = ('targets', 'value',)
+    _astroid_fields = ('targets', 'value', 'type_comment')
     targets = None
     value = None
+    type_comment = None
 
-    def postinit(self, targets=None, value=None):
+    def postinit(self, targets=None, value=None, type_comment=None):
         self.targets = targets
         self.value = value
+        self.type_comment = type_comment
 
 
 class AugAssign(mixins.AssignTypeMixin, Statement):
@@ -1466,18 +1465,20 @@ class ExtSlice(NodeNG):
 
 class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """class representing a For node"""
-    _astroid_fields = ('target', 'iter', 'body', 'orelse',)
+    _astroid_fields = ('target', 'iter', 'body', 'orelse', 'type_comment',)
     target = None
     iter = None
     body = None
     orelse = None
+    type_comment = None
 
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
-    def postinit(self, target=None, iter=None, body=None, orelse=None):
+    def postinit(self, target=None, iter=None, body=None, orelse=None, type_comment=None):
         self.target = target
         self.iter = iter
         self.body = body
         self.orelse = orelse
+        self.type_comment = type_comment
 
     optional_assign = True
     @decorators.cachedproperty
@@ -1895,13 +1896,15 @@ class While(mixins.BlockRangeMixIn, Statement):
 
 class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """class representing a With node"""
-    _astroid_fields = ('items', 'body')
+    _astroid_fields = ('items', 'body', 'type_comment')
     items = None
     body = None
+    type_comment = None
 
-    def postinit(self, items=None, body=None):
+    def postinit(self, items=None, body=None, type_comment=None):
         self.items = items
         self.body = body
+        self.type_comment = type_comment
 
     @decorators.cachedproperty
     def blockstart_tolineno(self):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -312,8 +312,9 @@ class NodeNG(object):
             if not attr: # None or empty listy / tuple
                 continue
             if isinstance(attr, (list, tuple)):
-                if attr[-1]:
-                    return attr[-1]
+                for item in attr[::-1]:
+                    if item:
+                        return item
                 continue
 
             return attr
@@ -1467,12 +1468,12 @@ class ExtSlice(NodeNG):
 
 class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """class representing a For node"""
-    _astroid_fields = ('target', 'iter', 'body', 'orelse', 'type_comment',)
+    _astroid_fields = ('target', 'iter', 'type_comment', 'body', 'orelse')
     target = None
     iter = None
+    type_comment = None
     body = None
     orelse = None
-    type_comment = None
 
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(self, target=None, iter=None, body=None, orelse=None, type_comment=None):
@@ -1898,10 +1899,10 @@ class While(mixins.BlockRangeMixIn, Statement):
 
 class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """class representing a With node"""
-    _astroid_fields = ('items', 'body', 'type_comment')
+    _astroid_fields = ('items', 'type_comment', 'body')
     items = None
-    body = None
     type_comment = None
+    body = None
 
     def postinit(self, items=None, body=None, type_comment=None):
         self.items = items
@@ -1917,6 +1918,8 @@ class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
             yield expr
             if var:
                 yield var
+        if self.type_comment:
+            yield self.type_comment
         for elt in self.body:
             yield elt
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -186,7 +186,7 @@ class TreeRebuilder(object):
         else:
             kwonlyargs = []
             kw_defaults = []
-            annotations = []
+            annotations = [None] * len(node.args)
         newnode.postinit(args, defaults, kwonlyargs, kw_defaults,
                          annotations, varargannotation, kwargannotation)
         # save argument names in locals:

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -702,11 +702,8 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
 
 
 class FunctionDef(node_classes.Statement, Lambda):
-    if six.PY3:
-        _astroid_fields = ('decorators', 'args', 'returns', 'body')
-        returns = None
-    else:
-        _astroid_fields = ('decorators', 'args', 'body')
+    _astroid_fields = ('decorators', 'args', 'returns', 'body')
+    returns = None
     decorators = None
     special_attributes = objectmodel.FunctionModel()
     is_function = True

--- a/astroid/tests/unittest_type_comments.py
+++ b/astroid/tests/unittest_type_comments.py
@@ -201,6 +201,13 @@ class TestFunctionTypeComments(unittest.TestCase):
             return str(a)
         """, ['int', 'bytes'], vararg='str', kwarg='int', returns='str', lines=[3, 4, 5, 6, 8])
 
+    def test_only_docstring(self):
+        self.check_annotations('''
+        def test():  #@
+            # type: () -> str
+            """This really sucks"""
+        ''', [], returns='str', lines=[3])
+
     def test_assignment(self):
         assign = extract_node(dedent("x = []  # type: List[Employee]"))
         self.assertIsInstance(assign, nodes.Assign)

--- a/astroid/tests/unittest_type_comments.py
+++ b/astroid/tests/unittest_type_comments.py
@@ -1,0 +1,238 @@
+import unittest
+from textwrap import dedent
+
+from astroid import extract_node
+from astroid import nodes
+
+class TestFunctionTypeComments(unittest.TestCase):
+
+    def check_annotations(self, code, args=(), returns=None, vararg=None, kwarg=None, lines=()):
+        func = extract_node(dedent(code))
+        found_lines = []
+
+        def check_name(node, value):
+            if value:
+                self.assertIsInstance(node, nodes.Name)
+                self.assertEqual(node.name, value)
+                found_lines.append(node.lineno)
+            else:
+                self.assertIsNone(node)
+
+        # Check annotations
+        annotations = func.args.annotations
+        self.assertEqual(len(annotations), len(args))
+        for i, arg in enumerate(args):
+            check_name(annotations[i], arg)
+        check_name(func.args.varargannotation, vararg)
+        check_name(func.args.kwargannotation, kwarg)
+
+        # Check returns
+        check_name(func.returns, returns)
+
+        # Check lines
+        self.assertEquals(list(lines), found_lines)
+
+    def test_unannotated(self):
+        self.check_annotations("""
+        def test(a, b):  #@
+            return str(a)
+        """, [None, None], None)
+
+    def test_return(self):
+        self.check_annotations("""
+        def test():  #@
+            # type: () -> str
+            return str(a)
+        """, [], 'str', lines=[3])
+
+    def test_ellipsis(self):
+        self.check_annotations("""
+        def test(a, b):  #@
+            # type: (...) -> str
+            return str(a)
+        """, [None, None], 'str', lines=[3])
+
+    def test_simple_func(self):
+        self.check_annotations("""
+        def test(a, b):  #@
+            # type: (int, str) -> str
+            return str(a)
+        """, ['int', 'str'], 'str', lines=[3, 3, 3])
+
+    def test_simple_func_same_line(self):
+        self.check_annotations("""
+        def test(a, b):  # type: (int, str) -> str #@
+            return str(a)
+        """, ['int', 'str'], 'str', lines=[2, 2, 2])
+
+    def test_split_lines(self):
+        self.check_annotations("""
+        def test( #@
+            a,   # type: int
+            b  # type: str
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, ['int', 'str'], 'str', lines=[3, 4, 6])
+
+    def test_class_method(self):
+        self.check_annotations("""
+        class Test(object):
+            def test(self, a, b):  #@
+                # type: (int, str) -> str
+                return str(a)
+        """, [None, 'int', 'str'], 'str', lines=[4, 4, 4])
+
+    def test_class_method_split(self):
+        self.check_annotations("""
+        class Test(object):
+            def test( #@
+                self,
+                a,  # type: int
+                b   # type: str
+            ):
+                # type: (...) -> str
+                return str(a)
+        """, [None, 'int', 'str'], 'str', lines=[5, 6, 8])
+
+    def test_class_method_self(self):
+        self.check_annotations("""
+        class Test(object):
+            def test(self, a, b):  #@
+                # type: (bytes, int, str) -> str
+                return str(a)
+        """, ['bytes', 'int', 'str'], 'str', lines=[4, 4, 4, 4])
+
+    def test_vararg(self):
+        self.check_annotations("""
+        def test(a, b, *args):  #@
+            # type: (int, str, *str) -> str
+            return str(a)
+        """, ['int', 'str'], vararg='str', returns='str', lines=[3, 3, 3, 3])
+
+        self.check_annotations("""
+        def test(a, # type: int #@
+                 b, # type: str
+                 *args # type: str
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, ['int', 'str'], vararg='str', returns='str', lines=[2, 3, 4, 6])
+
+    def test_kwarg(self):
+        self.check_annotations("""
+        def test(a, b, **kw):  #@
+            # type: (int, str, **int) -> str
+            return str(a)
+        """, ['int', 'str'], kwarg='int', returns='str', lines=[3, 3, 3, 3])
+
+        self.check_annotations("""
+        def test(a, # type: int #@
+                 b, # type: str
+                 **kwargs # type: str
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, ['int', 'str'], kwarg='str', returns='str', lines=[2, 3, 4, 6])
+
+    def test_only_vararg(self):
+        self.check_annotations("""
+        def test(*args):  #@
+            # type: (*str) -> str
+            return str(a)
+        """, [], vararg='str', returns='str', lines=[3, 3])
+
+        self.check_annotations("""
+        def test( #@
+                *args # type: str
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, [], vararg='str', returns='str', lines=[3, 5])
+
+    def test_only_kwarg(self):
+        self.check_annotations("""
+        def test(**kw):  #@
+            # type: (**int) -> str
+            return str(a)
+        """, [], kwarg='int', returns='str', lines=[3, 3])
+
+        self.check_annotations("""
+        def test( #@
+                **args # type: str
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, [], kwarg='str', returns='str', lines=[3, 5])
+
+    def test_all_args(self):
+        self.check_annotations("""
+        def test(a, b, *args, **kw):  #@
+            # type: (int, bytes, *str, **int) -> str
+            return str(a)
+        """, ['int', 'bytes'], vararg='str', kwarg='int', returns='str', lines=[3, 3, 3, 3, 3])
+
+        self.check_annotations("""
+        def test( #@
+            a, # type: int
+            b, # type: bytes
+            *args,  # type: str
+            **kw  # type: int
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, ['int', 'bytes'], vararg='str', kwarg='int', returns='str', lines=[3, 4, 5, 6, 8])
+
+    def test_all_args_with_defaults(self):
+        self.check_annotations("""
+        def test(a, b=None, *args, **kw):  #@
+            # type: (int, bytes, *str, **int) -> str
+            return str(a)
+        """, ['int', 'bytes'], vararg='str', kwarg='int', returns='str', lines=[3, 3, 3, 3, 3])
+
+        self.check_annotations("""
+        def test( #@
+            a, # type: int
+            b=None, # type: bytes
+            *args,  # type: str
+            **kw  # type: int
+        ):
+            # type: (...) -> str
+            return str(a)
+        """, ['int', 'bytes'], vararg='str', kwarg='int', returns='str', lines=[3, 4, 5, 6, 8])
+
+    def test_assignment(self):
+        assign = extract_node(dedent("x = []  # type: List[Employee]"))
+        self.assertIsInstance(assign, nodes.Assign)
+        self.assertEqual(assign.type_comment.as_string(), 'List[Employee]')
+
+    def test_multi_assignment(self):
+        assign = extract_node(dedent("x, y, z = [], [], []  # type: List[int], List[int], List[str]"))
+        self.assertIsInstance(assign, nodes.Assign)
+        self.assertEqual(assign.type_comment.as_string(), '(List[int], List[int], List[str])')
+
+    def not_passing_test_multi_assignment(self):
+        assign = extract_node(dedent("""
+        x = [
+        1,
+        2,
+        ]  # type: List[int]
+        """))
+        self.assertIsInstance(assign, nodes.Assign)
+        self.assertEqual(assign.type_comment.as_string(), '(List[int], List[int], List[str])')
+
+    def test_with(self):
+        _with = extract_node(dedent("""
+        with frobnicate():  # type: int
+            pass
+        """))
+        self.assertIsInstance(_with, nodes.With)
+        self.assertEqual(_with.type_comment.as_string(), 'int')
+
+    def test_for(self):
+        _for = extract_node(dedent("""
+        for x, y in points:  # type: float, float
+           pass
+        """))
+        self.assertIsInstance(_for, nodes.For)
+        self.assertEqual(_for.type_comment.as_string(), '(float, float)')

--- a/astroid/type_comments.py
+++ b/astroid/type_comments.py
@@ -1,0 +1,164 @@
+"""Inject type_comments into the AST."""
+import collections
+import re
+import tokenize
+
+from six import StringIO
+
+from astroid import nodes
+
+TYPE_ANNOTATION = re.compile(r'#\s*type:\s*(.*)')  # # type:
+IGNORE = re.compile(r'\s*ignore\b')
+FUNCTION_ANNOTATION = re.compile(r'(\(.*\))\s*->\s*(.*)')
+STAR_ARGS = re.compile(r'([(,]\s*)\*{1,2}')  # "(*Any" or "... , *Any" or "... , **Any" or
+EMPTY_ARGS = re.compile(r'\(\s*\)')  # ( any-whitespace )
+UNTYPED_ELLIPSIS_ARGS = re.compile(r'\(\s*\.{3}\s*\)')  # ( any-whitespace ... any-whitespace )
+COMPLEX_NAME = re.compile(r".*[,(\[]")
+
+TypeComment = collections.namedtuple('TypeComment', 'arg, vararg, kwarg, returns')
+
+def extract_type_comment(comment):
+    # type: (str) -> Optional[TypeComment]
+    """Return a TypeComment if this is a `# type:` comment"""
+
+    # Skip if the comment does not start with '# type:'.
+    m = TYPE_ANNOTATION.match(comment)
+    if not m:
+        return None
+    expr = m.group(1)  # Everything after '# type:'
+
+    # Skip if it's "# type: ignore"
+    if IGNORE.match(expr):
+        return None
+
+    expr = expr.split("#")[0].strip()
+    # Does it look like a signature annotation?
+    m = FUNCTION_ANNOTATION.match(expr)
+    if m:
+        arg_types, return_type = m.groups()
+        if EMPTY_ARGS.match(arg_types) or UNTYPED_ELLIPSIS_ARGS.match(expr):
+            # `...` is not valid Python 2 syntax, so just return the return_type.
+            ret = TypeComment(None, None, None, return_type)
+        else:
+            rest, _, kwarg = arg_types.strip(" ()").partition("**")
+            rest, _, vararg = rest.strip(" ,").partition("*")
+            args = rest.strip(" ,")
+
+            ret = TypeComment(
+                ("(%s,)" % args) if args else "()",
+                vararg,
+                kwarg,
+                return_type
+            )
+    else:
+        ret = TypeComment(expr, None, None, None)
+
+    # Skip if expr can't be parsed using compile().
+    for expr in ret:
+        try:
+            if expr:
+                compile(expr, '<string>', 'eval')
+        except Exception:
+            return None
+
+    return ret
+
+def get_scope_map(module):
+    """Return a dictionary of line number to scopes for quick lookups."""
+    def recurse(node, scope_map):
+        if isinstance(node, nodes.FunctionDef):
+            # For functions we look until the first item in the body.
+            # Sadly the docstring doesn't count in the body so it's not perfect.
+            for line in range(node.fromlineno, node.body[0].fromlineno):
+                scope_map[line] = node
+        elif isinstance(node, (nodes.Assign, nodes.With, nodes.For)):
+            for line in range(node.fromlineno, node.tolineno + 1):
+                scope_map[line] = node
+
+        for child in node.get_children():
+            recurse(child, scope_map)
+        return scope_map
+    return recurse(module, {})
+
+def inject_type_comments(builder, data, module):
+    """Inject type_comments into the module node."""
+    if "type:" not in data:
+        return
+
+    scope_map = get_scope_map(module)
+
+    def build(token, line, parent):
+        """Build an astroid node from token at lineno"""
+        # For performance reasons try to create NodeNG objects directly.
+        if token == 'None':
+            return nodes.Const(None, line, parent=parent)
+        elif COMPLEX_NAME.match(token) is None:
+            return nodes.Name(token, line, parent=parent)
+        else:
+            # This is faster than using extract_node.
+            ret = builder.string_build("\n" * (line - 1) + token).body[0].value
+            ret.parent = parent
+            return ret
+
+    # Tokenize the file looking for those juicy # type: annotations.
+    tokens = tokenize.generate_tokens(StringIO(data).readline)
+    last_name = None
+    for tok_type, tok_val, (lineno, _), _, _ in tokens:
+        if tok_type == tokenize.NAME:
+            # Save this name for parsing *arg and **kwarg type comments. See below.
+            last_name = tok_val
+        elif tok_type == tokenize.COMMENT:
+            type_comment = extract_type_comment(tok_val)
+            if type_comment:
+                target = scope_map[lineno]
+                if not target:
+                    continue
+
+                arg, vararg, kwarg, returns = type_comment
+                if not returns:
+                    # This is a "type: arg" comment
+                    assert vararg is None
+                    assert kwarg is None
+
+                    annotation = build(arg, lineno, target)
+                    if isinstance(target, nodes.FunctionDef):
+                        for i, argument in enumerate(target.args.args):
+                            if target.args.args[i].lineno == lineno:
+                                target.args.annotations[i] = annotation
+                                break
+                        else:
+                            # Sadly, vararg and kwarg lose their line numbers in the AST.
+                            # So we'll use the last_name to figure out which argument this
+                            # might be.
+                            if last_name == target.args.vararg:
+                                target.args.varargannotation = annotation
+                            elif last_name == target.args.kwarg:
+                                target.args.kwargannotation = annotation
+                    elif isinstance(target, (nodes.Assign, nodes.With, nodes.For)):
+                        target.type_comment = annotation
+                else:
+                    # This is a "(arg, *vararg, *kwarg) -> returns" comment
+                    if isinstance(target, nodes.FunctionDef):
+                        if arg:
+                            # Arg will always be a tuple of arguments.
+                            annotations = build(arg, lineno, target).elts
+
+                            if len(annotations) == len(target.args.annotations):
+                                start = 0
+                            elif len(annotations) == len(target.args.annotations) - 1:
+                                # XXX: Check if it could be a method, self.is_method() is pretty expensive
+                                # In methods you're allowed to not type `self`.
+                                start = 1
+                            else:
+                                raise Exception("Mismatch in args")
+
+                            for i, elt in enumerate(annotations):
+                                target.args.annotations[i + start] = elt
+
+                        if vararg:
+                            target.args.varargannotation = build(vararg, lineno, target)
+
+                        if kwarg:
+                            target.args.kwargannotation = build(kwarg, lineno, target)
+
+                        target.returns = build(returns, lineno, target)

--- a/astroid/type_comments.py
+++ b/astroid/type_comments.py
@@ -69,7 +69,12 @@ def get_scope_map(module):
         if isinstance(node, nodes.FunctionDef):
             # For functions we look until the first item in the body.
             # Sadly the docstring doesn't count in the body so it's not perfect.
-            for line in range(node.fromlineno, node.body[0].fromlineno):
+            if node.body:
+                tolineno = node.body[0].fromlineno
+            else:
+                # For functions without bodies (so just a docstring) we just sort of take the 2 lines after the start.
+                tolineno = node.blockstart_tolineno + 3
+            for line in range(node.fromlineno, tolineno):
                 scope_map[line] = node
         elif isinstance(node, (nodes.Assign, nodes.With, nodes.For)):
             for line in range(node.fromlineno, node.tolineno + 1):


### PR DESCRIPTION
### Fixes / new features
- Added annotations to the PY2 ast.
- Adds a second pass of the source looking for `# type:` comments.  Adds those into the nodes.
- Some perf improvements.

Just looking for comments on my approach here.