### PR TITLE
Nested call args2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -208,6 +208,8 @@ Release Date: 2017-12-15
 
       Close PyCQA/pylint#1530
 
+    * Fix inference for nested calls
+
     * Dunder class at method level is now inferred as the class of the method
 
       Close PyCQA/pylint#1328

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -22,7 +22,10 @@ class CallSite:
     and the argument name.
     """
 
-    def __init__(self, callcontext):
+    def __init__(self, callcontext, argument_context_map=None):
+        if argument_context_map is None:
+            argument_context_map = {}
+        self.argument_context_map = argument_context_map
         args = callcontext.args
         keywords = callcontext.keywords
         self.duplicated_keywords = set()
@@ -68,6 +71,7 @@ class CallSite:
     def _unpack_keywords(self, keywords):
         values = {}
         context = contextmod.InferenceContext()
+        context.extra_context = self.argument_context_map
         for name, value in keywords:
             if name is None:
                 # Then it's an unpacking operation (**)
@@ -104,10 +108,10 @@ class CallSite:
                 values[name] = value
         return values
 
-    @staticmethod
-    def _unpack_args(args):
+    def _unpack_args(self, args):
         values = []
         context = contextmod.InferenceContext()
+        context.extra_context = self.argument_context_map
         for arg in args:
             if isinstance(arg, nodes.Starred):
                 try:

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -376,8 +376,7 @@ class BoundMethod(UnboundMethod):
 
         In order for such call to be valid, the metaclass needs to be
         a subtype of ``type``, the name needs to be a string, the bases
-        needs to be a tuple of classes and the attributes a dictionary
-        of strings to values.
+        needs to be a tuple of classes
         """
         from astroid import node_classes
         # Verify the metaclass
@@ -419,13 +418,10 @@ class BoundMethod(UnboundMethod):
         for key, value in attrs.items:
             key = next(key.infer(context=context))
             value = next(value.infer(context=context))
