### PR TITLE
Quickstart _infer_binary_operation to raise errors that occur during startup

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -611,6 +611,22 @@ def _get_aug_flow(left, left_type, aug_opnode, right, right_type,
     return methods
 
 
+def quickstart(func):
+    """
+    Run a generator enough to get the first value, and then buffer that value.
+    This will raise any exceptions that happen during the generator startup
+    when func is called, rather than when it is used.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        result_generator = func(*args, **kwargs)
+        first_value = next(result_generator)
+
+        return itertools.chain([first_value], result_generator)
+    return wrapper
+
+
+@quickstart
 def _infer_binary_operation(left, right, binary_opnode, context, flow_factory):
     """Infer a binary operation between a left operand and a right operand
 

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -2497,6 +2497,20 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, Instance)
         self.assertEqual(inferred.name, 'A')
 
+    def test_binop_different_types_unknown_bases(self):
+        node = extract_node('''
+        from foo import bar
+
+        class A(bar):
+            pass
+        class B(object):
+            def __radd__(self, other):
+                return other
+        A() + B() #@
+        ''')
+        inferred = next(node.infer())
+        self.assertIs(inferred, util.Uninferable)
+
     def test_binop_different_types_normal_not_implemented_and_reflected(self):
         node = extract_node('''
         class A(object):


### PR DESCRIPTION
Since https://github.com/PyCQA/astroid/commit/3e27213914271309a4716662b09fda91fca9efa1,
`is_subtype` and `is_supertype` raise exceptions when they can't find a relationship between types. This is caught by the callers of `_infer_binary_operation`. However, the error is only thrown after the generator return by `_infer_binary_operation` is started.

Prior to this patch, the generator is only started inside the `else` clause of:

```
try:
    results = _infer_binary_operation(lhs, rhs, self, context, _get_binop_flow)
except exceptions._NonDeducibleTypeHierarchy:
    yield util.Uninferable
else:
    for result in results:
        yield result
```

To address this, the `quickstart` decorator pulls the first value from the generator when it's called, and then buffers that first result until it is needed by the later iteration.