### PR TITLE
Fix len builtin for instances of str or bytes

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -240,7 +240,8 @@ def object_len(node, context=None):
     inferred_node = safe_infer(node, context=context)
     if inferred_node is None or inferred_node is util.Uninferable:
         raise exceptions.InferenceError(node=node)
-    if inferred_node.qname() in ('builtins.str', 'builtins.bytes'):
+    if (isinstance(inferred_node, nodes.Const) and
+            isinstance(inferred_node.value, (bytes, str))):
         return len(inferred_node.value)
     if isinstance(inferred_node, (nodes.List, nodes.Set, nodes.Tuple, FrozenSet)):
         return len(inferred_node.elts)

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1230,6 +1230,17 @@ class TestLenBuiltinInference:
         """)
         assert next(node.infer()).as_string() == '5'
 
+    def test_len_builtin_inference_attribute_error_str(self):
+        """Make sure len builtin doesn't raise an AttributeError
+        on instances of str or bytes
+
+        See https://github.com/PyCQA/pylint/issues/1942
+        """
+        code = 'len(str("F"))'
+        try:
+            next(astroid.extract_node(code).infer())
+        except astroid.InferenceError:
+            pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A ClassDef of str or bytes may have the same qname as a Const value of str or bytes
causing an AttributeError in len builtin inference

Close PyCQA/pylint#1942