### PR TITLE
Minor inference performance improvements

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -427,16 +427,22 @@ def _infer_boolop(self, context=None):
         return None
 
     for pair in itertools.product(*values):
-        if any(item is util.Uninferable for item in pair):
-            # Can't infer the final result, just yield Uninferable.
-            yield util.Uninferable
-            continue
+        bool_values = []
 
-        bool_values = [item.bool_value() for item in pair]
-        if any(item is util.Uninferable for item in bool_values):
-            # Can't infer the final result, just yield Uninferable.
-            yield util.Uninferable
-            continue
+        for item in pair:
+            if item is util.Uninferable:
+                # Can't infer the final result, just yield Uninferable.
+                yield util.Uninferable
+                break
+
+            bool_value = item.bool_value()
+
+            if bool_value is util.Uninferable:
+                # Can't infer the final result, just yield Uninferable.
+                yield util.Uninferable
+                break
+
+            bool_values.append(bool_value)
 
         # Since the boolean operations are short circuited operations,
         # this code yields the first value for which the predicate is True

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -187,7 +187,7 @@ def infer_name(self, context=None):
                                                 context=context)
     context = context.clone()
     context.lookupname = self.name
-    return bases._infer_stmts(stmts, context, frame)
+    return bases._infer_stmts(stmts, context, frame, copy=False)
 
 # pylint: disable=no-value-for-parameter
 nodes.Name._infer = decorators.raise_if_nothing_inferred(
@@ -276,7 +276,7 @@ def infer_import_from(self, context=None, asname=True):
         context = contextmod.copy_context(context)
         context.lookupname = name
         stmts = module.getattr(name, ignore_locals=module is self.root())
-        return bases._infer_stmts(stmts, context)
+        return bases._infer_stmts(stmts, context, copy=False)
     except exceptions.AttributeInferenceError as error:
         raise exceptions.InferenceError(
             error.message,

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -588,6 +588,9 @@ def _get_binop_contexts(context, left, right):
     for x.__op__(y), the other one for y.__rop__(x), where
     only the arguments are inversed.
     """
+    if context is None:
+        context = contextmod.InferenceContext()
+
     # The order is important, since the first one should be
     # left.__op__(right).
     for arg in (right, left):
@@ -714,15 +717,16 @@ def _infer_binary_operation(left, right, binary_opnode, context, flow_factory):
 def _infer_binop(self, context):
     """Binary operation inference logic."""
     if context is None:
-        context = contextmod.InferenceContext()
+        lhs_context = rhs_context = None
+    else:
+        # we use two separate contexts for evaluating lhs and rhs
+        # because evaluating lhs may leave some undesired entries in
+        # context.path which may not let us infer right value of rhs
+        lhs_context = context.clone()
+        rhs_context = context.clone()
+
     left = self.left
     right = self.right
-
-    # we use two separate contexts for evaluating lhs and rhs because
-    # 1. evaluating lhs may leave some undesired entries in context.path
-    #    which may not let us infer right value of rhs
-    lhs_context = context.clone()
-    rhs_context = context.clone()
 
     for lhs in left.infer(context=lhs_context):
         if lhs is util.Uninferable:

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1054,7 +1054,7 @@ class LookupMixIn:
         """
         frame, stmts = self.lookup(name)
         context = contextmod.InferenceContext()
-        return bases._infer_stmts(stmts, context, frame)
+        return bases._infer_stmts(stmts, context, frame, copy=False)
 
     def _filter_stmts(self, stmts, frame, offset):
         """Filter the given list of statements to remove ignorable statements.

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -2440,6 +2440,9 @@ class Const(mixins.NoChildrenMixin, NodeNG, bases.Instance):
         """
         return bool(self.value)
 
+    def infer(self, context=None, **kwargs):
+        yield self
+
 
 class Continue(mixins.NoChildrenMixin, Statement):
     """Class representing an :class:`ast.Continue` node.

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -527,7 +527,7 @@ class Module(LocalsDictNodeNG):
         context.lookupname = name
         try:
             return bases._infer_stmts(self.getattr(name, context),
-                                      context, frame=self)
+                                      context, frame=self, copy=False)
         except exceptions.AttributeInferenceError as error:
             raise exceptions.InferenceError(
                 error.message,
@@ -2381,7 +2381,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         context.lookupname = name
         try:
             attr = self.getattr(name, context, class_context=class_context)[0]
-            for inferred in bases._infer_stmts([attr], context, frame=self):
+            for inferred in bases._infer_stmts([attr], context, frame=self, copy=False):
                 # yield Uninferable object instead of descriptors when necessary
                 if (not isinstance(inferred, node_classes.Const)
                         and isinstance(inferred, bases.Instance)):


### PR DESCRIPTION
Here are a few minor changes to bring some minor speed improvements to
inference. This was my first time looking at that stuff, so I may have
misunderstood some of it. I think the commits are all independent, and
I'm not sure exactly which ones are responsible for how much of the
performance.

As usual, I ran Pylint before and after these changes against a few
targets: Pylint itself, Pycodestyle (a large, single file), and Zulip
(a large directory).

(Times were recorded on a 2012 MBP.)

### Pylint

#### Before
```
real	0m35.291s
user	0m34.866s
sys	0m0.388s

real	0m35.877s
user	0m35.436s
sys	0m0.384s

real	0m35.295s
user	0m34.691s
sys	0m0.381s
```

#### After
```
real	0m34.090s
user	0m33.653s
sys	0m0.397s

real	0m33.693s
user	0m33.286s
sys	0m0.379s

real	0m33.789s
user	0m33.379s
sys	0m0.381s
```

### [pycodestyle.py](https://github.com/PyCQA/pycodestyle/blob/master/pycodestyle.py)

#### Before
```
real	0m11.905s
user	0m11.491s
sys	0m0.174s

real	0m11.588s
user	0m11.348s
sys	0m0.163s

real	0m11.660s
user	0m11.364s
sys	0m0.167s
```

#### After
```
real	0m11.081s
user	0m10.916s
sys	0m0.140s

real	0m10.982s
user	0m10.808s
sys	0m0.127s

real	0m10.998s
user	0m10.801s
sys	0m0.141s
```

### [zulip/zerver](https://github.com/zulip/zulip/tree/master/zerver)

#### Before
```
real	12m43.572s
user	6m9.156s
sys	4m53.472s
```

#### After
```
real	12m29.165s
user	5m55.484s
sys	4m55.770s
```