### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ log
 build
 dist/
 astroid.egg-info/
+.idea
 .tox
 .coverage
 .coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ http://lists.logilab.org/mailman/listinfo/python-projects .
 Python Versions
 ---------------
 
-astroid is compatible with Python 2.7 as well as 3.3 and later. astroid uses
+astroid is compatible with Python 2.7 as well as 3.4 and later. astroid uses
 the same code base for both Python versions, using six.
 
 Test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,6 @@ environment:
     - PYTHON: "C:\\Python27"
       TOXENV: "py27"
 
-    - PYTHON: "C:\\Python33"
-      TOXENV: "py33"
-
     - PYTHON: "C:\\Python34"
       TOXENV: "py34"
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -34,13 +34,14 @@ def has_environment_marker_range_operators_support():
 
 
 if has_environment_marker_range_operators_support():
-    extras_require[':python_version<"3.4"'] = ['enum34>=1.1.3', 'singledispatch']
-    extras_require[':python_version<"3.3"'] = ['backports.functools_lru_cache']
+    extras_require[':python_version<"3.4"'] = ['enum34>=1.1.3',
+                                               'singledispatch',
+                                               'backports.functools_lru_cache']
 else:
     if py_version < (3, 4):
-        install_requires.extend(['enum34', 'singledispatch'])
-    if py_version < (3, 3):
-        install_requires.append('backports.functools_lru_cache')
+        install_requires.extend(['enum34',
+                                 'singledispatch',
+                                 'backports.functools_lru_cache'])
 
 
 # pylint: disable=redefined-builtin; why license is a builtin anyway?
