### PR TITLE
Making Pylint faster 2

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -654,11 +654,7 @@ class NodeNG(object):
         yield from ()
 
     def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.get_children():
-            if child_node.is_lambda:
-                continue
-            for matching in child_node._get_yield_nodes_skip_lambdas():
-                yield matching
+        yield from ()
 
     def _infer_name(self, frame, name):
         # overridden for ImportFrom, Import, Global, TryExcept and Arguments
@@ -2708,6 +2704,10 @@ class Expr(Statement):
     def get_children(self):
         yield self.value
 
+    def _get_yield_nodes_skip_lambdas(self):
+        if not self.value.is_lambda:
+            yield from self.value._get_yield_nodes_skip_lambdas()
+
 
 class Ellipsis(NodeNG): # pylint: disable=redefined-builtin
     """Class representing an :class:`ast.Ellipsis` node.
@@ -2833,6 +2833,12 @@ class ExceptHandler(mixins.AssignTypeMixin, Statement):
             if child_node.is_function:
                 continue
             yield from child_node._get_return_nodes_skip_functions()
+
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class Exec(Statement):
@@ -2994,6 +3000,17 @@ class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
             if child_node.is_function:
                 continue
             yield from child_node._get_return_nodes_skip_functions()
+
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
+        for child_node in self.orelse:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class AsyncFor(For):
@@ -3285,6 +3302,17 @@ class If(mixins.BlockRangeMixIn, Statement):
             if child_node.is_function:
                 continue
             yield from child_node._get_return_nodes_skip_functions()
+
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
+        for child_node in self.orelse:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class IfExp(NodeNG):
@@ -4017,6 +4045,17 @@ class TryExcept(mixins.BlockRangeMixIn, Statement):
             for matching in child_node._get_return_nodes_skip_functions():
                 yield matching
 
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
+        for child_node in self.orelse:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
 
 class TryFinally(mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.TryFinally` node.
@@ -4095,6 +4134,17 @@ class TryFinally(mixins.BlockRangeMixIn, Statement):
                 continue
             for matching in child_node._get_return_nodes_skip_functions():
                 yield matching
+
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
+        for child_node in self.finalbody:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class Tuple(_BaseContainer):
@@ -4306,6 +4356,17 @@ class While(mixins.BlockRangeMixIn, Statement):
             for matching in child_node._get_return_nodes_skip_functions():
                 yield matching
 
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
+        for child_node in self.orelse:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
 
 class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.With` node.
@@ -4373,6 +4434,12 @@ class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
                 continue
             yield from child_node._get_return_nodes_skip_functions()
 
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
 
 class AsyncWith(With):
     """Asynchronous ``with`` built with the ``async`` keyword."""
@@ -4406,12 +4473,6 @@ class Yield(NodeNG):
 
     def _get_yield_nodes_skip_lambdas(self):
         yield self
-
-        for child_node in self.get_children():
-            if child_node.is_function_or_lambda:
-                continue
-            for matching in child_node._get_yield_nodes_skip_lambdas():
-                yield matching
 
 
 class YieldFrom(Yield):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -2741,7 +2741,8 @@ class EmptyNode(NodeNG):
         yield from ()
 
 
-class ExceptHandler(mixins.AssignTypeMixin, Statement):
+class ExceptHandler(mixins.MultiLineBlockMixin,
+                    mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.ExceptHandler`. node.
 
     An :class:`ExceptHandler` is an ``except`` block on a try-except.
@@ -2758,6 +2759,7 @@ class ExceptHandler(mixins.AssignTypeMixin, Statement):
     [<ExceptHandler l.4 at 0x7f23b2e9e860>]
     """
     _astroid_fields = ('type', 'name', 'body',)
+    _multi_line_block_fields = ('body',)
     type = None
     """The types that the block handles.
 
@@ -2827,18 +2829,6 @@ class ExceptHandler(mixins.AssignTypeMixin, Statement):
             if node.name in exceptions:
                 return True
         return False
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class Exec(Statement):
@@ -2910,7 +2900,8 @@ class ExtSlice(NodeNG):
         self.dims = dims
 
 
-class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
+class For(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn,
+          mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.For` node.
 
     >>> node = astroid.extract_node('for thing in things: print(thing)')
@@ -2918,6 +2909,7 @@ class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     <For l.1 at 0x7f23b2e8cf28>
     """
     _astroid_fields = ('target', 'iter', 'body', 'orelse',)
