### PR TITLE
.travis.yml: python3.6 is no longer in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: TOXENV=pypy
     - python: 3.5
       env: TOXENV=pylint
-    - python: 3.6-dev
+    - python: 3.6
       env: TOXENV=py36
 
 before_install:


### PR DESCRIPTION
### Fixes / new features
- change python3.6 target