### PR TITLE
Add a brain for the json module.

### DIFF
--- a/astroid/brain/brain_json.py
+++ b/astroid/brain/brain_json.py
@@ -1,0 +1,21 @@
+import astroid
+
+
+def _json_transform():
+    # pylint always thinks that json.loads returns a bool.
+    # Message: Instance of 'bool' has no 'get' member (no-member)
+    return astroid.parse('''
+    def loads(s, encoding=None, cls=None, object_hook=None, parse_float=None,
+        parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
+        if 1 in kw: return {}
+        if 2 in kw: return []
+        if 3 in kw: return True
+        if 4 in kw: return ""
+        if 5 in kw: return u""
+        if 6 in kw: return None
+        if 7 in kw: return 3.14
+    ''')
+
+
+astroid.register_module_extender(astroid.MANAGER, 'json', _json_transform)
+astroid.register_module_extender(astroid.MANAGER, 'simplejson', _json_transform)

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -625,6 +625,27 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, astroid.Instance)
         self.assertEqual(inferred.qname(), "typing.NamedTuple")
 
+
+class JsonBrainTest(unittest.TestCase):
+    def test_load_type(self):
+        result = builder.extract_node('''
+        import json
+        json.load('path')
+        ''')
+        inferred = list(result.infer())
+        for inferred in result.infer():
+            self.assertIsInstance(inferred, (nodes.Const, nodes.Dict, nodes.List))
+
+    def test_loads_type(self):
+        result = builder.extract_node('''
+        import json
+        json.loads('{}')
+        ''')
+        inferred = list(result.infer())
+        for inferred in result.infer():
+            self.assertIsInstance(inferred, (nodes.Const, nodes.Dict, nodes.List))
+
+
 class ReBrainTest(unittest.TestCase):
     def test_regex_flags(self):
         import re


### PR DESCRIPTION
This implements the fix suggested in https://github.com/PyCQA/pylint/issues/922 for the result of `json.load` being inferred as a `bool`.