### PR TITLE
Catch _NonDeducibleTypeHierarchy in inference._infer_augassign

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -725,12 +725,10 @@ def _infer_augassign(self, context=None):
                 return
 
             try:
-                results = _infer_binary_operation(lhs, rhs, self, context, _get_aug_flow)
+                for result in _infer_binary_operation(lhs, rhs, self, context, _get_aug_flow):
+                    yield result
             except exceptions._NonDeducibleTypeHierarchy:
                 yield util.Uninferable
-            else:
-                for result in results:
-                    yield result
 
 
 @decorators.path_wrapper


### PR DESCRIPTION
Similarly to _infer_binop, we have to handle exceptions raised by
helpers.is_subtype and helpers.is_supertype in _infer_augassign.

### Fixes / new features
- fixes exception raised by `pylint` and hanging `pylint -j2`

Sorry for no test. This exception hangs our project's CI, but I'm not able to reproduce this problem locally nor find a simple test case for it.