### PR TITLE
Allow pytest to recognize the tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[tool:pytest]
+python_files = unittest_*


### PR DESCRIPTION
configure pytest to look for `unittest_*` files so that it pytest works (mostly)