@@ -59,7 +60,6 @@ classifiers = ["Topic :: Software Development :: Libraries :: Python Modules",
                "Programming Language :: Python :: 2",
                "Programming Language :: Python :: 2.7",
                "Programming Language :: Python :: 3",
-               "Programming Language :: Python :: 3.3",
                "Programming Language :: Python :: 3.4",
                "Programming Language :: Python :: 3.5",
                "Programming Language :: Python :: 3.6",

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -20,10 +20,6 @@ from astroid import nodes
 from astroid.builder import AstroidBuilder, extract_node
 from astroid import util
 
-PY3K = sys.version_info > (3, 0)
-PY33 = sys.version_info >= (3, 3)
-PY34 = sys.version_info >= (3, 4)
-
 
 def _infer_first(node, context):
     if node is util.Uninferable:

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -11,7 +11,7 @@ import six
 import astroid
 
 
-PY33 = sys.version_info >= (3, 3)
+PY34 = sys.version_info >= (3, 4)
 PY36 = sys.version_info >= (3, 6)
 
 
@@ -51,7 +51,7 @@ def _subprocess_transform():
                      startupinfo=None, creationflags=0):
             pass
         """
-    if PY33:
+    if PY34:
         wait_signature = 'def wait(self, timeout=None)'
     else:
         wait_signature = 'def wait(self)'

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -178,7 +178,7 @@ _SPEC_FINDERS = (
     ImpFinder,
     ZipFinder,
 )
-if _HAS_MACHINERY and sys.version_info[:2] > (3, 3):
+if _HAS_MACHINERY and sys.version_info[:2] > (3, 4):
     _SPEC_FINDERS += (PathSpecFinder, )
 _SPEC_FINDERS += (ExplicitNamespacePackageFinder, )
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -178,7 +178,7 @@ _SPEC_FINDERS = (
     ImpFinder,
     ZipFinder,
 )
-if _HAS_MACHINERY and sys.version_info[:2] > (3, 4):
+if _HAS_MACHINERY and sys.version_info[:2] >= (3, 4):
     _SPEC_FINDERS += (PathSpecFinder, )
 _SPEC_FINDERS += (ExplicitNamespacePackageFinder, )
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -163,19 +163,12 @@ class TreeRebuilder(object):
                     varargannotation = self.visit(node.vararg.annotation,
                                                   newnode)
                 vararg = vararg.arg
-            elif PY3 and node.varargannotation:
-                varargannotation = self.visit(node.varargannotation,
-                                              newnode)
         if kwarg:
             if PY34:
                 if node.kwarg.annotation:
                     kwargannotation = self.visit(node.kwarg.annotation,
                                                  newnode)
                 kwarg = kwarg.arg
-            elif PY3:
-                if node.kwargannotation:
-                    kwargannotation = self.visit(node.kwargannotation,
-                                                 newnode)
         if PY3:
             kwonlyargs = [self.visit(child, newnode) for child
                           in node.kwonlyargs]

--- a/astroid/tests/unittest_manager.py
+++ b/astroid/tests/unittest_manager.py
@@ -26,7 +26,7 @@ BUILTINS = six.moves.builtins.__name__
 def _get_file_from_object(obj):
     if platform.python_implementation() == 'Jython':
         return obj.__file__.split("$py.class")[0] + ".py"
-    if sys.version_info > (3, 4):
+    if sys.version_info >= (3, 4):
         return obj.__file__
     if not obj.__file__.endswith(".py"):
         return obj.__file__[:-1]
@@ -104,7 +104,7 @@ class AstroidManagerTest(resources.SysPathSetup,
     def test_ast_from_namespace_pkg_resources(self):
         self._test_ast_from_old_namespace_package_protocol('pkg_resources')
 
-    @unittest.skipUnless(sys.version_info[:2] > (3, 4), "Needs PEP 420 namespace protocol")
+    @unittest.skipUnless(sys.version_info[:2] >= (3, 4), "Needs PEP 420 namespace protocol")
     def test_implicit_namespace_package(self):
         data_dir = os.path.dirname(resources.find('data/namespace_pep_420'))
         contribute = os.path.join(data_dir, 'contribute_to_namespace')

--- a/astroid/tests/unittest_manager.py
+++ b/astroid/tests/unittest_manager.py
@@ -26,7 +26,7 @@ BUILTINS = six.moves.builtins.__name__
 def _get_file_from_object(obj):
     if platform.python_implementation() == 'Jython':
         return obj.__file__.split("$py.class")[0] + ".py"
-    if sys.version_info > (3, 0):
+    if sys.version_info > (3, 4):
         return obj.__file__
     if not obj.__file__.endswith(".py"):
         return obj.__file__[:-1]
@@ -104,7 +104,7 @@ class AstroidManagerTest(resources.SysPathSetup,
     def test_ast_from_namespace_pkg_resources(self):
         self._test_ast_from_old_namespace_package_protocol('pkg_resources')
 
-    @unittest.skipUnless(sys.version_info[:2] > (3, 3), "Needs PEP 420 namespace protocol")
+    @unittest.skipUnless(sys.version_info[:2] > (3, 4), "Needs PEP 420 namespace protocol")
     def test_implicit_namespace_package(self):
         data_dir = os.path.dirname(resources.find('data/namespace_pep_420'))
         contribute = os.path.join(data_dir, 'contribute_to_namespace')

--- a/astroid/tests/unittest_python3.py
+++ b/astroid/tests/unittest_python3.py
@@ -20,7 +20,7 @@ class Python3TC(unittest.TestCase):
     def setUpClass(cls):
         cls.builder = AstroidBuilder()
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_starred_notation(self):
         astroid = self.builder.string_build("*a, b = [1, 2, 3]", 'test', 'test')
 
@@ -29,7 +29,7 @@ class Python3TC(unittest.TestCase):
 
         self.assertTrue(isinstance(node.assign_type(), Assign))
 
-    @require_version('3.3')
+    @require_version('3.4')
     def test_yield_from(self):
         body = dedent("""
         def func():
@@ -45,7 +45,7 @@ class Python3TC(unittest.TestCase):
         self.assertEqual(yieldfrom_stmt.as_string(),
                          'yield from iter([1, 2])')
 
