### PR TITLE
Allow pylint/astroid to correctly interpret a class whose baseclass has been assigned to

### DIFF
--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -999,6 +999,9 @@ def _is_metaclass(klass, seen=None):
     for base in klass.bases:
         try:
             for baseobj in base.infer():
+                if isinstance(baseobj, mixins.AssignTypeMixin):
+                    baseobj = baseobj.frame().lookup(baseobj.parent.value.name)[1][0]
+
                 baseobj_name = baseobj.qname()
                 if baseobj_name in seen:
                     continue


### PR DESCRIPTION
If a class is derived from a base class that had been assigned to elsewhere in the code, `_is_metaclass` will see an `AssignAttr` or an `AssignName` as an inferred `baseobj`. These don't have `qname()`, so we use the first assigned value as the `baseobj` instead.