### PR TITLE
Add blake2s to hashing algorithims.

### DIFF
--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -36,7 +36,7 @@ def _hashlib_transform():
     if PY36:
         algorithms += [
             'sha3_224', 'sha3_256', 'sha3_384', 'sha3_512', 'shake_128', 'shake_256',
-            'blake2b',
+            'blake2b', 'blake2s',
         ]
     classes = "".join(
         template % {'name': hashfunc, 'digest': 'b""' if six.PY3 else '""'}


### PR DESCRIPTION
Can test with the following code:

```
from hashlib import blake2s

h = blake2s(digest_size=20)
h.update(b'Replacing SHA1 with the more secure function')
print(h.hexdigest())
input("Press Enter to continue...")
```

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] Add a ChangeLog entry describing what your PR does
- [ ] Write a good description on what the PR does

## Description
Add's "blake2s" to acceptable algorithms for python 3.6.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
https://github.com/PyCQA/pylint/issues/1968
This issue was closed but really was only half fixed, 2s is still reporting the error 2b reported prior to this change.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
