### PR TITLE
Backport #526 to 1.6 branch

### DIFF
--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -31,7 +31,7 @@ class LruWrappedModel(objectmodel.FunctionModel):
         _CacheInfo(0, 0, 0, 0)
         ''')
         class CacheInfoBoundMethod(BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context=None, context_lookup=None):
                 yield helpers.safe_infer(cache_info)
 
         return CacheInfoBoundMethod(proxy=self._instance, bound=self._instance)

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -300,7 +300,7 @@ class FunctionModel(ObjectModel):
 
         class DescriptorBoundMethod(bases.BoundMethod):
             """Bound method which knows how to understand calling descriptor binding."""
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context=None, context_lookup=None):
                 if len(caller.args) != 2:
                     raise exceptions.InferenceError(
                         "Invalid arguments for descriptor binding",
@@ -403,7 +403,7 @@ class ClassModel(ObjectModel):
         # Cls.mro is a method and we need to return one in order to have a proper inference.
         # The method we're returning is capable of inferring the underlying MRO though.
         class MroBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context=None, context_lookup=None):
                 yield other_self.py__mro__
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -446,7 +446,7 @@ class ClassModel(ObjectModel):
         obj.postinit(classes)
 
         class SubclassesBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context=None, context_lookup=None):
                 yield obj
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -589,7 +589,7 @@ class DictModel(ObjectModel):
         """Generate a bound method that can infer the given *obj*."""
 
         class DictMethodBoundMethod(astroid.BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context=None, context_lookup=None):
                 yield obj
 
         meth = next(self._instance._proxied.igetattr(name))

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1139,7 +1139,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
             names.append(self.args.kwarg)
         return names
 
-    def infer_call_result(self, caller, context=None):
+    def infer_call_result(self, caller, context=None, context_lookup=None):
         """Infer what the function returns when called.
 
         :param caller: Unused
@@ -1148,7 +1148,6 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         # pylint: disable=no-member; github.com/pycqa/astroid/issues/291
         # args is in fact redefined later on by postinit. Can't be changed
         # to None due to a strong interaction between Lambda and FunctionDef.
-
         return self.body.infer(context)
 
     def scope_lookup(self, node, name, offset=0):
@@ -1526,7 +1525,7 @@ class FunctionDef(node_classes.Statement, Lambda):
         return next(self.nodes_of_class(yield_nodes,
                                         skip_klass=(FunctionDef, Lambda)), False)
 
-    def infer_call_result(self, caller, context=None):
+    def infer_call_result(self, caller=None, context=None, context_lookup=None):
         """Infer what the function returns when called.
 
         :returns: What the function returns.
@@ -1953,7 +1952,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG,
         result.parent = caller.parent
         return result
 
-    def infer_call_result(self, caller, context=None):
+    def infer_call_result(self, caller, context=None, context_lookup=None):
         """infer what a class is returning when called"""
         if (self.is_subtype_of('%s.type' % (BUILTINS,), context)
                 and len(caller.args) == 3):


### PR DESCRIPTION
This is a cherry-pick of f7f8052 from #526 to fix some problems with astroid handling `object.__new__`.

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] Add a ChangeLog entry describing what your PR does
- [x] Write a good description on what the PR does

## Description

We were running into an issue where this bit of code causes astroid to exceed the recursion limit:

```
import astroid

astroid.extract_node("""
def _getInstanceFromArg(arg):
    return _newInstance(arg)


def _newInstance(arg):
    cls = _getInstanceFromArg(arg)
    instance = object.__new__(cls)
    instance._arg = arg
    return instance
""")
```

I bisected the fix back to f7f8052 and applied it on top of the 1.6 branch (I am bound to Python 2.7 for the time being). Is this a good candidate for backport?

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