+    _multi_line_block_fields = ('body', 'orelse')
     target = None
     """What the loop assigns to.
 
@@ -2982,35 +2974,6 @@ class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
 
         yield from self.body
         yield from self.orelse
-
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
-
-        for child_node in self.orelse:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-        for child_node in self.orelse:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-        for child_node in self.orelse:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class AsyncFor(For):
@@ -3214,7 +3177,7 @@ class Global(Statement):
         yield from ()
 
 
-class If(mixins.BlockRangeMixIn, Statement):
+class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.If` node.
 
     >>> node = astroid.extract_node('if condition: print(True)')
@@ -3222,6 +3185,7 @@ class If(mixins.BlockRangeMixIn, Statement):
     <If l.1 at 0x7f23b2e9dd30>
     """
     _astroid_fields = ('test', 'body', 'orelse')
+    _multi_line_block_fields = ('body', 'orelse')
     test = None
     """The condition that the statement tests.
 
@@ -3284,35 +3248,6 @@ class If(mixins.BlockRangeMixIn, Statement):
 
         yield from self.body
         yield from self.orelse
-
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
-
-        for child_node in self.orelse:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-        for child_node in self.orelse:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-        for child_node in self.orelse:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class IfExp(NodeNG):
@@ -3952,7 +3887,7 @@ class Subscript(NodeNG):
         yield self.slice
 
 
-class TryExcept(mixins.BlockRangeMixIn, Statement):
+class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.TryExcept` node.
 
     >>> node = astroid.extract_node('''
@@ -3965,6 +3900,7 @@ class TryExcept(mixins.BlockRangeMixIn, Statement):
     <TryExcept l.2 at 0x7f23b2e9d908>
     """
     _astroid_fields = ('body', 'handlers', 'orelse',)
+    _multi_line_block_fields = ('body', 'orelse')
     body = None
     """The contents of the block to catch exceptions from.
 
@@ -4026,38 +3962,9 @@ class TryExcept(mixins.BlockRangeMixIn, Statement):
         yield from self.handlers or ()
         yield from self.orelse or ()
 
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
 
-        for child_node in self.orelse:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-        for child_node in self.orelse or ():
-            if child_node.is_function:
-                continue
-            for matching in child_node._get_return_nodes_skip_functions():
-                yield matching
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-        for child_node in self.orelse:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-
-class TryFinally(mixins.BlockRangeMixIn, Statement):
+class TryFinally(mixins.MultiLineBlockMixin,
+                 mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.TryFinally` node.
 
     >>> node = astroid.extract_node('''
@@ -4072,6 +3979,7 @@ class TryFinally(mixins.BlockRangeMixIn, Statement):
     <TryFinally l.2 at 0x7f23b2e41d68>
     """
     _astroid_fields = ('body', 'finalbody',)
+    _multi_line_block_fields = ('body', 'finalbody')
     body = None
     """The try-except that the finally is attached to.
 
@@ -4115,36 +4023,6 @@ class TryFinally(mixins.BlockRangeMixIn, Statement):
     def get_children(self):
         yield from self.body
         yield from self.finalbody
-
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
-
-        for child_node in self.finalbody:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-        for child_node in self.finalbody:
-            if child_node.is_function:
-                continue
-            for matching in child_node._get_return_nodes_skip_functions():
-                yield matching
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-        for child_node in self.finalbody:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class Tuple(_BaseContainer):
@@ -4268,7 +4146,7 @@ class UnaryOp(NodeNG):
         yield self.operand
 
 
-class While(mixins.BlockRangeMixIn, Statement):
+class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.While` node.
 
     >>> node = astroid.extract_node('''
@@ -4279,6 +4157,7 @@ class While(mixins.BlockRangeMixIn, Statement):
     <While l.2 at 0x7f23b2e4e390>
     """
     _astroid_fields = ('test', 'body', 'orelse',)
