### PR TITLE
Update Unknown Node

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4421,6 +4421,10 @@ class Unknown(mixins.AssignTypeMixin, NodeNG):
     introspection failed.
     """
     name = "Unknown"
+
+    def qname(self):
+        return "Unknown"
+
     def infer(self, context=None, **kwargs):
         """Inference on an Unknown node immediately terminates."""
         yield util.Uninferable

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4420,6 +4420,7 @@ class Unknown(mixins.AssignTypeMixin, NodeNG):
     the args attribute of FunctionDef nodes where function signature
     introspection failed.
     """
+    name = "Unknown"
     def infer(self, context=None, **kwargs):
         """Inference on an Unknown node immediately terminates."""
         yield util.Uninferable

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -863,6 +863,7 @@ def test_unknown():
     assert isinstance(next(nodes.Unknown().infer()),
                       type(util.Uninferable))
     assert isinstance(nodes.Unknown().name, str)
+    assert isinstance(nodes.Unknown().qname(), str)
 
 
 if __name__ == '__main__':

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -858,5 +858,12 @@ class ContextTest(unittest.TestCase):
         self.assertIs(starred.ctx, astroid.Store)
 
 
+def test_unknown():
+    """Test Unknown node"""
+    assert isinstance(next(nodes.Unknown().infer()),
+                      type(util.Uninferable))
+    assert isinstance(nodes.Unknown().name, str)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 - Add name attribute to Unknown class
 This allows .root().name calls to work for Unknown objects
 - add qname to Unknown node to avoid error in pylint
