### PR TITLE
Fix shared InferenceContext path causing uninferable results

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,11 @@ Change log for the astroid package (used to be astng)
 
      Close #473
 
+   * Fix multiple objects sharing the same InferenceContext.path causing
+   uninferable results
+
+     Close #483
+
 2017-12-15 -- 1.6.0
 
    * When verifying duplicates classes in MRO, ignore on-the-fly generated classes

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -68,7 +68,11 @@ class cachedproperty(object):
 
 
 def path_wrapper(func):
-    """return the given infer function wrapped to handle the path"""
+    """return the given infer function wrapped to handle the path
+
+    Used to stop inference if the node has already been looked
+    at for a given `InferenceContext` to prevent infinite recursion
+    """
     # TODO: switch this to wrapt after the monkey-patching is fixed (ceridwen)
     @functools.wraps(func)
     def wrapped(node, context=None, _func=func, **kwargs):

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -112,16 +112,13 @@ class AstroidManager(object):
             os.chdir(os.path.dirname(context_file))
         try:
             found_spec = self.file_from_module_name(modname, context_file)
-            # pylint: disable=no-member
             if found_spec.type == spec.ModuleType.PY_ZIPMODULE:
-                # pylint: disable=no-member
                 module = self.zip_import_data(found_spec.location)
                 if module is not None:
                     return module
 
             elif found_spec.type in (spec.ModuleType.C_BUILTIN,
                                      spec.ModuleType.C_EXTENSION):
-                # pylint: disable=no-member
                 if (found_spec.type == spec.ModuleType.C_EXTENSION
                         and not self._can_load_extension(modname)):
                     return self._build_stub_module(modname)
@@ -136,21 +133,17 @@ class AstroidManager(object):
             elif found_spec.type == spec.ModuleType.PY_COMPILED:
                 raise exceptions.AstroidImportError(
                     "Unable to load compiled module {modname}.",
-                    # pylint: disable=no-member
                     modname=modname, path=found_spec.location)
 
             elif found_spec.type == spec.ModuleType.PY_NAMESPACE:
                 return self._build_namespace_module(modname,
-                                                    # pylint: disable=no-member
                                                     found_spec.submodule_search_locations)
 
-            # pylint: disable=no-member
             if found_spec.location is None:
                 raise exceptions.AstroidImportError(
                     "Can't find a file for module {modname}.",
                     modname=modname)
 
-            # pylint: disable=no-member
             return self.ast_from_file(found_spec.location, modname, fallback=False)
         except exceptions.AstroidBuildingError as e:
             for hook in self._failed_import_hooks:

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -1129,6 +1129,33 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(len(foo_class.instance_attrs['attr']), 1)
         self.assertEqual(bar_class.instance_attrs, {'attr': [assattr]})
 
+    def test_nonregr_multi_referential_addition(self):
+        """Regression test for https://github.com/PyCQA/astroid/issues/483
+        Make sure issue where referring to the same variable
+        in the same inferred expression caused an uninferable result.
+        """
+        code = """
+        b = 1
+        a = b + b
+        a #@
+        """
+        variable_a = extract_node(code)
+        self.assertEqual(variable_a.inferred()[0].value, 2)
+
+    @test_utils.require_version(minver='3.5')
+    def test_nonregr_layed_dictunpack(self):
+        """Regression test for https://github.com/PyCQA/astroid/issues/483
+        Make sure mutliple dictunpack references are inferable
+        """
+        code = """
+        base = {'data': 0}
+        new = {**base, 'data': 1}
+        new3 = {**base, **new}
+        new3 #@
+        """
+        ass = extract_node(code)
+        self.assertIsInstance(ass.inferred()[0], nodes.Dict)
+
     def test_python25_no_relative_import(self):
         ast = resources.build_file('data/package/absimport.py')
         self.assertTrue(ast.absolute_import_activated(), True)

--- a/astroid/tests/unittest_manager.py
+++ b/astroid/tests/unittest_manager.py
@@ -196,7 +196,6 @@ class AstroidManagerTest(resources.SysPathSetup,
         """check if the unittest filepath is equals to the result of the method"""
         self.assertEqual(
             _get_file_from_object(unittest),
-            # pylint: disable=no-member; can't infer the ModuleSpec
             self.manager.file_from_module_name('unittest', None).location)
 
     def test_file_from_module_name_astro_building_exception(self):

--- a/astroid/tests/unittest_raw_building.py
+++ b/astroid/tests/unittest_raw_building.py
@@ -46,14 +46,12 @@ class RawBuildingTC(unittest.TestCase):
 
     def test_build_function_args(self):
         args = ['myArgs1', 'myArgs2']
-        # pylint: disable=no-member; not aware of postinit
         node = build_function('MyFunction', args)
         self.assertEqual('myArgs1', node.args.args[0].name)
         self.assertEqual('myArgs2', node.args.args[1].name)
         self.assertEqual(2, len(node.args.args))
 
     def test_build_function_defaults(self):
-        # pylint: disable=no-member; not aware of postinit
         defaults = ['defaults1', 'defaults2']
         node = build_function('MyFunction', None, defaults)
         self.assertEqual(2, len(node.args.defaults))

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -233,7 +233,7 @@ class ModuleNodeTest(ModuleLoader, unittest.TestCase):
         path = resources.find('data/all.py')
         astroid = builder.AstroidBuilder().file_build(path, 'all')
         with self.assertRaises(AttributeError):
-            # pylint: disable=pointless-statement
+            # pylint: disable=pointless-statement,no-member
             astroid.file_stream
 
     def test_stream_api(self):


### PR DESCRIPTION
Upon InferenceContext clone, the `path` attribute set is now shallow copied instead of shared (unintentionally?) among multiple diverged `InferenceContext` objects.

Fixes #483 