### PR TITLE
Further use of context_lookup to fix nested calls

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -139,14 +139,14 @@ def object_issubclass(node, class_or_seq, context=None):
     return _object_type_is_subclass(node, class_or_seq, context=context)
 
 
-def safe_infer(node, context=None):
+def safe_infer(node, context=None, context_lookup=None):
     """Return the inferred value for the given node.
 
     Return None if inference failed or if there is some ambiguity (more than
     one node has been inferred).
     """
     try:
-        inferit = node.infer(context=context)
+        inferit = node.infer(context=context, context_lookup=context_lookup)
         value = next(inferit)
     except exceptions.InferenceError:
         return None

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -35,7 +35,7 @@ class FrozenSet(node_classes._BaseContainer):
     def pytype(self):
         return '%s.frozenset' % BUILTINS
 
-    def _infer(self, context=None):
+    def _infer(self, context=None, context_lookup=None):
         yield self
 
     @decorators.cachedproperty
@@ -67,7 +67,7 @@ class Super(node_classes.NodeNG):
         self._self_class = self_class
         self._scope = scope
 
-    def _infer(self, context=None):
+    def _infer(self, context=None, context_lookup=None):
         yield self
 
     def super_mro(self):

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1571,7 +1571,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                 yield node_classes.Const(None)
             else:
                 try:
-                    for inferred in returnnode.value.infer(context):
+                    for inferred in returnnode.value.infer(context, context_lookup=context_lookup):
                         yield inferred
                 except exceptions.InferenceError:
                     yield util.Uninferable

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4447,5 +4447,40 @@ def test_augassign_recursion():
     assert next(cls_node.infer()) is util.Uninferable
 
 
+class TestInferencePropagation:
+    """Make sure function argument values are properly
+    propagated to sub functions"""
+    def test_call_context_propagation(self):
+        n = extract_node("""
+        def chest(a):
+            return a * a
+        def best(a, b):
+            return chest(a)
+        def test(a, b, c):
+            return best(a, b)
+        test(4, 5, 6) #@
+        """)
+        assert next(n.infer()).as_string() == "16"
+
+    def test_call_starargs_propagation(self):
+        code = """
+        def foo(*args):
+            return args
+        def bar(*args):
+            return foo(*args)
+        bar(4, 5, 6, 7) #@
+        """
+        assert next(extract_node(code).infer()).as_string() == "(4, 5, 6, 7)"
+
+    def test_call_kwargs_propagation(self):
+        code = """
+        def b(**kwargs):
+            return kwargs
+        def f(**kwargs):
+            return b(**kwargs)
+        f(**{'f': 1}) #@
+        """
+        assert next(extract_node(code).infer()).as_string() == "{'f': 1}"
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Deliver the correct context with the correct boundnode
for function argument nodes

Close #177
