### PR TITLE
treat coroutines as generators

### DIFF
--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -932,14 +932,17 @@ class FunctionDef(node_classes.Statement, Lambda):
             return True
 
     def is_generator(self):
-        """return true if this is a generator function (or coroutine)"""
-        yield_nodes = (node_classes.Yield, node_classes.YieldFrom, node_classes.Await)
+        """return true if this is a generator function (or old-style coroutine)"""
+        yield_nodes = (node_classes.Yield, node_classes.YieldFrom)
         return next(self.nodes_of_class(yield_nodes,
                                         skip_klass=(FunctionDef, Lambda)), False)
 
+    def is_coroutine(self):
+        return False
+
     def infer_call_result(self, caller, context=None):
         """infer what a function is returning when called"""
-        if self.is_generator():
+        if self.is_generator() or self.is_coroutine():
             result = bases.Generator(self)
             yield result
             return
@@ -979,8 +982,7 @@ class FunctionDef(node_classes.Statement, Lambda):
 
 class AsyncFunctionDef(FunctionDef):
     """Asynchronous function created with the `async` keyword."""
-    def is_generator(self):
-        # coroutines are "kind-of" generators
+    def is_coroutine(self):
         return True
 
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -932,8 +932,8 @@ class FunctionDef(node_classes.Statement, Lambda):
             return True
 
     def is_generator(self):
-        """return true if this is a generator function"""
-        yield_nodes = (node_classes.Yield, node_classes.YieldFrom)
+        """return true if this is a generator function (or coroutine)"""
+        yield_nodes = (node_classes.Yield, node_classes.YieldFrom, node_classes.Await)
         return next(self.nodes_of_class(yield_nodes,
                                         skip_klass=(FunctionDef, Lambda)), False)
 
@@ -979,6 +979,9 @@ class FunctionDef(node_classes.Statement, Lambda):
 
 class AsyncFunctionDef(FunctionDef):
     """Asynchronous function created with the `async` keyword."""
+    def is_generator(self):
+        # coroutines are "kind-of" generators
+        return True
 
 
 def _rec_get_names(args, names=None):


### PR DESCRIPTION
I know it’s technically not true, but it’s good enough approximation
for initial support of asyncio.

Initial effort to fix PyCQA/pylint#1715 