### PR TITLE
builder: fix detection of whether found file is a package when there is a __init__.py in file name

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -192,7 +192,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
             modname = modname[:-9]
             package = True
         else:
-            package = path.find('__init__.py') > -1 if path else False
+            package = path is not None and os.path.splitext(os.path.basename(path))[0] == '__init__'
         builder = rebuilder.TreeRebuilder(self._manager)
         module = builder.visit_module(node, modname, node_file, package)
         module._import_from_nodes = builder._import_from_nodes

--- a/astroid/tests/unittest_builder.py
+++ b/astroid/tests/unittest_builder.py
@@ -370,6 +370,9 @@ class BuilderTest(unittest.TestCase):
         datap = resources.build_file('data/__init__.py', 'data.__init__')
         self.assertEqual(datap.name, 'data')
         self.assertEqual(datap.package, 1)
+        datap = resources.build_file('data/tmp__init__.py', 'data.tmp__init__')
+        self.assertEqual(datap.name, 'data.tmp__init__')
+        self.assertEqual(datap.package, 0)
 
     def test_yield_parent(self):
         """check if we added discard nodes as yield parent (w/ compiler)"""

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -55,12 +55,6 @@ class ModuleLoader(resources.SysPathSetup):
 
 
 class ModuleNodeTest(ModuleLoader, unittest.TestCase):
-    def test_is_package(self):
-        self.assertFalse(self.module.package)
-        self.assertFalse(self.module2.package)
-        self.assertFalse(self.nonregr.package)
-        self.assertTrue(self.pack.package)
-
     def test_special_attributes(self):
         self.assertEqual(len(self.module.getattr('__name__')), 1)
         self.assertIsInstance(self.module.getattr('__name__')[0], nodes.Const)

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -55,6 +55,7 @@ class ModuleLoader(resources.SysPathSetup):
 
 
 class ModuleNodeTest(ModuleLoader, unittest.TestCase):
+
     def test_special_attributes(self):
         self.assertEqual(len(self.module.getattr('__name__')), 1)
         self.assertIsInstance(self.module.getattr('__name__')[0], nodes.Const)

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -55,6 +55,11 @@ class ModuleLoader(resources.SysPathSetup):
 
 
 class ModuleNodeTest(ModuleLoader, unittest.TestCase):
+    def test_is_package(self):
+        self.assertFalse(self.module.package)
+        self.assertFalse(self.module2.package)
+        self.assertFalse(self.nonregr.package)
+        self.assertTrue(self.pack.package)
 
     def test_special_attributes(self):
         self.assertEqual(len(self.module.getattr('__name__')), 1)


### PR DESCRIPTION
Fixes PyCQA/pylint#1348