+    _multi_line_block_fields = ('body', 'orelse')
     test = None
     """The condition that the loop tests.
 
@@ -4337,38 +4216,9 @@ class While(mixins.BlockRangeMixIn, Statement):
         yield from self.body
         yield from self.orelse
 
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
 
-        for child_node in self.orelse:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-        for child_node in self.orelse:
-            if child_node.is_function:
-                continue
-            for matching in child_node._get_return_nodes_skip_functions():
-                yield matching
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-        for child_node in self.orelse:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
-
-
-class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
+class With(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn,
+           mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.With` node.
 
     >>> node = astroid.extract_node('''
@@ -4379,6 +4229,7 @@ class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     <With l.2 at 0x7f23b2e4e710>
     """
     _astroid_fields = ('items', 'body')
+    _multi_line_block_fields = ('body',)
     items = None
     """The pairs of context managers and the names they are assigned to.
 
@@ -4423,22 +4274,6 @@ class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
                 yield var
         for elt in self.body:
             yield elt
-
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class AsyncWith(With):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -643,9 +643,7 @@ class NodeNG(object):
                 yield matching
 
     def _get_assign_nodes(self):
-        for child_node in self.get_children():
-            for matching in child_node._get_assign_nodes():
-                yield matching
+        yield from ()
 
     def _get_name_nodes(self):
         for child_node in self.get_children():
@@ -1737,9 +1735,7 @@ class Assign(mixins.AssignTypeMixin, Statement):
     def _get_assign_nodes(self):
         yield self
 
-        for child_node in self.get_children():
-            for matching in child_node._get_assign_nodes():
-                yield matching
+        yield from self.value._get_assign_nodes()
 
 
 class AnnAssign(mixins.AssignTypeMixin, Statement):
@@ -2979,6 +2975,13 @@ class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
         yield from self.body
         yield from self.orelse
 
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
+
+        for child_node in self.orelse:
+            yield from child_node._get_assign_nodes()
+
 
 class AsyncFor(For):
     """Class representing an :class:`ast.AsyncFor` node.
@@ -3251,6 +3254,13 @@ class If(mixins.BlockRangeMixIn, Statement):
 
         yield from self.body
         yield from self.orelse
+
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
+
+        for child_node in self.orelse:
+            yield from child_node._get_assign_nodes()
 
 
 class IfExp(NodeNG):
