### PR TITLE
Changes for running pylint without __init__ file

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -442,7 +442,7 @@ def get_module_part(dotted_name, context_file=None):
     return dotted_name
 
 
-def get_module_files(src_directory, blacklist, list_all=False):
+def get_module_files(src_directory, blacklist, lint_all=False, list_all=False):
     """given a package directory return a list of all available python
     module's files in the package and its subpackages
 
@@ -469,7 +469,7 @@ def get_module_files(src_directory, blacklist, list_all=False):
             continue
         _handle_blacklist(blacklist, dirnames, filenames)
         # check for __init__.py
-        if not list_all and '__init__.py' not in filenames:
+        if not list_all and not lint_all:
             dirnames[:] = ()
             continue
         for filename in filenames:


### PR DESCRIPTION
Related to [PR #2190](https://github.com/PyCQA/pylint/pull/2190) on pylint

I think this won't require any other changes since `get_module_files` is directly called from the `expand_module` function in `/pylint/utils.py`.

 