### PR TITLE
Add cPickle to the list of available imports for six.moves in Python2

### DIFF
--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -40,6 +40,7 @@ if sys.version_info[0] == 2:
     import BaseHTTPServer
     import CGIHTTPServer
     import SimpleHTTPServer
+    import cPickle
 
     from StringIO import StringIO
     from cStringIO import StringIO as cStringIO


### PR DESCRIPTION
close PyCQA/pylint#2185