### PR TITLE
Enhancement of numpy brain

### DIFF
--- a/astroid/brain/brain_numpy.py
+++ b/astroid/brain/brain_numpy.py
@@ -146,6 +146,39 @@ def numpy_core_umath_transform():
     def true_divide(x1, x2, {opt_args:s}): pass
     '''.format(opt_args=ufunc_optional_keyword_arguments))
 
+
+def numpy_core_numerictypes_transform():
+    return astroid.parse('''
+    # different types defined in numerictypes.py
+    uint16 = type('uint16') 
+    uint32 = type('uint32')
+    uint64 = type('uint64')
+    int128 = type('int128')
+    uint128 = type('uint128')
+    float16 = type('float16')
+    float32 = type('float32')
+    float64 = type('float64')
+    float80 = type('float80')
+    float96 = type('float96')
+    float128 = type('float128')
+    float256 = type('float256')
+    complex32 = type('complex32')
+    complex64 = type('complex64')
+    complex128 = type('complex128')
+    complex160 = type('complex160')
+    complex192 = type('complex192')
+    complex256 = type('complex256')
+    complex512 = type('complex512')
+    timedelta64 = type('timedelta64')
+    datetime64 = type('datetime64')
+    unicode_ = type('unicode_')
+    string_ = type('string_')
+    object_ = type('object_')
+    ''')
+
+
 astroid.register_module_extender(astroid.MANAGER, 'numpy.core.umath', numpy_core_umath_transform)
 astroid.register_module_extender(astroid.MANAGER, 'numpy.random.mtrand',
                                  numpy_random_mtrand_transform)
+astroid.register_module_extender(astroid.MANAGER, 'numpy.core.numerictypes',
+                                 numpy_core_numerictypes_transform)

--- a/astroid/tests/unittest_brain_numpy.py
+++ b/astroid/tests/unittest_brain_numpy.py
@@ -238,5 +238,32 @@ class NumpyBrainRandomMtrandTest(SubTestWrapper):
                 self.assertEqual(default_args_values, exact_kwargs_default_values)
 
 
+@unittest.skipUnless(HAS_NUMPY, "This test requires the numpy library.")
+class NumpyBrainCoreNumericTypesTest(SubTestWrapper):
+    """
+    Test of all the missing types defined in numerictypes module.
+    """
+    all_types = ['uint16', 'uint32', 'uint64', 'int128', 'uint128',
+                 'float16', 'float32', 'float64', 'float80', 'float96',
+                 'float128', 'float256', 'complex32', 'complex64', 'complex128',
+                 'complex160', 'complex192', 'complex256', 'complex512',
+                 'timedelta64', 'datetime64', 'unicode_', 'string_', 'object_']
+
+    def _inferred_numpy_attribute(self, attrib):
+        node = builder.extract_node("""
+        import numpy.core.numerictypes as tested_module
+        missing_type = tested_module.{:s}""".format(attrib))
+        return next(node.value.infer())
+
+    def test_numpy_core_types(self):
+        """
+        Test that all defined types have ClassDef type.
+        """
+        for typ in self.all_types:
+            with self.subTest(typ=typ):
+                inferred = self._inferred_numpy_attribute(typ)
+                self.assertIsInstance(inferred, nodes.ClassDef)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses the problem of false positive ``no-member`` emission when using ``numpy`` and specific types (last part of #https://github.com/PyCQA/pylint/issues/779).
The missing types have been added to the numpy brain and a corresponding unit test has been created.