### PR TITLE
Add brain inference support for the `issubclass` builtin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ Change log for the astroid package (used to be astng)
 
      Part of PyCQA/pylint#811
 
+   * Add brain tip for `issubclass` builtin
+
+     Close #101.
+
    * Fix submodule imports from six
 
    Close PYCQA/pylint#1640

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -116,6 +116,41 @@ def object_isinstance(node, class_or_seq, context=None):
     return False
 
 
+def object_issubclass(node, class_or_seq, context=None):
+    """Check if a type is a subclass of any node in class_or_seq
+
+    :param node: A given node
+    :param class_or_seq: Union[Nodes.NodeNG], Sequence[nodes.NodeNG]]
+    :rtype: bool
+
+    :raises AstroidTypeError: if the given ``classes_or_seq`` are not types
+    :raises AstroidError: if the type of the given node cannot be inferred
+        or its type's mro doesn't work
+    """
+    if not isinstance(class_or_seq, (tuple, list)):
+        class_seq = (class_or_seq,)
+    else:
+        class_seq = class_or_seq
+
+    if not isinstance(node, nodes.ClassDef):
+        raise TypeError("{node} needs to be a ClassDef node".format(node=node))
+
+    # Instances are not types
+    class_seq = [item if not isinstance(item, bases.Instance)
+                 else util.Uninferable for item in class_seq]
+    # strict compatibility with issubclass
+    # issubclass(int, (int, 1)) evaluates to true
+    # issubclass(int, (1, int)) raises TypeError
+    for klass in class_seq:
+        if klass is util.Uninferable:
+            raise exceptions.AstroidTypeError(
+                "issubclass() arg 2 must be a type or tuple of types")
+        for obj_subclass in node.mro():
+            if obj_subclass == klass:
+                return True
+    return False
+
+
 def safe_infer(node, context=None):
     """Return the inferred value for the given node.
 

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -96,8 +96,8 @@ def _object_type_is_subclass(obj_type, class_or_seq, context=None):
     class_seq = [item if not isinstance(item, bases.Instance)
                  else util.Uninferable for item in class_seq]
     # strict compatibility with issubclass
-    # issubclass(1, (int, 1)) evaluates to true
-    # issubclass(1, (1, int)) raises TypeError
+    # issubclass(type, (object, 1)) evaluates to true
+    # issubclass(object, (1, type)) raises TypeError
     for klass in class_seq:
         if klass is util.Uninferable:
             raise exceptions.AstroidTypeError("arg 2 must be a type or tuple of types")
@@ -112,7 +112,7 @@ def object_isinstance(node, class_or_seq, context=None):
     """Check if a node 'isinstance' any node in class_or_seq
 
     :param node: A given node
-    :param class_or_seq: Union[Nodes.NodeNG], Sequence[nodes.NodeNG]]
+    :param class_or_seq: Union[nodes.NodeNG, Sequence[nodes.NodeNG]]
     :rtype: bool
 
     :raises AstroidTypeError: if the given ``classes_or_seq`` are not types
@@ -127,7 +127,7 @@ def object_issubclass(node, class_or_seq, context=None):
     """Check if a type is a subclass of any node in class_or_seq
 
     :param node: A given node
-    :param class_or_seq: Union[Nodes.NodeNG], Sequence[nodes.NodeNG]]
+    :param class_or_seq: Union[Nodes.NodeNG, Sequence[nodes.NodeNG]]
     :rtype: bool
 
     :raises AstroidTypeError: if the given ``classes_or_seq`` are not types


### PR DESCRIPTION
This is in a similar vein with the `isinstance` builtin, but with minor changes.

Close #101

