### PR TITLE
Fix an infinite loop that could occur during inference of __nonzero__.

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -258,7 +258,8 @@ class Instance(BaseInstance):
              all its instances are considered true.
         """
         context = contextmod.InferenceContext()
-        context.callcontext = contextmod.CallContext(args=[self])
+        context.callcontext = contextmod.CallContext(args=[])
+        context.boundnode = self
 
         try:
             result = _infer_method_result_truth(self, BOOL_SPECIAL_METHOD, context)

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -2441,6 +2441,19 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             inferred = next(node.infer())
             self.assertEqual(inferred.bool_value(), expected_value)
 
+    def test_bool_value_variable(self):
+        instance = extract_node('''
+        class VariableBoolInstance(object):
+            def __init__(self, value):
+                self.value = value
+            def {bool}(self):
+                return self.value
+
+        not VariableBoolInstance(True)
+        '''.format(bool=BOOL_SPECIAL_METHOD))
+        inferred = next(instance.infer())
+        self.assertIs(inferred.bool_value(), util.Uninferable)
+
     def test_infer_coercion_rules_for_floats_complex(self):
         ast_nodes = extract_node('''
         1 + 1.0 #@


### PR DESCRIPTION
For example:

```
class AccessResponse(object):
    def __init__(self, has_access):
        self.has_access = has_access

    def __nonzero__(self):
        return self.has_access

not AccessResponse(False)
```