-            if key.__class__.__name__ != 'Const':
-                # Something invalid as an attribute.
-                return None
-            if not isinstance(key.value, str):
-                # Not a proper attribute.
-                return None
-            cls_locals[key.value].append(value)
+            # Ignore non string keys
+            if (key.__class__.__name__ == 'Const' and
+                    isinstance(key.value, str)):
+                cls_locals[key.value].append(value)
 
         # Build the class from now.
         cls = mcs.__class__(name=name.value, lineno=caller.lineno,

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -343,7 +343,9 @@ class UnboundMethod(Proxy):
         # instance of the class given as first argument.
         if (self._proxied.name == '__new__' and
                 self._proxied.parent.frame().qname() == '%s.object' % BUILTINS):
-            if caller.args:
+            # XXX Avoid issue with type.__new__ inference.
+            # https://github.com/PyCQA/astroid/issues/581
+            if caller.args and len(caller.args) != 4:
                 node_context = context.extra_context.get(caller.args[0])
                 infer = caller.args[0].infer(context=node_context)
             else:

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -33,7 +33,7 @@ class LruWrappedModel(objectmodel.FunctionModel):
         _CacheInfo(0, 0, 0, 0)
         ''')
         class CacheInfoBoundMethod(BoundMethod):
-            def infer_call_result(self, caller, context=None, context_lookup=None):
+            def infer_call_result(self, caller, context=None):
                 yield helpers.safe_infer(cache_info)
 
         return CacheInfoBoundMethod(proxy=self._instance, bound=self._instance)
@@ -94,7 +94,7 @@ def _functools_partial_inference(node, context=None):
         filled_positionals = len(call.positional_arguments[1:])
         filled_keywords = list(call.keyword_arguments)
 
-        def infer_call_result(self, caller=None, context=None, context_lookup=None):
+        def infer_call_result(self, caller=None, context=None):
             nonlocal call
             filled_args = call.positional_arguments[1:]
             filled_keywords = call.keyword_arguments
@@ -113,7 +113,6 @@ def _functools_partial_inference(node, context=None):
             return super().infer_call_result(
                 caller=caller,
                 context=context,
-                context_lookup=context_lookup,
             )
 
     partial_function = PartialFunction(

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -18,7 +18,7 @@ class InferenceContext:
     Account for already visited nodes to infinite stop infinite recursion
     """
 
-    __slots__ = ('path', 'lookupname', 'callcontext', 'boundnode', 'inferred')
+    __slots__ = ('path', 'lookupname', 'callcontext', 'boundnode', 'inferred', 'extra_context')
 
     def __init__(self, path=None, inferred=None):
         self.path = path or set()
@@ -61,6 +61,13 @@ class InferenceContext:
         Currently the key is ``(node, lookupname, callcontext, boundnode)``
         and the value is tuple of the inferred results
         """
+        self.extra_context = {}
+        """
+        :type: dict(NodeNG, Context)
+
+        Context that needs to be passed down through call stacks
+        for call arguments
+        """
 
     def push(self, node):
         """Push node into inference path
@@ -87,6 +94,7 @@ class InferenceContext:
         clone = InferenceContext(copy.copy(self.path), inferred=self.inferred)
         clone.callcontext = self.callcontext
         clone.boundnode = self.boundnode
+        clone.extra_context = copy.copy(self.extra_context)
         return clone
 
     def cache_generator(self, key, generator):

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -186,9 +186,10 @@ def infer_call(self, context=None):
     callcontext.callcontext = contextmod.CallContext(args=self.args,
                                                      keywords=self.keywords)
     callcontext.boundnode = None
-    context_lookup = None
+    extra_context = {}
     if context is not None:
-        context_lookup = _populate_context_lookup(self, context.clone())
+        extra_context = _populate_context_lookup(self, context.clone())
+        callcontext.extra_context = extra_context
     for callee in self.func.infer(context):
         if callee is util.Uninferable:
             yield callee
@@ -198,7 +199,6 @@ def infer_call(self, context=None):
                 yield from callee.infer_call_result(
                     caller=self,
                     context=callcontext,
-                    context_lookup=context_lookup,
                 )
         except exceptions.InferenceError:
             ## XXX log error ?

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -294,7 +294,7 @@ class FunctionModel(ObjectModel):
                 # is different.
                 return 0
 
-            def infer_call_result(self, caller, context=None, context_lookup=None):
+            def infer_call_result(self, caller, context=None):
                 if len(caller.args) != 2:
                     raise exceptions.InferenceError(
                         "Invalid arguments for descriptor binding",
@@ -418,7 +418,7 @@ class ClassModel(ObjectModel):
         # Cls.mro is a method and we need to return one in order to have a proper inference.
         # The method we're returning is capable of inferring the underlying MRO though.
         class MroBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context=None, context_lookup=None):
+            def infer_call_result(self, caller, context=None):
                 yield other_self.py__mro__
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -461,7 +461,7 @@ class ClassModel(ObjectModel):
         obj.postinit(classes)
 
         class SubclassesBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context=None, context_lookup=None):
+            def infer_call_result(self, caller, context=None):
                 yield obj
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -594,7 +594,7 @@ class DictModel(ObjectModel):
         """Generate a bound method that can infer the given *obj*."""
 
         class DictMethodBoundMethod(astroid.BoundMethod):
-            def infer_call_result(self, caller, context=None, context_lookup=None):
+            def infer_call_result(self, caller, context=None):
                 yield obj
 
         meth = next(self._instance._proxied.igetattr(name))

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -283,6 +283,8 @@ class NodeNG:
         :returns: The inferred values.
         :rtype: iterable
         """
+        if context is not None:
+            context = context.extra_context.get(self, context)
         if self._explicit_inference is not None:
             # explicit_inference is not bound, give it self explicitly
             try:

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -306,7 +306,8 @@ def _arguments_infer_argname(self, name, context):
             return
 
     if context and context.callcontext:
-        call_site = arguments.CallSite(context.callcontext)
+        call_site = arguments.CallSite(context.callcontext,
+                                       context.extra_context)
         for value in call_site.infer_argument(self.parent, name, context):
             yield value
         return

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1150,7 +1150,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
             names.append(self.args.kwarg)
         return names
 
-    def infer_call_result(self, caller, context=None, context_lookup=None):
+    def infer_call_result(self, caller, context=None):
         """Infer what the function returns when called.
 
         :param caller: Unused
@@ -1567,7 +1567,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         """
         return next(self._get_yield_nodes_skip_lambdas(), False)
 
-    def infer_call_result(self, caller=None, context=None, context_lookup=None):
+    def infer_call_result(self, caller=None, context=None):
         """Infer what the function returns when called.
 
         :returns: What the function returns.
@@ -2030,7 +2030,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         result.parent = caller.parent
         return result
 
-    def infer_call_result(self, caller, context=None, context_lookup=None):
+    def infer_call_result(self, caller, context=None):
         """infer what a class is returning when called"""
         if (self.is_subtype_of('%s.type' % (BUILTINS,), context)
                 and len(caller.args) == 3):
@@ -2049,7 +2049,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
                 dunder_call.qname() != "builtins.type.__call__"):
             context = contextmod.bind_context_to_node(context, self)
             yield from dunder_call.infer_call_result(
-                caller, context, context_lookup)
+                caller, context)
         else:
             # Call type.__call__ if not set metaclass
             # (since type is the default metaclass)

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -4616,5 +4616,41 @@ def test_call_on_instance_with_inherited_dunder_call_method():
     assert val.name == "Sub"
 
 
+class TestInferencePropagation:
+    """Make sure function argument values are properly
+    propagated to sub functions"""
+    def test_call_context_propagation(self):
+        n = extract_node("""
+        def chest(a):
+            return a * a
+        def best(a, b):
+            return chest(a)
+        def test(a, b, c):
+            return best(a, b)
+        test(4, 5, 6) #@
+        """)
+        assert next(n.infer()).as_string() == "16"
+
+    def test_call_starargs_propagation(self):
+        code = """
+        def foo(*args):
+            return args
+        def bar(*args):
+            return foo(*args)
+        bar(4, 5, 6, 7) #@
+        """
+        assert next(extract_node(code).infer()).as_string() == "(4, 5, 6, 7)"
+
+    def test_call_kwargs_propagation(self):
+        code = """
+        def b(**kwargs):
+            return kwargs
+        def f(**kwargs):
+            return b(**kwargs)
+        f(**{'f': 1}) #@
+        """
+        assert next(extract_node(code).infer()).as_string() == "{'f': 1}"
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add context_lookup to the context class as `extra_context`

Deliver the correct context with the correct boundnode
for function argument nodes

Close #177

This removes use of `context_lookup` as per your previous recommendation @PCManticore 

---

I had to make some changes to `type.__new__` tests because my changes caused them to fail. These tests were faulty anyway.