### PR TITLE
Assign __module__ and __qualname__ to class locals implicitly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ Change log for the astroid package (used to be astng)
 =====================================================
 
 --
+   * Fix missing __module__ and __qualname__ from class definition locals
+
+	Close PYCQA/pylint#1753
+
    * Fix a crash when __annotations__ access a parent's __init__ that does not have arguments
 
      Close #473

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1797,6 +1797,21 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         if parent is not None:
             parent.frame().set_local(name, self)
 
+        for local_name, node in self.implicit_locals():
+            self.add_local_node(node, local_name)
+
+    def implicit_locals(self):
+        """Get implicitly defined class definition locals.
+
+        :returns: the the name and Const pair for each local
+        :rtype: tuple(tuple(str, node_classes.Const), ...)
+        """
+        locals_ = (('__module__', self.special_attributes.py__module__),)
+        if sys.version_info >= (3, 3):
+            # __qualname__ is defined in PEP3155
+            locals_ += (("__qualname__", self.special_attributes.py__qualname__),)
+        return locals_
+
     # pylint: disable=redefined-outer-name
     def postinit(self, bases, body, decorators, newstyle=None, metaclass=None, keywords=None):
         """Do some setup after initialisation.

--- a/astroid/tests/unittest_builder.py
+++ b/astroid/tests/unittest_builder.py
@@ -648,13 +648,18 @@ class FileBuildTest(unittest.TestCase):
         klass1 = module['YO']
         locals1 = klass1.locals
         keys = sorted(locals1.keys())
-        self.assertEqual(keys, ['__init__', 'a'])
+        assert_keys = ['__init__', '__module__', '__qualname__', 'a']
+        if sys.version_info < (3, 3):
+            assert_keys.pop(assert_keys.index('__qualname__'))
+        self.assertEqual(keys, assert_keys)
         klass2 = module['YOUPI']
         locals2 = klass2.locals
         keys = locals2.keys()
-        self.assertEqual(sorted(keys),
-                         ['__init__', 'class_attr', 'class_method',
-                          'method', 'static_method'])
+        assert_keys = ['__init__', '__module__', '__qualname__', 'class_attr', 'class_method',
+              'method', 'static_method']
+        if sys.version_info < (3, 3):
+            assert_keys.pop(assert_keys.index('__qualname__'))
+        self.assertEqual(sorted(keys), assert_keys)
 
     def test_class_instance_attrs(self):
         module = self.module

--- a/astroid/tests/unittest_builder.py
+++ b/astroid/tests/unittest_builder.py
@@ -655,8 +655,10 @@ class FileBuildTest(unittest.TestCase):
         klass2 = module['YOUPI']
         locals2 = klass2.locals
         keys = locals2.keys()
-        assert_keys = ['__init__', '__module__', '__qualname__', 'class_attr', 'class_method',
-              'method', 'static_method']
+        assert_keys = [
+            '__init__', '__module__', '__qualname__', 'class_attr', 'class_method',
+            'method', 'static_method'
+        ]
         if sys.version_info < (3, 3):
             assert_keys.pop(assert_keys.index('__qualname__'))
         self.assertEqual(sorted(keys), assert_keys)


### PR DESCRIPTION
This prevents the locals `__qualname__` and `__module__` in the class definition from raising a false-positive no-member by implicitly creating them.

There is a problem that pylint thinks that locals reference variables upward in the mro without a namespace (class name), which is not the case, but I this fix is more of an improvement than before.

fixes PyCQA/pylint#1753