### PR TITLE
Fix metaclass detection when multiple keyword arguments are used in ClassDef

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -166,6 +166,9 @@ Change log for the astroid package (used to be astng)
       assumptions about what could be passed to other implementations,
       leading to various possible crashes when one or more arguments
       weren't given. Closes issue #277.
+
+    * Fix metaclass detection, when multiple keyword arguments
+      are used in class definition.
     
 
 2015-11-29 -- 1.4.1

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -317,7 +317,7 @@ class TreeRebuilder(object):
             for keyword in node.keywords:
                 if keyword.arg == 'metaclass':
                     metaclass = self.visit(keyword, newnode).value
-                break
+                    break
         if node.decorator_list:
             decorators = self.visit_decorators(node, newnode)
         else:

--- a/astroid/tests/unittest_python3.py
+++ b/astroid/tests/unittest_python3.py
@@ -96,6 +96,15 @@ class Python3TC(unittest.TestCase):
         self.assertEqual(metaclass.name, 'ABCMeta')
 
     @require_version('3.0')
+    def test_metaclass_multiple_keywords(self):
+        astroid = self.builder.string_build("class Test(magic=None, metaclass=type): pass")
+        klass = astroid.body[0]
+
+        metaclass = klass.metaclass()
+        self.assertIsInstance(metaclass, ClassDef)
+        self.assertEqual(metaclass.name, 'type')
+
+    @require_version('3.0')
     def test_as_string(self):
         body = dedent("""
         from abc import ABCMeta


### PR DESCRIPTION
Needed for PyCQA/pylint#1320