### PR TITLE
Fix finder for namespace packages

### DIFF
--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -121,6 +121,8 @@ class ExplicitNamespacePackageFinder(ImpFinder):
     """A finder for the explicit namespace packages, generated through pkg_resources."""
 
     def find_module(self, modname, module_parts, processed, submodule_path):
+        if processed:
+           return None
         if util.is_namespace(modname) and modname in sys.modules:
             submodule_path = sys.modules[modname].__path__
             return ModuleSpec(name=modname, location='',

--- a/astroid/tests/unittest_manager.py
+++ b/astroid/tests/unittest_manager.py
@@ -139,6 +139,20 @@ class AstroidManagerTest(resources.SysPathSetup,
             del pkg_resources._namespace_packages['foogle']
             sys.modules.pop('foogle')
 
+    def test_namespace_and_file_mismatch(self):
+        filepath = unittest.__file__
+        ast = self.manager.ast_from_file(filepath)
+        self.assertEqual(ast.name, 'unittest')
+        pth = 'foogle_fax-0.12.5-py2.7-nspkg.pth'
+        site.addpackage(resources.RESOURCE_PATH, pth, [])
+        pkg_resources._namespace_packages['foogle'] = []
+        try:
+            with self.assertRaises(exceptions.AstroidImportError):
+                self.manager.ast_from_module_name('unittest.foogle.fax')
+        finally:
+            del pkg_resources._namespace_packages['foogle']
+            sys.modules.pop('foogle')
+
     def _test_ast_from_zip(self, archive):
         origpath = sys.path[:]
         sys.modules.pop('mypypa', None)


### PR DESCRIPTION
Fixes https://github.com/PyCQA/pylint/issues/1489

#### Issue description
Run pylint (with a version `>= 1.7.0`) on a file `test.py` with the following content:

```
import google.auth
```

Provided that `google-auth` is installed, it outputs the following warning:
```
W:  1, 0: Relative import 'google.auth', should be 'test.google.auth' (relative-import)
```

#### Fix description

In `ExplicitNamespacePackageFinder.find_module` the value of the `submodule_path` parameter is not used. Since `test` is a valid module and `google` a valid namespace, it concludes that `test.google` is valid, returns a `ModuleSpec`, instead of returning `None`.

Checking for `submodule_path` seems to fix the pylint issue.
