### PR TITLE
Making Pylint faster 3 (2)

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -16,6 +16,7 @@ import builtins as builtins_mod
 import itertools
 import pprint
 import warnings
+from functools import lru_cache
 from functools import singledispatch as _singledispatch
 
 from astroid import as_string
@@ -996,6 +997,7 @@ class _BaseContainer(mixins.ParentAssignTypeMixin,
 class LookupMixIn(object):
     """Mixin to look up a name in the right scope."""
 
+    @lru_cache(maxsize=None)
     def lookup(self, name):
         """Lookup where the given variable is assigned.
 


### PR DESCRIPTION
(Something got messed up while pushing changes and https://github.com/PyCQA/astroid/pull/545 got closed. This is essentially the same PR.)

Here are times from using the `lru_cache`. A lot of stuff has been added to pylint since I last measured, so these times are higher than the previous ones.

#### master
```
real	4m32.310s
user	3m51.296s
sys	0m13.453s

real	4m28.269s
user	3m47.220s
sys	0m13.167s

real	4m30.490s
user	3m48.246s
sys	0m13.341s
```

#### cache lookup
```
real	3m59.156s
user	3m17.773s
sys	0m13.364s

real	3m58.147s
user	3m17.060s
sys	0m13.311s

real	3m57.503s
user	3m15.869s
sys	0m13.449s
```
