### PR TITLE
Run python 3.6 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ environment:
     - PYTHON: "C:\\Python35"
       TOXENV: "py35"
 
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36"
+
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*


### PR DESCRIPTION
This is already done for travis:

https://github.com/PyCQA/astroid/blob/aae8d207b65c27dc04e4a8cfab176e06d03065b2/.travis.yml#L15-L18

Unfortunately, version 3.7 is not available in AppVeyor https://www.appveyor.com/docs/build-environment/#python, so I have only included python 3.6.