### PR TITLE
Fix attributes of ancestor classes from appearing in attribute inference

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -343,9 +343,7 @@ class UnboundMethod(Proxy):
         # instance of the class given as first argument.
         if (self._proxied.name == '__new__' and
                 self._proxied.parent.frame().qname() == '%s.object' % BUILTINS):
-            # XXX Avoid issue with type.__new__ inference.
-            # https://github.com/PyCQA/astroid/issues/581
-            if caller.args and len(caller.args) == 1:
+            if caller.args:
                 node_context = context.extra_context.get(caller.args[0])
                 infer = caller.args[0].infer(context=node_context)
             else:
@@ -440,10 +438,7 @@ class BoundMethod(UnboundMethod):
         if (self.bound.__class__.__name__ == 'ClassDef'
                 and self.bound.name == 'type'
                 and self.name == '__new__'
-                and len(caller.args) == 4
-                # TODO(cpopa): this check shouldn't be needed.
-                and self._proxied.parent.frame().qname() == '%s.object' % BUILTINS):
-
+                and len(caller.args) == 4):
             # Check if we have an ``type.__new__(mcs, name, bases, attrs)`` call.
             new_cls = self._infer_type_new_call(caller, context)
             if new_cls:

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -2366,8 +2366,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         context = contextmod.copy_context(context)
         context.lookupname = name
         try:
-            attrs = self.getattr(name, context, class_context=class_context)
-            for inferred in bases._infer_stmts(attrs, context, frame=self):
+            attr = self.getattr(name, context, class_context=class_context)[0]
+            for inferred in bases._infer_stmts([attr], context, frame=self):
                 # yield Uninferable object instead of descriptors when necessary
                 if (not isinstance(inferred, node_classes.Const)
                         and isinstance(inferred, bases.Instance)):


### PR DESCRIPTION
Close #581