### PR TITLE
Tests are no longer installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include ChangeLog
-include README
+include README.rst
 include COPYING
 include COPYING.LESSER
-include tox.ini
-recursive-include astroid/tests/testdata *.py *.zip *.egg
+include pytest.ini
+recursive-include astroid/tests *.py *.zip *.egg *.pth
 recursive-include astroid/brain *.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files=*test_*.py
+addopts=-m "not acceptance"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [wheel]
 universal = 1
+
+[aliases]
+test = pytest
+
 [tool:pytest]
-python_files = unittest_* test_*.py
 testpaths = astroid/tests

--- a/setup.py
+++ b/setup.py
@@ -24,22 +24,6 @@ with open(pkginfo, 'rb') as fobj:
 with open(os.path.join(astroid_dir, 'README.rst')) as fobj:
     long_description = fobj.read()
 
-class AstroidInstallLib(install_lib.install_lib):
-    def byte_compile(self, files):
-        test_datadir = os.path.join('astroid', 'tests', 'testdata')
-        files = [f for f in files if test_datadir not in f]
-        install_lib.install_lib.byte_compile(self, files)
-
-
-class AstroidEasyInstallLib(easy_install.easy_install):
-    # override this since pip/easy_install attempt to byte compile
-    # test data files, some of them being syntactically wrong by design,
-    # and this scares the end-user
-    def byte_compile(self, files):
-        test_datadir = os.path.join('astroid', 'tests', 'testdata')
-        files = [f for f in files if test_datadir not in f]
-        easy_install.easy_install.byte_compile(self, files)
-
 
 def install():
     return setup(name = distname,
@@ -51,13 +35,13 @@ def install():
                  author = author,
                  author_email = author_email,
                  url = web,
-                 include_package_data = True,
                  python_requires='>=3.4.*',
                  install_requires = install_requires,
                  extras_require=extras_require,
-                 packages = find_packages(),
-                 cmdclass={'install_lib': AstroidInstallLib,
-                           'easy_install': AstroidEasyInstallLib}
+                 packages=find_packages(exclude=['astroid.tests']) + ['astroid.brain'],
+                 setup_requires=['pytest-runner'],
+                 test_suite='test',
+                 tests_require=['pytest'],
                  )
 
 


### PR DESCRIPTION
Tests can also be run from the source distribution with `python setup.py test`.
We should be able to move the tests directory out of the astroid source and put it at the root level of the repository. But I think it makes more sense to do this when we have less pull requests about to be merged.