### PR TITLE
Catch exceptions raised in running pylint on enum.py.

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1748,7 +1748,8 @@ class Slice(NodeNG):
     def pytype(self):
         return '%s.slice' % BUILTINS
 
-    def igetattr(self, attrname, context=None):
+    def igetattr(self, attrname, context=None, **kwargs):
+        util.check_extra_kwargs(**kwargs)
         if attrname == 'start':
             yield self._wrap_attribute(self.lower)
         elif attrname == 'stop':
@@ -1759,7 +1760,8 @@ class Slice(NodeNG):
             for value in self.getattr(attrname, context=context):
                 yield value
 
-    def getattr(self, attrname, context=None):
+    def getattr(self, attrname, context=None, **kwargs):
+        util.check_extra_kwargs(**kwargs)
         return self._proxied.getattr(attrname, context)
 
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -118,9 +118,10 @@ class Super(node_classes.NodeNG):
         """Get the name of the MRO pointer."""
         return self.mro_pointer.name
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context=None, **kwargs):
         """Retrieve the inferred values of the given attribute name."""
 
+        util.check_extra_kwargs(**kwargs)
         if name in self.special_attributes:
             yield self.special_attributes.lookup(name)
             return
@@ -171,7 +172,8 @@ class Super(node_classes.NodeNG):
                                                      attribute=name,
                                                      context=context)
 
-    def getattr(self, name, context=None):
+    def getattr(self, name, context=None, **kwargs):
+        util.check_extra_kwargs(**kwargs)
         return list(self.igetattr(name, context=context))
 
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -332,7 +332,8 @@ class Module(LocalsDictNodeNG):
     def display_type(self):
         return 'Module'
 
-    def getattr(self, name, context=None, ignore_locals=False):
+    def getattr(self, name, context=None, ignore_locals=False, **kwargs):
+        util.check_extra_kwargs(**kwargs)
         result = []
         name_in_locals = name in self.locals
 
@@ -353,10 +354,11 @@ class Module(LocalsDictNodeNG):
         raise exceptions.AttributeInferenceError(target=self, attribute=name,
                                                  context=context)
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context=None, **kwargs):
         """inferred getattr"""
         # set lookup name since this is necessary to infer on import nodes for
         # instance
+        util.check_extra_kwargs(**kwargs)
         context = contextmod.copy_context(context)
         context.lookupname = name
         try:
@@ -854,18 +856,20 @@ class FunctionDef(node_classes.Statement, Lambda):
         """
         return self.fromlineno, self.tolineno
 
-    def getattr(self, name, context=None):
+    def getattr(self, name, context=None, **kwargs):
         """this method doesn't look in the instance_attrs dictionary since it's
         done by an Instance proxy at inference time.
         """
+        util.check_extra_kwargs(**kwargs)
         if name in self.instance_attrs:
             return self.instance_attrs[name]
         if name in self.special_attributes:
             return [self.special_attributes.lookup(name)]
         raise exceptions.AttributeInferenceError(target=self, attribute=name)
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context=None, **kwargs):
         """Inferred getattr, which returns an iterator of inferred statements."""
+        util.check_extra_kwargs(**kwargs)
         try:
             return bases._infer_stmts(self.getattr(name, context),
                                       context, frame=self)
@@ -1382,7 +1386,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
                       PendingDeprecationWarning, stacklevel=2)
         return self.instantiate_class()
 
-    def getattr(self, name, context=None, class_context=True):
+    def getattr(self, name, context=None, class_context=True, **kwargs):
         """Get an attribute from this class, using Python's attribute semantic
 
         This method doesn't look in the instance_attrs dictionary
