### PR TITLE
Update subprocess brain to know about Popen args member in python>=3.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,11 @@ Change log for the astroid package (used to be astng)
 
      Close PyCQA/pylint#1839
 
+   * Subprocess.Popen brain now knows of the args member
+
+     Close PyCQA/pylint#1860
+
+
 2017-12-15 -- 1.6.0
 
    * When verifying duplicates classes in MRO, ignore on-the-fly generated classes

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -13,6 +13,7 @@ import astroid
 
 PY34 = sys.version_info >= (3, 4)
 PY36 = sys.version_info >= (3, 6)
+PY33 = sys.version_info >= (3, 3)
 
 
 def _subprocess_transform():
@@ -62,10 +63,14 @@ def _subprocess_transform():
         '''
     else:
         ctx_manager = ''
+    py3_args = ""
+    if PY33:
+        py3_args = "args = []"
     code = textwrap.dedent('''
     class Popen(object):
         returncode = pid = 0
         stdin = stdout = stderr = file()
+        %(py3_args)s
 
         %(communicate_signature)s:
             return %(communicate)r
@@ -83,7 +88,9 @@ def _subprocess_transform():
        ''' % {'communicate': communicate,
               'communicate_signature': communicate_signature,
               'wait_signature': wait_signature,
-              'ctx_manager': ctx_manager})
+              'ctx_manager': ctx_manager,
+              'py3_args': py3_args,
+              })
 
     init_lines = textwrap.dedent(init).splitlines()
     indented_init = '\n'.join([' ' * 4 + line for line in init_lines])

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -860,5 +860,24 @@ class RandomSampleTest(unittest.TestCase):
         self.assertEqual(elems, [1, 2])
 
 
+class SubprocessTest(unittest.TestCase):
+    """Test subprocess brain"""
+    # TODO Add more tests so that we can some day
+    # Remove this brain when all the tests work without the brain
+    @unittest.skipIf(sys.version_info < (3, 3),
+                     reason="Python 2.7 subprocess doesnt have args")
+    def test_subprocess_args(self):
+        """Make sure the args attribute exists for Popen
+
+        Test for https://github.com/PyCQA/pylint/issues/1860"""
+        name = astroid.extract_node("""
+        import subprocess
+        p = subprocess.Popen(['ls'])
+        p #@
+        """)
+        [inst] = name.inferred()
+        self.assertIsInstance(next(inst.igetattr("args")), nodes.List)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes PyCQA/pylint#1860