### PR TITLE
Backport "Fix submodule import in six.moves"  to 1.6 release branch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 Change log for the astroid package (used to be astng)
 =====================================================
 
+   * Fix submodule imports from six
+
+     Close PYCQA/pylint#1640
+
    * Enhancement of brain_numpy by adding different types from
      numpy.core.numerictypes
 

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -373,6 +373,20 @@ class SixBrainTest(unittest.TestCase):
             qname = 'httplib.HTTPSConnection'
         self.assertEqual(inferred.qname(), qname)
 
+    @unittest.skipIf(six.PY2,
+                     "The python 2 six brain uses dummy classes")
+    def test_from_submodule_imports(self):
+        """Make sure ulrlib submodules can be imported from
+
+        See PyCQA/pylint#1640 for relevant issue
+        """
+        ast_node = builder.extract_node('''
+        from six.moves.urllib.parse import urlparse
+        urlparse #@
+        ''')
+        inferred = next(ast_node.infer())
+        self.assertIsInstance(inferred, nodes.FunctionDef)
+
 
 @unittest.skipUnless(HAS_MULTIPROCESSING,
                      'multiprocesing is required for this test, but '


### PR DESCRIPTION
(cherry-pick cf5648658c87b6e3b2fa4394b5921792827246dc)