### PR TITLE
Stop astroid from getting stuck in an infinite loop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -130,6 +130,11 @@ Release Date: Unknown
 
      Close #533
 
+   * Stop astroid from getting stuck in an infinite loop if a function shares
+   its name with its decorator
+
+     Close #375
+
 
 
 What's New in astroid 1.6.0?

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1070,6 +1070,11 @@ class LookupMixIn(object):
             # line filtering is on and we have reached our location, break
             if mylineno > 0 and stmt.fromlineno > mylineno:
                 break
+            # Ignore decorators with the same name as the
+            # decorated function
+            # Fixes issue #375
+            if mystmt is stmt and is_from_decorator(self):
+                continue
             assert hasattr(node, 'assign_type'), (node, node.scope(),
                                                   node.scope().locals)
             assign_type = node.assign_type()
@@ -4434,3 +4439,13 @@ def const_factory(value):
         node = EmptyNode()
         node.object = value
         return node
+
+
+def is_from_decorator(node):
+    """Return True if the given node is the child of a decorator"""
+    parent = node.parent
+    while parent is not None:
+        if isinstance(parent, Decorators):
+            return True
+        parent = parent.parent
+    return False

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4544,5 +4544,27 @@ def test_unpacking_starred_empty_list_in_assignment():
     assert inferred.as_string() == '[]'
 
 
+def test_regression_infinite_loop_decorator():
+    """Make sure decorators with the same names
+    as a decorated method do not cause an infinite loop
+
+    See https://github.com/PyCQA/astroid/issues/375
+    """
+    code = """
+    from functools import lru_cache
+
+    class Foo():
+        @lru_cache()
+        def lru_cache(self, value):
+            print('Computing {}'.format(value))
+            return value
+    Foo().lru_cache(1)
+    """
+    node = extract_node(code)
+    [result] = node.inferred()
+    assert result.value == 1
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Stop issue where decorators with the same name as the decorated function would cause an infinite loop

This infinite recursion was caused by an oversight in name lookup which prefferred methods even if they weren't defined yet

Close #375
Close PyCQA/pylint#1462