### PR TITLE
Limit inference to a maximum of 100 results at a time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -157,6 +157,12 @@ Release Date: Unknown
 
      Close PyCQA/pylint#2159
 
+   * Limit the maximum amount of interable result in an NodeNG.infer() call to
+    100 by default for performance issues with variables with large amounts of
+    possible values.
+    The max inferable value can be tuned by setting the ASTROID_MAX_INFERABLE environment
+    variable at start up.
+
 
 What's New in astroid 1.6.0?
 ============================

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -52,6 +52,8 @@ class AstroidManager:
             # Export these APIs for convenience
             self.register_transform = self._transform.register_transform
             self.unregister_transform = self._transform.unregister_transform
+            self.max_inferable = int(
+                os.environ.get("ASTROID_MAX_INFERABLE", 100))
 
     def visit_transforms(self, node):
         """Visit the transforms and apply them to the given *node*."""

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -323,7 +323,9 @@ class NodeNG:
         if key in context.inferred:
             return iter(context.inferred[key])
 
-        return context.cache_generator(key, self._infer(context, **kwargs))
+        gen = context.cache_generator(
+            key, self._infer(context, **kwargs))
+        return util.limit_inference(gen, MANAGER.max_inferable)
 
     def _repr_name(self):
         """Get a name for nice representation.

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -5,6 +5,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
 
 import warnings
+from itertools import islice
 
 import importlib
 import lazy_object_proxy
@@ -124,6 +125,29 @@ def proxy_alias(alias_name, node_type):
                  {'__class__': object.__dict__['__class__'],
                   '__instancecheck__': _instancecheck})
     return proxy(lambda: node_type)
+
+
+def limit_inference(iterator, size):
+    """Limit inference amount.
+
+    Limit inference amount to help with performance issues with
+    exponentially exploding possible results.
+
+    :param iterator: Inference generator to limit
+    :type iterator: Iterator(NodeNG)
+
+    :param size: Maximum mount of nodes yielded plus an
+        Uninferable at the end if limit reached
+    :type size: int
+
+    :yields: A possibly modified generator
+    :rtype param: Iterable
+    """
+    yield from islice(iterator, size)
+    has_more = next(iterator, False)
+    if has_more is not False:
+        yield Uninferable
+        return
 
 
 # Backwards-compatibility aliases


### PR DESCRIPTION
Prevents spot performance issues.

Add new envrionment variable call ASTROID_MAX_INFERABLE to tune
the max inferable amount of values at a time.

Close #579
Close PyCQA/pylint#2251