### PR TITLE
Improving caching

### DIFF
--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -35,8 +35,12 @@ def has_environment_marker_range_operators_support():
 
 if has_environment_marker_range_operators_support():
     extras_require[':python_version<"3.4"'] = ['enum34', 'singledispatch']
-elif py_version < (3, 4):
-    install_requires.extend(['enum34', 'singledispatch'])
+    extras_require[':python_version<"3.2"'] = ['functools32']
+else:
+    if py_version < (3, 4):
+        install_requires.extend(['enum34', 'singledispatch'])
+    if py_version < (3, 2):
+        install_requires.append('functools32')
 
 
 # pylint: disable=redefined-builtin; why license is a builtin anyway?

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -20,6 +20,11 @@ attribute. Thus the model can be viewed as a special part of the lookup
 mechanism.
 """
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from functools32 import lru_cache
+
 import pprint
 import os
 import types
@@ -88,6 +93,7 @@ class ObjectModel(object):
     def __contains__(self, name):
         return name in self.attributes()
 
+    @lru_cache(maxsize=None)
     def attributes(self):
         """Get the attributes which are exported by this object model."""
         return [obj[2:] for obj in dir(self) if obj.startswith('py')]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands = pylint -rn --rcfile={toxinidir}/pylintrc {envsitepackagesdir}/astroid
 [testenv]
 deps =
   py27,py33,pypy: enum34
+  py27,pypy: functools32
   lazy-object-proxy
   nose
   py27,py34,py35,py36: numpy


### PR DESCRIPTION
Before:
```
Command exited with non-zero status 30
305.85user 11.24system 5:17.37elapsed 99%CPU (0avgtext+0avgdata 584308maxresident)k
0inputs+888outputs (0major+168864minor)pagefaults 0swaps
```

After:
```
Command exited with non-zero status 30
296.86user 11.82system 5:09.93elapsed 99%CPU (0avgtext+0avgdata 584008maxresident)k
208inputs+480outputs (0major+169539minor)pagefaults 0swaps
```