### PR TITLE
Fix inference tip collisions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -86,6 +86,11 @@ Change log for the astroid package (used to be astng)
 
       Close PyCQA/pylint#1328
 
+    * Stop most inference tip overwrites from happening by using
+		predicates on existing inference_tip transforms.
+
+      Close #472
+
 2017-06-03 -- 1.5.3
 
     * enum34 dependency is forced to be at least version 1.1.3. Fixes spurious

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -97,9 +97,12 @@ class AsStringRegexpPredicate(object):
         # pylint: disable=no-member; github.com/pycqa/astroid/126
         return self.regexp.search(node.as_string())
 
-def inference_tip(infer_function):
+def inference_tip(infer_function, raise_on_overwrite=False):
     """Given an instance specific inference function, return a function to be
     given to MANAGER.register_transform to set this inference function.
+
+    :param bool raise_on_overwrite: Raise an `InferenceOverwriteError`
+        if the inference tip will overwrite another. Used for debugging
 
     Typical usage
 
@@ -107,8 +110,24 @@ def inference_tip(infer_function):
 
        MANAGER.register_transform(Call, inference_tip(infer_named_tuple),
                                   predicate)
+
+    .. Note::
+
+        Using an inference tip will override
+        any previously set inference tip for the given
+        node. Use a predicate in the transform to prevent
+        excess overwrites.
     """
     def transform(node, infer_function=infer_function):
+        if (raise_on_overwrite
+                and node._explicit_inference is not None
+                and node._explicit_inference is not infer_function):
+            raise InferenceOverwriteError(
+                "Inference already set to {existing_inference}. "
+                "Trying to overwrite with {new_inference} for {node}"
+                .format(existing_inference=infer_function,
+                        new_inference=node._explicit_inference,
+                        node=node))
         node._explicit_inference = infer_function
         return node
     return transform

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -490,14 +490,24 @@ def infer_slice(node, context=None):
 
 
 def _infer_object__new__decorator(node, context=None):
+    # Instantiate class immediately
+    # since that's what @object.__new__ does
+    return iter((node.instantiate_class(),))
+
+
+def _infer_object__new__decorator_check(node):
+    """Predicate before inference_tip
+
+    Check if the given ClassDef has a @object.__new__ decorator
+    """
     if not node.decorators:
-        raise UseInferenceDefault
+        return False
 
     for decorator in node.decorators.nodes:
         if isinstance(decorator, nodes.Attribute):
             if decorator.as_string() == OBJECT_DUNDER_NEW:
-                return iter((node.instantiate_class(),))
-    raise UseInferenceDefault
+                return True
+    return False
 
 
 # Builtins inference
@@ -517,5 +527,6 @@ register_builtin_transform(infer_slice, 'slice')
 # Infer object.__new__ calls
 MANAGER.register_transform(
     nodes.ClassDef,
-    inference_tip(_infer_object__new__decorator)
+    inference_tip(_infer_object__new__decorator),
+    _infer_object__new__decorator_check
 )

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -51,9 +51,6 @@ def infer_typing_namedtuple_class(node, context=None):
     """Infer a subclass of typing.NamedTuple"""
 
     # Check if it has the corresponding bases
-    if not set(node.basenames) & TYPING_NAMEDTUPLE_BASENAMES:
-        raise UseInferenceDefault
-
     annassigns_fields = [
         annassign.target.name for annassign in node.body
         if isinstance(annassign, nodes.AnnAssign)
@@ -67,6 +64,15 @@ def infer_typing_namedtuple_class(node, context=None):
     )
     node = extract_node(code)
     return node.infer(context=context)
+
+
+def has_namedtuple_base(node):
+    """Predicate for class inference tip
+
+    :type node: ClassDef
+    :rtype: bool
+    """
+    return set(node.basenames) & TYPING_NAMEDTUPLE_BASENAMES
 
 
 def looks_like_typing_namedtuple(node):
@@ -83,7 +89,9 @@ MANAGER.register_transform(
     inference_tip(infer_typing_namedtuple),
     looks_like_typing_namedtuple
 )
+
 MANAGER.register_transform(
     nodes.ClassDef,
-    inference_tip(infer_typing_namedtuple_class)
+    inference_tip(infer_typing_namedtuple_class),
+    has_namedtuple_base
 )

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -198,6 +198,13 @@ class AstroidTypeError(AstroidError):
     """Raised when a TypeError would be expected in Python code."""
 
 
+class InferenceOverwriteError(AstroidError):
+    """Raised when an inference tip is overwritten
+
+    Currently only used for debugging.
+    """
+
+
 # Backwards-compatibility aliases
 OperationError = util.BadOperationMessage
 UnaryOperationError = util.BadUnaryOperationMessage

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4318,10 +4318,7 @@ class CallSiteTest(unittest.TestCase):
         self.assertIn('f', site.duplicated_keywords)
 
 
-@unittest.skip(
-    reason="This test is pass/failing in in a non-determenistic manner")
 class ObjectDunderNewTest(unittest.TestCase):
-
     def test_object_dunder_new_is_inferred_if_decorator(self):
         node = extract_node('''
         @object.__new__


### PR DESCRIPTION
Set predicates for transforms which use inference_tips to prevent
_explicit_inference being overwritten

Fixes #472 
