### PR TITLE
backport: Fix augassign recursion error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@ Change log for the astroid package (used to be astng)
    * Enhancement of brain_numpy by adding different types from
      numpy.core.numerictypes
 
+   * Fix RecursionError for augmented assign
+
+     Close #437, #447, #313, PyCQA/pylint#1642, PyCQA/pylint#1805, PyCQA/pylint#1854, PyCQA/pylint#1452
+
 2018-01-23 -- 1.6.1
 
    * Fix a crash when __annotations__ access a parent's __init__ that does not have arguments

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -713,12 +713,7 @@ def _infer_augassign(self, context=None):
             yield util.Uninferable
             return
 
-        # TODO(cpopa): if we have A() * A(), trying to infer
-        # the rhs with the same context will result in an
-        # inference error, so we create another context for it.
-        # This is a bug which should be fixed in InferenceContext at some point.
         rhs_context = context.clone()
-        rhs_context.path = set()
         for rhs in self.value.infer(context=rhs_context):
             if rhs is util.Uninferable:
                 # Don't know how to process this.

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4286,5 +4286,24 @@ class ObjectDunderNewTest(unittest.TestCase):
         self.assertIsInstance(inferred, Instance)
 
 
+def test_augassign_recursion():
+    """Make sure inference doesn't throw a RecursionError
+
+    Regression test for augmented assign dropping context.path
+    causing recursion errors
+
+    """
+    # infinitely recurses in python
+    code = """
+    def rec():
+        a = 0
+        a += rec()
+        return a
+    rec()
+    """
+    cls_node = extract_node(code)
+    assert next(cls_node.infer()) is util.Uninferable
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The augmented assign rhs context path was deleted most likely
due to a recently fixed inference bug where InferenceContext path
attributes were shared between objects.

Recursive functions on the right hand side of the augmented assign would
forget that they were already called, causing an eventual RecursionError
in astroid inference

Now that the InferenceContext clone() method properly copies the
inference path between Contexts, it's fine to remove this hack.

Fixes #437, Fixes #447, Fixes #313, Fixes PyCQA/pylint#1642, Fixes PyCQA/pylint#1805, Fixes PyCQA/pylint#1854, Fixes PyCQA/pylint#1452
