### PR TITLE
Fix namespace population when wildcard import is used

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -214,7 +214,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
                     imported = node.do_import_module()
                 except exceptions.AstroidBuildingError:
                     continue
-                for name in imported.public_names():
+                for name in imported.wildcard_import_names():
                     node.parent.set_local(name, node)
                     sort_locals(node.parent.scope().locals[name])
             else:

--- a/astroid/tests/unittest_builder.py
+++ b/astroid/tests/unittest_builder.py
@@ -772,17 +772,16 @@ class TestImportAll(unittest.TestCase):
         self.astroid_builder = builder.AstroidBuilder()
 
     def test_x(self):
-        import textwrap
-        m1_string = textwrap.dedent("""
+        m1_string = """
         __all__ = ['a', 'b', 'c']
         a = 1
         b = 2
         c = 3
         d = 4
-        """)
+        """
         m2_string = "from m1 import *"
-        m1 = self.astroid_builder.string_build(m1_string, 'm1')
-        m2 = self.astroid_builder.string_build(m2_string, 'm2')
+        m1 = builder.parse(m1_string, 'm1')
+        m2 = builder.parse(m2_string, 'm2')
         exported = ['a', 'b', 'c']
         self.assertEqual(m1.wildcard_import_names(), exported)
         self.assertEqual(len(m2.locals), 3)

--- a/astroid/tests/unittest_builder.py
+++ b/astroid/tests/unittest_builder.py
@@ -767,5 +767,28 @@ class TestGuessEncoding(unittest.TestCase):
         self.assertIsNone(e)
 
 
+class TestImportAll(unittest.TestCase):
+    def setUp(self):
+        self.astroid_builder = builder.AstroidBuilder()
+
+    def test_x(self):
+        import textwrap
+        m1_string = textwrap.dedent("""
+        __all__ = ['a', 'b', 'c']
+        a = 1
+        b = 2
+        c = 3
+        d = 4
+        """)
+        m2_string = "from m1 import *"
+        m1 = self.astroid_builder.string_build(m1_string, 'm1')
+        m2 = self.astroid_builder.string_build(m2_string, 'm2')
+        exported = ['a', 'b', 'c']
+        self.assertEqual(m1.wildcard_import_names(), exported)
+        self.assertEqual(len(m2.locals), 3)
+        for n in exported:
+            self.assertIn(n, m2.locals)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix PyCQA/pylint#1312