### PR TITLE
Use set-difference rather than nested loops

### DIFF
--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -191,13 +191,13 @@ def _is_setuptools_namespace(location):
 
 def _precache_zipimporters(path=None):
     pic = sys.path_importer_cache
-    path = path or sys.path
+    path = set(path or sys.path)
+    path.difference_update(pic)
     for entry_path in path:
-        if entry_path not in pic:
-            try:
-                pic[entry_path] = zipimport.zipimporter(entry_path)
-            except zipimport.ZipImportError:
-                continue
+        try:
+            pic[entry_path] = zipimport.zipimporter(entry_path)
+        except zipimport.ZipImportError:
+            continue
     return pic
 
 


### PR DESCRIPTION
On https://github.com/edx/edx-platform/tree/master/common/lib/xmodule/xmodule, this resulted in the following performance improvement (with no change in the errors detected):

This gets most of the performance benefits of #413, but should be much more of an unambiguous win.

Before:

```
Command exited with non-zero status 30
619.70user 322.11system 15:44.25elapsed 99%CPU (0avgtext+0avgdata 587068maxresident)k
0inputs+464outputs (0major+201145minor)pagefaults 0swaps
```

After:

```
Command exited with non-zero status 30
294.99user 10.76system 5:05.97elapsed 99%CPU (0avgtext+0avgdata 583536maxresident)k
0inputs+440outputs (0major+167856minor)pagefaults 0swaps
```