### PR TITLE
Fix typing.NamedTuple being not callable

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -233,7 +233,7 @@ class Instance(BaseInstance):
 
     def callable(self):
         try:
-            self._proxied.getattr('__call__', class_context=False)
+            self._proxied.getattr('__call__')
             return True
         except exceptions.AttributeInferenceError:
             return False

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -3338,7 +3338,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     @test_utils.require_version('3.5')
     def test_typing_namedtuple_is_callable(self):
-        import typing
         node = extract_node("""
         import typing
         MyNamedTuple = typing.NamedTuple('Named', [('foo', int), ('bar', int)])

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -3338,14 +3338,16 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     @test_utils.require_version('3.5')
     def test_typing_namedtuple_is_callable(self):
+        import typing
         node = extract_node("""
         import typing
-        Named = typing.NamedTuple('Named', [('foo', int), ('bar', int)])
-        Named
+        MyNamedTuple = typing.NamedTuple('Named', [('foo', int), ('bar', int)])
+        MyNamedTuple
         """)
+        MyNamedTuple = typing.NamedTuple('Named', [('foo', int), ('bar', int)])  # pylint: disable=invalid-name
         inferred = list(node.infer())
-        assert len(inferred) == 1
-        assert inferred[0].callable()
+        self.assertEqual(1, len(inferred))
+        self.assertEqual(callable(MyNamedTuple), inferred[0].callable())
 
 
 class GetattrTest(unittest.TestCase):

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -3336,6 +3336,17 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 25)
 
+    @test_utils.require_version('3.5')
+    def test_typing_namedtuple_is_callable(self):
+        node = extract_node("""
+        import typing
+        Named = typing.NamedTuple('Named', [('foo', int), ('bar', int)])
+        Named
+        """)
+        inferred = list(node.infer())
+        assert len(inferred) == 1
+        assert inferred[0].callable()
+
 
 class GetattrTest(unittest.TestCase):
 

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -3336,7 +3336,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 25)
 
-    @test_utils.require_version('3.5')
+    @test_utils.require_version('3.6')
     def test_typing_namedtuple_is_callable(self):
         node = extract_node("""
         import typing
@@ -3344,8 +3344,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         MyNamedTuple
         """)
         inferred = list(node.infer())
-        if util.Uninferable in inferred:
-            return
         self.assertEqual(1, len(inferred))
         self.assertTrue(inferred[0].callable())
 

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -3344,10 +3344,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         MyNamedTuple = typing.NamedTuple('Named', [('foo', int), ('bar', int)])
         MyNamedTuple
         """)
-        MyNamedTuple = typing.NamedTuple('Named', [('foo', int), ('bar', int)])  # pylint: disable=invalid-name
         inferred = list(node.infer())
+        if util.Uninferable in inferred:
+            return
         self.assertEqual(1, len(inferred))
-        self.assertEqual(callable(MyNamedTuple), inferred[0].callable())
+        self.assertTrue(inferred[0].callable())
 
 
 class GetattrTest(unittest.TestCase):


### PR DESCRIPTION
Needed for PyCQA/pylint#1320