### PR TITLE
Typo in load module exception handling (s/spec/found_spec) 

### DIFF
--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -130,7 +130,7 @@ class AstroidManager(object):
                 except Exception as ex: # pylint: disable=broad-except
                     util.reraise(exceptions.AstroidImportError(
                         'Loading {modname} failed with:\n{error}',
-                        modname=modname, path=spec.location, error=ex))
+                        modname=modname, path=found_spec.location, error=ex))
                 return self.ast_from_module(module, modname)
 
             elif found_spec.type == spec.ModuleType.PY_COMPILED:


### PR DESCRIPTION
### Fixes / new features
This is a fix for the following `AttributeError` that crashes pylint (v1.7.0)
```
...
  File "/usr/local/lib/python2.7/dist-packages/pylint/checkers/variables.py", line 1217, in _check_module_attrs
    module = next(module.getattr(name)[0].infer())
  File "/usr/local/lib/python2.7/dist-packages/astroid/scoped_nodes.py", line 345, in getattr
    result = [self.import_module(name, relative_only=True)]
  File "/usr/local/lib/python2.7/dist-packages/astroid/scoped_nodes.py", line 409, in import_module
    return MANAGER.ast_from_module_name(absmodname)
  File "/usr/local/lib/python2.7/dist-packages/astroid/manager.py", line 133, in ast_from_module_name
    modname=modname, path=spec.location, error=ex))
AttributeError: 'module' object has no attribute 'location
```

