### PR TITLE
backport: pytest

### DIFF
--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -645,9 +645,26 @@ class PytestBrainTest(unittest.TestCase):
             self.assertIn(attr, module)
 
 
-class IOBrainTest(unittest.TestCase):
+def streams_are_fine():
+    """Check if streams are being overwritten,
+    for example, by pytest
 
-    @unittest.skipUnless(six.PY3, 'Needs Python 3 io model')
+    stream inference will not work if they are overwritten
+
+    PY3 only
+    """
+    import io
+    for stream in (sys.stdout, sys.stderr, sys.stdin):
+        if not isinstance(stream, io.IOBase):
+            return False
+    return True
+
+
+class IOBrainTest(unittest.TestCase):
+    @unittest.skipUnless(
+        six.PY3 and streams_are_fine(),
+        "Needs Python 3 io model / doesn't work with plain pytest."
+        "use pytest -s for this test to work")
     def test_sys_streams(self):
         for name in {'stdout', 'stderr', 'stdin'}:
             node = astroid.extract_node('''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+[tool:pytest]
+python_files = unittest_* test_*.py
+testpaths = astroid/tests

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,11 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
 
 commands =
-    python -Wi -m coverage run -m unittest {posargs: discover -s astroid/tests -p "unittest*.py"}
+    ; --pyargs is needed so the directory astroid doesn't shadow the tox
+    ; installed astroid package
+    ; This is important for tests' test data which create files
+    ; inside the package
+    python -Wi {envsitepackagesdir}/coverage run -m pytest --pyargs astroid {posargs:}
     ; Transform absolute path to relative path
     ; for compatibility with coveralls.io and fix 'source not available' error.
     ; If you can find a cleaner way is welcome


### PR DESCRIPTION
There was some trouble getting this to work. I needed to use
--pyargs for pytest to work in tox

Allow for test file prefix unittest_ to be changed to standard test_
Helps with updating the astroid tests to standard pytest conventions

Make pytest use proper test directory by default