@@ -1397,6 +1401,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         metaclass will be done.
 
         """
+        util.check_extra_kwargs(**kwargs)
         values = self.locals.get(name, [])
         if name in self.special_attributes and class_context and not values:
             result = [self.special_attributes.lookup(name)]
@@ -1461,10 +1466,11 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
             else:
                 yield bases.BoundMethod(attr, self)
 
-    def igetattr(self, name, context=None, class_context=True):
+    def igetattr(self, name, context=None, class_context=True, **kwargs):
         """inferred getattr, need special treatment in class to handle
         descriptors
         """
+        util.check_extra_kwargs(**kwargs)
         # set lookup name since this is necessary to infer on import nodes for
         # instance
         context = contextmod.copy_context(context)

--- a/astroid/tests/unittest_utils.py
+++ b/astroid/tests/unittest_utils.py
@@ -7,6 +7,7 @@
 import unittest
 
 from astroid import builder
+from astroid import exceptions
 from astroid import InferenceError
 from astroid import nodes
 from astroid import node_classes
@@ -106,6 +107,35 @@ class InferenceUtil(unittest.TestCase):
         inferred = next(node.infer())
         with self.assertRaises(InferenceError):
             list(node_classes.unpack_infer(inferred))
+
+
+class NonInferenceUtil(unittest.TestCase):
+    assertRaisesAstroid = None
+    def setUp(self):
+        try:
+            self.assertRaisesAstroid = self.assertRaisesRegex
+        except AttributeError:
+            self.assertRaisesAstroid = self.assertRaisesRegexp
+
+    def mock_function(self, **kwargs):
+        astroid_util.check_extra_kwargs(**kwargs)
+
+    def test_check_extra_kwargs_no_errors(self):
+        self.assertIsNone(self.mock_function())
+
+    def test_check_extra_kwargs_one_kwarg(self):
+        # pylint: disable=deprecated-method
+        self.assertRaisesAstroid(exceptions.AstroidTypeError,
+                                 "mock_function got an unexpected keyword argument a",
+                                 self.mock_function,
+                                 a=1)
+
+    def test_check_extra_kwargs_two_kwargs(self):
+        # pylint: disable=deprecated-method
+        self.assertRaisesAstroid(exceptions.AstroidTypeError,
+                                 "mock_function got unexpected keyword arguments ",
+                                 self.mock_function,
+                                 a=1, b=2)
 
 
 if __name__ == '__main__':

--- a/astroid/tests/unittest_utils.py
+++ b/astroid/tests/unittest_utils.py
@@ -126,14 +126,14 @@ class NonInferenceUtil(unittest.TestCase):
     def test_check_extra_kwargs_one_kwarg(self):
         # pylint: disable=deprecated-method
         self.assertRaisesAstroid(exceptions.AstroidTypeError,
-                                 "mock_function got an unexpected keyword argument a",
+                                 "Calling function got an unexpected keyword argument a",
                                  self.mock_function,
                                  a=1)
 
     def test_check_extra_kwargs_two_kwargs(self):
         # pylint: disable=deprecated-method
         self.assertRaisesAstroid(exceptions.AstroidTypeError,
-                                 "mock_function got unexpected keyword arguments ",
+                                 "Calling function got unexpected keyword arguments ",
                                  self.mock_function,
                                  a=1, b=2)
 

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -111,6 +111,19 @@ def proxy_alias(alias_name, node_type):
                   '__instancecheck__': _instancecheck})
     return proxy(lambda: node_type)
 
+def check_extra_kwargs(**kwargs):
+    if not kwargs:
+        return
+
+    import inspect
+    from astroid.exceptions import AstroidTypeError
+
+    if len(kwargs) == 1:
+        msg = '{} got an unexpected keyword argument {}'
+    else:
+        msg = '{} got unexpected keyword arguments {}'
+    raise AstroidTypeError(msg.format(inspect.stack()[1][3], ', '.join(kwargs.keys())))
+
 
 # Backwards-compatibility aliases
 YES = Uninferable

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -115,14 +115,13 @@ def check_extra_kwargs(**kwargs):
     if not kwargs:
         return
 
-    import inspect
     from astroid.exceptions import AstroidTypeError
 
     if len(kwargs) == 1:
-        msg = '{} got an unexpected keyword argument {}'
+        msg = 'Calling function got an unexpected keyword argument {}.'
     else:
-        msg = '{} got unexpected keyword arguments {}'
-    raise AstroidTypeError(msg.format(inspect.stack()[1][3], ', '.join(kwargs.keys())))
+        msg = 'Calling function got unexpected keyword arguments {}.'
+    raise AstroidTypeError(msg.format(', '.join(kwargs.keys())))
 
 
 # Backwards-compatibility aliases


### PR DESCRIPTION
### Fixes / new features
- Catch exceptions raised in running pylint on enum.py from the standard library.
