### PR TITLE
Making Pylint faster 3

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1013,7 +1013,14 @@ class LookupMixIn(object):
             globals or builtin).
         :rtype: tuple(str, list(NodeNG))
         """
-        return self.scope().scope_lookup(self, name)
+        try:
+            return self._lookup_cache[name]
+        except AttributeError:
+            self._lookup_cache = {name: self.scope().scope_lookup(self, name)}
+            return self._lookup_cache[name]
+        except KeyError:
+            self._lookup_cache[name] = self.scope().scope_lookup(self, name)
+            return self._lookup_cache[name]
 
     def ilookup(self, name):
         """Lookup the inferred values of the given variable.


### PR DESCRIPTION
This PR makes just one change, namely caching the result of the function `lookup`. The impact of this change seems to be proportional to the size of the project. Here are the results of timing before and after against [`zulip/zerver`](https://github.com/zulip/zulip/tree/master/zerver) (a large directory belonging to the Zulip chat app) and against [`pycodestyle.py`](https://github.com/PyCQA/pycodestyle/blob/master/pycodestyle.py).

### `zulip/zerver`

#### Before
```
real	3m27.529s
user	3m2.148s
sys	0m10.265s

real	3m29.610s
user	3m3.250s
sys	0m10.677s

real	3m30.208s
user	3m3.869s
sys	0m10.154s
```

#### After
```
real	2m54.406s
user	2m29.059s
sys	0m9.832s

real	2m55.215s
user	2m30.475s
sys	0m10.268s

real	2m53.733s
user	2m28.744s
sys	0m9.856s
```

### `pycodestyle.py`

#### Before
```
real	0m5.523s
user	0m5.380s
sys	0m0.109s

real	0m5.430s
user	0m5.311s
sys	0m0.095s

real	0m5.365s
user	0m5.223s
sys	0m0.092s
```

#### After
```
real	0m4.834s
user	0m4.660s
sys	0m0.119s

real	0m4.736s
user	0m4.579s
sys	0m0.104s

real	0m4.736s
user	0m4.557s
sys	0m0.110s
```

(By the way, you might look at the numbers here and notice that they are substantially less than the numbers presented in my [previous](https://github.com/PyCQA/astroid/pull/497) [PRs](https://github.com/PyCQA/astroid/pull/519). This is because those times were recorded with a profiler enabled. It seems obvious in hindsight that running a program with a profiler enabled would cause it to run slower, even substantially slower, but live and learn I guess. In any case, these are real times.)
