### PR TITLE
Add qname method to Super objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ Change log for the astroid package (used to be astng)
 =====================================================
 
 --
+   * Add brain tip for attrs library to prevent unsupported-assignment-operation false positives
+
+	 Close PYCQA/pylint#1698
+
    * file_stream was removed, since it was deprecated for three releases
 
      Instead one should use the .stream() method.

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -1,0 +1,40 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
+"""
+Astroid hook for the attrs library
+
+Without this hook pylint reports unsupported-assignment-operation
+for atrrs classes
+"""
+
+import astroid
+from astroid import MANAGER
+
+
+def is_decorated_with_attrs(
+        node, decorator_names=('attr.s', 'attr.attrs', 'attr.attributes')):
+    """Return True if a decorated node has
+    an attr decorator applied."""
+    if not node.decorators:
+        return False
+    for decorator_attribute in node.decorators.nodes:
+        if decorator_attribute.as_string() in decorator_names:
+            return True
+    return False
+
+
+def attr_attributes_transform(node):
+    """Given that the ClassNode has an attr decorator,
+    rewrite class attributes as instance attributes
+    """
+    for cdefbodynode in node.body:
+        if not isinstance(cdefbodynode, astroid.Assign):
+            continue
+        for target in cdefbodynode.targets:
+            node.locals[target.name] = [astroid.Attribute(target.name)]
+
+
+MANAGER.register_transform(
+    astroid.Class,
+    attr_attributes_transform,
+    is_decorated_with_attrs)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
   lazy-object-proxy
   nose
   py27,py34,py35,py36: numpy
+  py27,py34,py35,py36: attr
   pytest
   python-dateutil
   py27,py33,pypy: singledispatch


### PR DESCRIPTION
Super objects in python have a __qualname__ attribute
so super nodes should have an equivalent qname method.

Prevents an error in upstream pylint

Close #533