@@ -3970,6 +3980,13 @@ class TryExcept(mixins.BlockRangeMixIn, Statement):
         yield from self.handlers or ()
         yield from self.orelse or ()
 
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
+
+        for child_node in self.orelse:
+            yield from child_node._get_assign_nodes()
+
 
 class TryFinally(mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.TryFinally` node.
@@ -4029,6 +4046,13 @@ class TryFinally(mixins.BlockRangeMixIn, Statement):
     def get_children(self):
         yield from self.body
         yield from self.finalbody
+
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
+
+        for child_node in self.finalbody:
+            yield from child_node._get_assign_nodes()
 
 
 class Tuple(_BaseContainer):
@@ -4221,6 +4245,13 @@ class While(mixins.BlockRangeMixIn, Statement):
         yield from self.body
         yield from self.orelse
 
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
+
+        for child_node in self.orelse:
+            yield from child_node._get_assign_nodes()
+
 
 class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.With` node.
@@ -4277,6 +4308,10 @@ class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
                 yield var
         for elt in self.body:
             yield elt
+
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
 
 
 class AsyncWith(With):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -651,11 +651,7 @@ class NodeNG(object):
                 yield matching
 
     def _get_return_nodes_skip_functions(self):
-        for child_node in self.get_children():
-            if child_node.is_function:
-                continue
-            for matching in child_node._get_return_nodes_skip_functions():
-                yield matching
+        yield from ()
 
     def _get_yield_nodes_skip_lambdas(self):
         for child_node in self.get_children():
@@ -2832,6 +2828,12 @@ class ExceptHandler(mixins.AssignTypeMixin, Statement):
                 return True
         return False
 
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
 
 class Exec(Statement):
     """Class representing the ``exec`` statement.
@@ -2981,6 +2983,17 @@ class For(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
 
         for child_node in self.orelse:
             yield from child_node._get_assign_nodes()
+
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
+        for child_node in self.orelse:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
 
 
 class AsyncFor(For):
@@ -3261,6 +3274,17 @@ class If(mixins.BlockRangeMixIn, Statement):
 
         for child_node in self.orelse:
             yield from child_node._get_assign_nodes()
+
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
+        for child_node in self.orelse:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
 
 
 class IfExp(NodeNG):
@@ -3673,12 +3697,6 @@ class Return(Statement):
     def _get_return_nodes_skip_functions(self):
         yield self
 
-        for child_node in self.get_children():
-            if child_node.is_function:
-                continue
-            for matching in child_node._get_return_nodes_skip_functions():
-                yield matching
-
 
 class Set(_BaseContainer):
     """Class representing an :class:`ast.Set` node.
@@ -3987,6 +4005,18 @@ class TryExcept(mixins.BlockRangeMixIn, Statement):
         for child_node in self.orelse:
             yield from child_node._get_assign_nodes()
 
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
+        for child_node in self.orelse or ():
+            if child_node.is_function:
+                continue
+            for matching in child_node._get_return_nodes_skip_functions():
+                yield matching
+
 
 class TryFinally(mixins.BlockRangeMixIn, Statement):
     """Class representing an :class:`ast.TryFinally` node.
@@ -4053,6 +4083,18 @@ class TryFinally(mixins.BlockRangeMixIn, Statement):
 
         for child_node in self.finalbody:
             yield from child_node._get_assign_nodes()
+
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
+        for child_node in self.finalbody:
+            if child_node.is_function:
+                continue
+            for matching in child_node._get_return_nodes_skip_functions():
+                yield matching
 
 
 class Tuple(_BaseContainer):
@@ -4252,6 +4294,18 @@ class While(mixins.BlockRangeMixIn, Statement):
         for child_node in self.orelse:
             yield from child_node._get_assign_nodes()
 
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
+        for child_node in self.orelse:
+            if child_node.is_function:
+                continue
+            for matching in child_node._get_return_nodes_skip_functions():
+                yield matching
+
 
 class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.With` node.
@@ -4312,6 +4366,12 @@ class With(mixins.BlockRangeMixIn, mixins.AssignTypeMixin, Statement):
     def _get_assign_nodes(self):
         for child_node in self.body:
             yield from child_node._get_assign_nodes()
+
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
 
 
 class AsyncWith(With):

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1205,7 +1205,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         yield self.body
 
 
-class FunctionDef(node_classes.Statement, Lambda):
+class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
     """Class representing an :class:`ast.FunctionDef`.
 
     >>> node = astroid.extract_node('''
@@ -1216,6 +1216,7 @@ class FunctionDef(node_classes.Statement, Lambda):
     <FunctionDef.my_func l.2 at 0x7f23b2e71e10>
     """
     _astroid_fields = ('decorators', 'args', 'returns', 'body')
+    _multi_line_block_fields = ('body',)
     returns = None
     decorators = None
     """The decorators that are applied to this method or function.
@@ -1593,22 +1594,6 @@ class FunctionDef(node_classes.Statement, Lambda):
 
         for elt in self.body:
             yield elt
-
-    def _get_assign_nodes(self):
-        for child_node in self.body:
-            yield from child_node._get_assign_nodes()
-
-    def _get_return_nodes_skip_functions(self):
-        for child_node in self.body:
-            if child_node.is_function:
-                continue
-            yield from child_node._get_return_nodes_skip_functions()
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 class AsyncFunctionDef(FunctionDef):
@@ -2719,12 +2704,6 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
     def _get_assign_nodes(self):
         for child_node in self.body:
             yield from child_node._get_assign_nodes()
-
-    def _get_yield_nodes_skip_lambdas(self):
-        for child_node in self.body:
-            if child_node.is_lambda:
-                continue
-            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 # Backwards-compatibility aliases

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1594,6 +1594,10 @@ class FunctionDef(node_classes.Statement, Lambda):
         for elt in self.body:
             yield elt
 
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
+
 
 class AsyncFunctionDef(FunctionDef):
     """Class representing an :class:`ast.FunctionDef` node.
@@ -1710,7 +1714,6 @@ def get_wrapping_class(node):
         else:
             klass = klass.parent.frame()
     return klass
-
 
 
 class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
@@ -2700,6 +2703,10 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
 
         if self.decorators is not None:
             yield self.decorators
+
+    def _get_assign_nodes(self):
+        for child_node in self.body:
+            yield from child_node._get_assign_nodes()
 
 
 # Backwards-compatibility aliases

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1604,6 +1604,12 @@ class FunctionDef(node_classes.Statement, Lambda):
                 continue
             yield from child_node._get_return_nodes_skip_functions()
 
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
+
 
 class AsyncFunctionDef(FunctionDef):
     """Class representing an :class:`ast.FunctionDef` node.
@@ -2713,6 +2719,12 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
     def _get_assign_nodes(self):
         for child_node in self.body:
             yield from child_node._get_assign_nodes()
+
+    def _get_yield_nodes_skip_lambdas(self):
+        for child_node in self.body:
+            if child_node.is_lambda:
+                continue
+            yield from child_node._get_yield_nodes_skip_lambdas()
 
 
 # Backwards-compatibility aliases

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1598,6 +1598,12 @@ class FunctionDef(node_classes.Statement, Lambda):
         for child_node in self.body:
             yield from child_node._get_assign_nodes()
 
+    def _get_return_nodes_skip_functions(self):
+        for child_node in self.body:
+            if child_node.is_function:
+                continue
+            yield from child_node._get_return_nodes_skip_functions()
+
 
 class AsyncFunctionDef(FunctionDef):
     """Class representing an :class:`ast.FunctionDef` node.


### PR DESCRIPTION
My [last PR](https://github.com/PyCQA/astroid/pull/497) contained what I would describe as compiler-style
optimizations, mainly loop unrolling and getting rid of runtime type
checking and dynamic attribute handling. I applied those changes more
or less mechanically, without really understanding the purpose of all
the functions involved.

In spite of those improvements, the [last yappi graph](https://user-images.githubusercontent.com/17630138/36357123-f391482a-14be-11e8-9266-c48b5eb17140.png) still showed
major hotspots in `_get_return_nodes_skip_functions` and
`_get_yield_nodes_skip_lambdas` (and also, to a lesser extent, in
`_get_assign_nodes`). Thinking about how those functions were being
used, I realized that a lot of unnecessary work was still being done.
Consider `return` statements, for instance. Most node types (e.g.
function calls, assign statements, comprehensions) cannot legally
contain them, so if we're searching for `return` statements, we can
pass those nodes by immediately. The only nodes that can contain
`return` statements are nodes with multi-line bodies, like `If` and
`FunctionDef`, and thus they are the only ones that need to implement
`_get_return_nodes_skip_functions`. Similar reasoning holds for the
other changes here. (I'm sure there is plenty of cleverness to be applied
further.)

To test these changes, I ran `pylint` (with `pylint`'s `pylintrc`
file) against `pycodestyle.py`, as before, as well as against `pylint`
itself. These cases differ in two import ways: 1) `pylint` is a
multi-file project with nested directories, while `pycodestyle.py` is
just a single file, and 2) `pylint` is written to pass `pylint`
without any errors, while `pycodestyle.py` raises lots of `pylint`
errors.

Despite their differences, `pylint` ran about twenty seconds faster in
both cases:

# pycodestyle.py

## Before

    real	0m55.362s
    user	0m24.856s
    sys	0m30.283s
    
    real	0m54.343s
    user	0m24.282s
    sys	0m29.905s
    
    real	0m54.996s
    user	0m24.679s
    sys	0m30.169s

## After

    real	0m34.826s
    user	0m16.159s
    sys	0m18.539s
    
    real	0m35.294s
    user	0m16.434s
    sys	0m18.723s
    
    real	0m35.089s
    user	0m16.328s
    sys	0m18.658s

# pylint

## Before

    real	3m34.382s
    user	1m38.719s
    sys	1m55.555s
    
    real	3m34.185s
    user	1m38.867s
    sys	1m55.192s
    
    real	3m34.986s
    user	1m38.878s
    sys	1m55.964s

## After

    real	3m13.449s
    user	1m29.708s
    sys	1m43.619s
    
    real	3m13.627s
    user	1m29.739s
    sys	1m43.785s
    
    real	3m13.680s
    user	1m29.919s
    sys	1m43.661s

Now, as these optimizations become increasingly specialized, there
comes a risk that the code will become increasingly inelegant.
Certainly some elegance has already been sacrificed by replacing
`nodes_of_class` with type-specific variations. But I think that
`pylint`'s slowness is a major usability issue, especially for large
projects, and therefore the tradeoff is definitely worth it.