### PR TITLE
Fix submodule import in six.moves

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ Change log for the astroid package (used to be astng)
 =====================================================
 
 --
+   * Fix submodule imports from six
+
+   Close PYCQA/pylint#1640
+
    * Fix missing __module__ and __qualname__ from class definition locals
 
 	Close PYCQA/pylint#1753

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -373,6 +373,20 @@ class SixBrainTest(unittest.TestCase):
             qname = 'httplib.HTTPSConnection'
         self.assertEqual(inferred.qname(), qname)
 
+    @unittest.skipIf(six.PY2,
+                     "The python 2 six brain uses dummy classes")
+    def test_from_submodule_imports(self):
+        """Make sure ulrlib submodules can be imported from
+
+        See PyCQA/pylint#1640 for relevant issue
+        """
+        ast_node = builder.extract_node('''
+        from six.moves.urllib.parse import urlparse
+        urlparse #@
+        ''')
+        inferred = next(ast_node.infer())
+        self.assertIsInstance(inferred, nodes.FunctionDef)
+
 
 @unittest.skipUnless(HAS_MULTIPROCESSING,
                      'multiprocesing is required for this test, but '


### PR DESCRIPTION
This commit fixes import errors where modname
started with but was not equal to six.moves

Fixes  PyCQA/pylint#1640
