### PR TITLE
pytest as default CI test runner

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,4 @@ source =
 include =
     astroid/*
 omit =
-    */test/*
+    */tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [wheel]
 universal = 1
 [tool:pytest]
-python_files = unittest_*
+python_files = unittest_* test_*.py
+testpaths = astroid/tests

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ deps =
   py27,pypy: backports.functools_lru_cache
   py27,pypy: enum34
   lazy-object-proxy
+  ; we have a brain for nose
+  ; we use pytest for tests
   nose
   py27,py34,py35,py36: numpy
   py27,py34,py35,py36: attr

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,11 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 
 commands =
-    python -Wi -m coverage run -m unittest {posargs: discover -s astroid/tests -p "unittest*.py"}
+    ; --pyargs is needed so the directory astroid doesn't shadow the tox
+    ; installed astroid package
+    ; This is important for tests' test data which create files
+    ; inside the package
+    python -Wi {envsitepackagesdir}/coverage run -m pytest --pyargs astroid {posargs:}
     ; Transform absolute path to relative path
     ; for compatibility with coveralls.io and fix 'source not available' error.
     ; If you can find a cleaner way is welcome


### PR DESCRIPTION
Use pytest as the default test runner in the CI

Astroid should to modernize its test stack to make it easier to write tests