### PR TITLE
Fix __call__ precedence for classes with custom metaclasses

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -145,6 +145,9 @@ Release Date: Unknown
 
      Close #PyCQA/pylint#2199
 
+   * Fix __call__ precedence for classes with custom metaclasses
+
+     Close PyCQA/pylint#2159
 
 
 What's New in astroid 1.6.0?


### PR DESCRIPTION
Call the dunder call method if available from a custom metaclass

Note: I had to give ClassDef metaclass lookup a context to prevent a
Recursion

Close PyCQA/pylint#2159