### PR TITLE
Mark test which has never passed as an expected failure

### DIFF
--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4273,6 +4273,7 @@ class CallSiteTest(unittest.TestCase):
         self.assertIn('f', site.duplicated_keywords)
 
 
+@unittest.expectedFailure
 class ObjectDunderNewTest(unittest.TestCase):
 
     def test_object_dunder_new_is_inferred_if_decorator(self):


### PR DESCRIPTION
Resolves https://github.com/PyCQA/astroid/issues/454.

This test was added in commit c2e8ca524793905018e0e4adc5e29e1d3b0446c6 to fix #172, but it's never been passing.

Rather than having all CI builds failing, I recommend removing this test so the CI can be of more use for future PRs. And then revisit the test to make sure the fix for #172 is working as expected.

Here's the failing commit to fix #172:
https://travis-ci.org/hugovk/astroid/builds/286902750

And here's the passing commit (except for pylint) before that one:
https://travis-ci.org/hugovk/astroid/builds/286903238