### PR TITLE
brain_gi: use Exception as a base class for classes inheriting from Exception

### DIFF
--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -110,10 +110,13 @@ def _gi_build_stub(parent):
         ret += "\n\n"
     if classes:
         ret += "# %s classes\n\n" % parent.__name__
-    for name in sorted(classes):
-        ret += "class %s(object):\n" % name
+    for name, obj in sorted(classes.items()):
+        base = "object"
+        if issubclass(obj, Exception):
+            base = "Exception"
+        ret += "class %s(%s):\n" % (name, base)
 
-        classret = _gi_build_stub(classes[name])
+        classret = _gi_build_stub(obj)
         if not classret:
             classret = "pass\n"
 


### PR DESCRIPTION
All gi classes use object as a base which leads to pylint complaining in
case a class which is really an exception is used in a try/except construct.
See PyCQA/pylint#2504

In case the object is a subclass of Exception use Exception as a base instead
of object to make pylint happy.

This fixes pylint warnings with pygobject code such as:
    E0712: Catching an exception which doesn't inherit from Exception: GError (catching-non-exception)

Close PyCQA/pylint#2504