### PR TITLE
Stop repeat inference attempt causing a RuntimeError in Python3.7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 2.0.2?
 
 Release Date: |TBA|
 
+   * Stop repeat inference attempt causing a RuntimeError in Python3.7
+
+     Close PyCQA/pylint#2317
+
 
 What's New in astroid 2.0.1?
 ============================

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -83,7 +83,7 @@ def path_wrapper(func):
         if context is None:
             context = contextmod.InferenceContext()
         if context.push(node):
-            return None
+            raise exceptions.InferenceError(node=node)
 
         yielded = set()
         generator = _func(node, context, **kwargs)


### PR DESCRIPTION
Empty generators and next calls within a generator without a default argument
now cause a cascade effect which results in a RuntimeError.

Raise InferenceError instead of return None to avoid the above problem.

Close PyCQA/pylint#2317