-    @require_version('3.3')
+    @require_version('3.4')
     def test_yield_from_is_generator(self):
         body = dedent("""
         def func():
@@ -56,7 +56,7 @@ class Python3TC(unittest.TestCase):
         self.assertIsInstance(func, FunctionDef)
         self.assertTrue(func.is_generator())
 
-    @require_version('3.3')
+    @require_version('3.4')
     def test_yield_from_as_string(self):
         body = dedent("""
         def func():
@@ -69,7 +69,7 @@ class Python3TC(unittest.TestCase):
 
     # metaclass tests
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_simple_metaclass(self):
         astroid = self.builder.string_build("class Test(metaclass=type): pass")
         klass = astroid.body[0]
@@ -78,13 +78,13 @@ class Python3TC(unittest.TestCase):
         self.assertIsInstance(metaclass, ClassDef)
         self.assertEqual(metaclass.name, 'type')
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_metaclass_error(self):
         astroid = self.builder.string_build("class Test(metaclass=typ): pass")
         klass = astroid.body[0]
         self.assertFalse(klass.metaclass())
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_metaclass_imported(self):
         astroid = self.builder.string_build(dedent("""
         from abc import ABCMeta
@@ -95,7 +95,7 @@ class Python3TC(unittest.TestCase):
         self.assertIsInstance(metaclass, ClassDef)
         self.assertEqual(metaclass.name, 'ABCMeta')
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_metaclass_multiple_keywords(self):
         astroid = self.builder.string_build("class Test(magic=None, metaclass=type): pass")
         klass = astroid.body[0]
@@ -104,7 +104,7 @@ class Python3TC(unittest.TestCase):
         self.assertIsInstance(metaclass, ClassDef)
         self.assertEqual(metaclass.name, 'type')
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_as_string(self):
         body = dedent("""
         from abc import ABCMeta
@@ -115,7 +115,7 @@ class Python3TC(unittest.TestCase):
         self.assertEqual(klass.as_string(),
                          '\n\nclass Test(metaclass=ABCMeta):\n    pass\n')
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_old_syntax_works(self):
         astroid = self.builder.string_build(dedent("""
         class Test:
@@ -126,7 +126,7 @@ class Python3TC(unittest.TestCase):
         metaclass = klass.metaclass()
         self.assertIsNone(metaclass)
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_metaclass_yes_leak(self):
         astroid = self.builder.string_build(dedent("""
         # notice `ab` instead of `abc`
@@ -137,7 +137,7 @@ class Python3TC(unittest.TestCase):
         klass = astroid['Meta']
         self.assertIsNone(klass.metaclass())
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_parent_metaclass(self):
         astroid = self.builder.string_build(dedent("""
         from abc import ABCMeta
@@ -150,7 +150,7 @@ class Python3TC(unittest.TestCase):
         self.assertIsInstance(metaclass, ClassDef)
         self.assertEqual(metaclass.name, 'ABCMeta')
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_metaclass_ancestors(self):
         astroid = self.builder.string_build(dedent("""
         from abc import ABCMeta
@@ -178,7 +178,7 @@ class Python3TC(unittest.TestCase):
                 self.assertIsInstance(meta, ClassDef)
                 self.assertEqual(meta.name, metaclass)
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_annotation_support(self):
         astroid = self.builder.string_build(dedent("""
         def test(a: int, b: str, c: None, d, e,
@@ -213,7 +213,7 @@ class Python3TC(unittest.TestCase):
         self.assertEqual(func.args.annotations[1].name, 'str')
         self.assertIsNone(func.returns)
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_kwonlyargs_annotations_supper(self):
         node = self.builder.string_build(dedent("""
         def test(*, a: int, b: str, c: None, d, e):
@@ -230,7 +230,7 @@ class Python3TC(unittest.TestCase):
         self.assertIsNone(arguments.kwonlyargs_annotations[3])
         self.assertIsNone(arguments.kwonlyargs_annotations[4])
 
-    @require_version('3.0')
+    @require_version('3.4')
     def test_annotation_as_string(self):
         code1 = dedent('''
         def test(a, b:int=4, c=2, f:'lala'=4)->2:

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ def install():
                  author_email = author_email,
                  url = web,
                  include_package_data = True,
+                 python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
                  install_requires = install_requires,
                  extras_require=extras_require,
                  packages = find_packages(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, pylint
+envlist = py27, py34, py35, py36, pypy, pylint
 skip_missing_interpreters = true
 
 [testenv:pylint]
@@ -8,13 +8,13 @@ commands = pylint -rn --rcfile={toxinidir}/pylintrc {toxinidir}/astroid
 [testenv]
 deps =
   py27,pypy: backports.functools_lru_cache
-  py27,py33,pypy: enum34
+  py27,pypy: enum34
   lazy-object-proxy
   nose
   py27,py34,py35,py36: numpy
   pytest
   python-dateutil
-  py27,py33,pypy: singledispatch
+  py27,pypy: singledispatch
   six
   wrapt
   pylint: git+https://github.com/pycqa/pylint@master


### PR DESCRIPTION
Latest master is failing on Python 3.3 because pytest, or rather py, has dropped support for Python 3.3 (https://github.com/pytest-dev/py/issues/159 https://github.com/pytest-dev/py/pull/165):

https://travis-ci.org/hugovk/astroid/builds/309952810

Here's the pip installs for astroid from PyPI for the last month (via `pypinfo --percent --pip astroid pyversion`) showing a small fraction on 3.3:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   61.4% |        417,265 |
| 3.6            |   18.8% |        127,876 |
| 3.5            |   11.4% |         77,237 |
| 3.4            |    7.4% |         50,348 |
| 2.6            |    0.4% |          3,046 |
| 3.3            |    0.3% |          1,733 |
| 3.7            |    0.2% |          1,573 |
| 3.2            |    0.0% |             32 |
| None           |    0.0% |              4 |