### PR TITLE
Fix contextmanager transform for nested contextmanagers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -56,6 +56,11 @@ Change log for the astroid package (used to be astng)
 
      Close PyCQA/pylint#1843
 
+    * Fix ``contextlib.contextmanager`` inference for nested
+        context managers
+
+        Close #1699
+
 
 2017-12-15 -- 1.6.0
 

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -443,7 +443,10 @@ def _infer_context_manager(self, mgr, context):
         # Get the first yield point. If it has multiple yields,
         # then a RuntimeError will be raised.
         # TODO(cpopa): Handle flows.
-        yield_point = next(func.nodes_of_class(nodes.Yield), None)
+        possible_yield_points = func.nodes_of_class(nodes.Yield)
+        # Ignore yields in nested functions
+        yield_point = next((node for node in possible_yield_points
+                            if node.scope() == func), None)
         if yield_point:
             if not yield_point.value:
                 # TODO(cpopa): an empty yield. Should be wrapped to Const.


### PR DESCRIPTION
Close PyCQA/pylint#1746

The contextmanager transform was incorrectly using the 'first' yield instead of the yield in the current scope.