### PR TITLE
Add attrs special attribute to prevent false positve in pylint

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,10 @@ Change log for the astroid package (used to be astng)
 
      Close #437, #447, #313, PyCQA/pylint#1642, PyCQA/pylint#1805, PyCQA/pylint#1854, PyCQA/pylint#1452
 
+   * Add missing attrs special attribute
+
+	Close PyCQA/pylint#1884
+
 
 2017-12-15 -- 1.6.0
 

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -32,6 +32,10 @@ def attr_attributes_transform(node):
     """Given that the ClassNode has an attr decorator,
     rewrite class attributes as instance attributes
     """
+    # Astroid can't infer this attribute properly
+    # Prevents https://github.com/PyCQA/pylint/issues/1884
+    node.locals["__attrs_attrs__"] = [astroid.Unknown(parent=node.body)]
+
     for cdefbodynode in node.body:
         if not isinstance(cdefbodynode, astroid.Assign):
             continue

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -888,6 +888,22 @@ class AttrsTest(unittest.TestCase):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr('d')[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
+    def test_special_attributes(self):
+        """Make sure special attrs attributes exist"""
+
+        code = """
+        import attr
+
+        @attr.s
+        class Foo:
+            pass
+        Foo()
+        """
+        foo_inst = next(astroid.extract_node(code).infer())
+        [attr_node] = foo_inst.getattr("__attrs_attrs__")
+        # Prevents https://github.com/PyCQA/pylint/issues/1884
+        assert isinstance(attr_node, nodes.Unknown)
+
 
 class RandomSampleTest(unittest.TestCase):
 


### PR DESCRIPTION
Astroid cannot infer this attribute because of the way
attr builds its classes

Close PyCQA/pylint#1884