### PR TITLE
Making Pylint faster

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -627,8 +627,16 @@ class NodeNG(object):
         """
         if isinstance(self, klass):
             yield self
+
+        if skip_klass is None:
+            for child_node in self.get_children():
+                for matching in child_node.nodes_of_class(klass, skip_klass):
+                    yield matching
+
+            return
+
         for child_node in self.get_children():
-            if skip_klass is not None and isinstance(child_node, skip_klass):
+            if isinstance(child_node, skip_klass):
                 continue
             for matching in child_node.nodes_of_class(klass, skip_klass):
                 yield matching

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -696,6 +696,10 @@ class Module(LocalsDictNodeNG):
         """
         return True
 
+    def get_children(self):
+        for elt in self.body:
+            yield elt
+
 
 class ComprehensionScope(LocalsDictNodeNG):
     """Scoping for different types of comprehensions."""
@@ -777,6 +781,11 @@ class GeneratorExp(ComprehensionScope):
         """
         return True
 
+    def get_children(self):
+        yield self.elt
+
+        yield from self.generators
+
 
 class DictComp(ComprehensionScope):
     """Class representing an :class:`ast.DictComp` node.
@@ -851,6 +860,12 @@ class DictComp(ComprehensionScope):
         """
         return util.Uninferable
 
+    def get_children(self):
+        yield self.key
+        yield self.value
+
+        yield from self.generators
+
 
 class SetComp(ComprehensionScope):
     """Class representing an :class:`ast.SetComp` node.
@@ -916,6 +931,11 @@ class SetComp(ComprehensionScope):
         """
         return util.Uninferable
 
+    def get_children(self):
+        yield self.elt
+
+        yield from self.generators
+
 
 class _ListComp(node_classes.NodeNG):
     """Class representing an :class:`ast.ListComp` node.
@@ -956,6 +976,11 @@ class _ListComp(node_classes.NodeNG):
         :rtype: Uninferable
         """
         return util.Uninferable
+
+    def get_children(self):
+        yield self.elt
+
+        yield from self.generators
 
 
 class ListComp(_ListComp, ComprehensionScope):
@@ -1173,6 +1198,10 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         :rtype: bool
         """
         return True
+
+    def get_children(self):
+        yield self.args
+        yield self.body
 
 
 class FunctionDef(node_classes.Statement, Lambda):
@@ -1553,6 +1582,18 @@ class FunctionDef(node_classes.Statement, Lambda):
         :rtype: bool
         """
         return True
+
+    def get_children(self):
+        if self.decorators is not None:
+            yield self.decorators
+
+        yield self.args
+
+        if self.returns is not None:
+            yield self.returns
+
+        for elt in self.body:
+            yield elt
 
 
 class AsyncFunctionDef(FunctionDef):
@@ -2648,6 +2689,16 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         :rtype: bool
         """
         return True
+
+    def get_children(self):
+        for elt in self.body:
+            yield elt
+
+        for elt in self.bases:
+            yield elt
+
+        if self.decorators is not None:
+            yield self.decorators
 
 
 # Backwards-compatibility aliases


### PR DESCRIPTION
I recently learned how to do Python profiling with `yappi`. `pylint` has
always seemed slow to me, so I decided to see if it could be sped up.

Here is the call graph from running `pylint` against
https://github.com/PyCQA/pycodestyle/blob/master/pycodestyle.py:

![pycodestyle-master](https://user-images.githubusercontent.com/17630138/36357104-bef2d0ca-14be-11e8-94f3-2e179fc69ffd.png)

On these graphs, nodes represent function calls, and the brighter the
node, the more time spent in that function. Each node has three
numbers: 1) the total time spent in the function, including its
subcalls; 2) the total time spent in that function but not its
subcalls; and 3) the total number of times the function was called.

I was somewhat surprised to learn (although it seems obvious in
retrospect) that the `pylint` code itself is not especially slow and
that most time is being spent in `astroid` functions. Looking at that
graph, it's obvious that `nodes_of_clas` and `get_children` are
bottlenecks, and optimizing those functions could have a big impact.
(To explain the numbers a bit, `nodes_of_class` is taking up almost
60% of total CPU time, and more than a third of that time is being
spent in `get_children`.)

First, I timed three runs of `pylint` with `astroid` on master to get
a benchmark:

```
real	1m17.996s
user	0m31.987s
sys	0m45.806s

real	1m17.828s
user	0m31.704s
sys 	0m45.936s

real	1m16.928s
user	0m31.327s
sys 	0m45.416s
```

Next, I timed three runs with astroid on the commit `Add type-specific
get_children`. This commit gives each (or almost each) node class its
own `get_children` method instead of having them all use the same
generic function. This sped things up:

```
real	1m11.266s
user	0m30.778s
sys	0m40.306s

real	1m11.503s
user	0m31.215s
sys	0m40.036s

real	1m11.761s
user	0m31.376s
sys	0m40.194s
```

Here is the call graph with that change:

![pycodestyle-children](https://user-images.githubusercontent.com/17630138/36357111-d14b4608-14be-11e8-9d34-a0fd1cd4a6b8.png)

As compared with the previous graph, `nodes_by_class` takes slightly
less total CPU time, but of the time it does take, less of it is spent
in its subcalls. This is because the type-specific `get_children`
calls go much faster.

Okay, so `nodes_of_class` is now the sole bottleneck. First, I applied
the commit `Move nodes_of_class null check out of inner loop`, which,
as the name suggests, just shuffles around the null check logic in
that function. This provided a modest speedup:

```
real	1m10.510s
user	0m30.712s
sys	0m39.624s

real	1m11.590s
user	0m31.072s
sys	0m40.328s

real	1m11.274s
user	0m31.055s
sys	0m40.049s
```

According to the call graph (which I won't bother to post), this
change saved about .2% of total CPU time, which is not bad for such a
small change.

Finally, I applied a much larger change, the commit `Add type-specific
nodes_of_class`. This commit adds a few functions that are just like
`nodes_of_class` except that they apply only to specific node
searches. This eliminates the need to do expensive runtime type
checking. These replacing calls to `nodes_of_class` within `astroid`
with these new functions sped things up significantly:

```
real	0m58.005s
user	0m25.634s
sys	0m32.200s

real	0m57.874s
user	0m25.870s
sys	0m31.838s

real	0m58.177s
user	0m26.026s
sys	0m31.984s
```

Here is the call graph

![pycodestyle-nodes](https://user-images.githubusercontent.com/17630138/36357123-f391482a-14be-11e8-9266-c48b5eb17140.png)

It's a little hard to interpret, but by my count `nodes_of_class` went
from taking ~58% of total CPU time to ~48%.

Note that all of this data comes from running `pylint`, as I said
earlier, against just a single file, `pycodestyle.py`. Larger `pylint`
targets (projects with lots of subdirectories, for instance) have
different profiles, and different functions become more prominent
(`get_children` and `nodes_of_class` are slow in all circumstances,
however). I have ideas for more optimizations, which I will come back
with after these first changes are taken care of.