### PR TITLE
Add qname method to Super objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -75,6 +75,11 @@ Change log for the astroid package (used to be astng)
 
      Close #112
 
+   * Add qname method to Super object preventing potential errors in upstream
+     pylint
+
+     Close #533
+
 
 2017-12-15 -- 1.6.0
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -118,6 +118,9 @@ class Super(node_classes.NodeNG):
         """Get the name of the MRO pointer."""
         return self.mro_pointer.name
 
+    def qname(self):
+        return "super"
+
     def igetattr(self, name, context=None):
         """Retrieve the inferred values of the given attribute name."""
 

--- a/astroid/tests/unittest_objects.py
+++ b/astroid/tests/unittest_objects.py
@@ -502,6 +502,19 @@ class SuperTests(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 42)
 
+    def test_super_qname(self):
+        """Make sure a Super object generates a qname
+        equivalent to super.__qname__
+        """
+        # See issue 533
+        code = """
+        class C:
+           def foo(self): return super()
+        C().foo() #@
+        """
+        super_obj = next(builder.extract_node(code).infer())
+        self.assertEqual(super_obj.qname(), "super")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Super objects in python have a __qualname__ attribute
so super nodes should have an equivalent qname method.

Prevents an error in upstream pylint

Close #533