### PR TITLE
Stop generated builtin str methods from referencing a dummy class

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -74,6 +74,11 @@ def _extend_str(class_node, rvalue):
     code = code.format(rvalue=rvalue)
     fake = AstroidBuilder(MANAGER).string_build(code)['whatever']
     for method in fake.mymethods():
+        method.parent = class_node
+        method.lineno = None
+        method.col_offset = None
+        if '__class__' in method.locals:
+            method.locals['__class__'] = [class_node]
         class_node.locals[method.name] = [method]
         method.parent = class_node
 


### PR DESCRIPTION
This class, called 'whatever' ended up appearing in pyreverse
due to a local called `__class__` which pointed to it. pyreverse
seemed to have found this class by recursively visiting nodes
and calling the values() method of each node.

Closes PyCQA/pylint#1875
