### PR TITLE
Fix issue with inherited __call__ improperly inferencing self

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -141,6 +141,10 @@ Release Date: Unknown
 
      Close #375
 
+   * Fix issue with inherited __call__ improperly inferencing self
+
+     Close #PyCQA/pylint#2199
+
 
 
 What's New in astroid 1.6.0?

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -228,6 +228,11 @@ class BaseInstance(Proxy):
 
     def infer_call_result(self, caller, context=None, context_lookup=None):
         """infer what a class instance is returning when called"""
+        if context is None:
+            context = contextmod.InferenceContext()
+        else:
+            context = context.clone()
+        context.boundnode = self
         inferred = False
         for node in self._proxied.igetattr('__call__', context):
             if node is util.Uninferable or not node.callable():

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4565,6 +4565,26 @@ def test_regression_infinite_loop_decorator():
     assert result.value == 1
 
 
+def test_call_on_instance_with_inherited_dunder_call_method():
+    """Stop inherited __call__ method from incorrectly returning wrong class
+
+    See https://github.com/PyCQA/pylint/issues/2199
+    """
+    node = extract_node("""
+    class Base:
+        def __call__(self):
+            return self
+
+    class Sub(Base):
+        pass
+    obj = Sub()
+    val = obj()
+    val #@
+    """)
+    [val] = node.inferred()
+    assert isinstance(val, Instance)
+    assert val.name == "Sub"
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instance infer_call_results needed boundnode set for its context.

Close PyCQA/pylint#2199