### PR TITLE
Remove some no-member pylint comments due to useless supression

### DIFF
--- a/astroid/tests/unittest_manager.py
+++ b/astroid/tests/unittest_manager.py
@@ -141,12 +141,12 @@ class AstroidManagerTest(resources.SysPathSetup,
     def test_nested_namespace_import(self):
         pth = 'foogle_fax-0.12.5-py2.7-nspkg.pth'
         site.addpackage(resources.RESOURCE_PATH, pth, [])
-        pkg_resources._namespace_packages['foogle'] = ['foogle.crank'] # pylint: disable=no-member
-        pkg_resources._namespace_packages['foogle.crank'] = [] # pylint: disable=no-member
+        pkg_resources._namespace_packages['foogle'] = ['foogle.crank']
+        pkg_resources._namespace_packages['foogle.crank'] = []
         try:
             self.manager.ast_from_module_name('foogle.crank')
         finally:
-            del pkg_resources._namespace_packages['foogle'] # pylint: disable=no-member
+            del pkg_resources._namespace_packages['foogle']
             sys.modules.pop('foogle')
 
     def test_namespace_and_file_mismatch(self):


### PR DESCRIPTION
Probably the result of 3192f78654355df102d5eee0655a6b1fe869ec75