### PR TITLE
Add move_to_end to OrderedDict collections brain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,10 @@ Change log for the astroid package (used to be astng)
 
      Close PyCQA/pylint#1860
 
+   * add move_to_end method to collections.OrderedDict brain
+
+     Close PyCQA/pylint#1872
+
 
 2017-12-15 -- 1.6.0
 

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -6,6 +6,7 @@ import sys
 
 import astroid
 
+PY34 = sys.version_info >= (3, 4)
 PY35 = sys.version_info >= (3, 5)
 
 
@@ -16,11 +17,7 @@ def _collections_transform():
         def __missing__(self, key): pass
         def __getitem__(self, key): return default_factory
 
-    ''' + _deque_mock() + '''
-
-    class OrderedDict(dict):
-        def __reversed__(self): return self[::-1]
-    ''')
+    ''' + _deque_mock() + _ordered_dict_mock())
 
 
 def _deque_mock():
@@ -61,6 +58,17 @@ def _deque_mock():
         def __imul__(self, other): pass
         def __rmul__(self, other): pass'''
     return base_deque_class
+
+
+def _ordered_dict_mock():
+    base_ordered_dict_class = '''
+    class OrderedDict(dict):
+        def __reversed__(self): return self[::-1]
+    '''
+    if PY34:
+        base_ordered_dict_class += '''
+        def move_to_end(self, key, last=False): pass'''
+    return base_ordered_dict_class
 
 astroid.register_module_extender(astroid.MANAGER, 'collections', _collections_transform)
 

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -101,6 +101,21 @@ class CollectionsDequeTests(unittest.TestCase):
         self.assertIn('index', inferred.locals)
 
 
+class OrderedDictTest(unittest.TestCase):
+    def _inferred_ordered_dict_instance(self):
+        node = builder.extract_node("""
+        import collections
+        d = collections.OrderedDict()
+        d
+        """)
+        return next(node.infer())
+
+    @test_utils.require_version(minver='3.4')
+    def test_ordered_dict_py34method(self):
+        inferred = self._inferred_ordered_dict_instance()
+        self.assertIn('move_to_end', inferred.locals)
+
+
 class NamedTupleTest(unittest.TestCase):
 
     def test_namedtuple_base(self):


### PR DESCRIPTION
### Fixes / new features
- Close https://github.com/PyCQA/pylint/issues/1872

