### PR TITLE
Reflect AST changes in Python 3.8.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,8 @@ Release Date: TBA
 
      Close PyCQA/pylint#2434
 
+   * Make compatible with AST changes in Python 3.8.
+
 
 What's New in astroid 2.0.4?
 ============================

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -479,6 +479,7 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
+    # Not used in Python 3.8+.
     def visit_ellipsis(self, node, parent):
         """visit an Ellipsis node by returning a fresh instance of it"""
         return nodes.Ellipsis(getattr(node, 'lineno', None),
@@ -509,6 +510,7 @@ class TreeRebuilder:
                          _visit_or_none(node, 'locals', self, newnode))
         return newnode
 
+    # Not used in Python 3.8+.
     def visit_extslice(self, node, parent):
         """visit an ExtSlice node by returning a fresh instance of it"""
         newnode = nodes.ExtSlice(parent=parent)
@@ -641,6 +643,7 @@ class TreeRebuilder:
             parent.set_local(name.split('.')[0], newnode)
         return newnode
 
+    # Not used in Python 3.8+.
     def visit_index(self, node, parent):
         """visit a Index node by returning a fresh instance of it"""
         newnode = nodes.Index(parent=parent)
@@ -702,12 +705,19 @@ class TreeRebuilder:
             self._save_assignment(newnode)
         return newnode
 
+    def visit_constant(self, node, parent):
+        """visit a Constant node by returning a fresh instance of Const"""
+        return nodes.Const(node.value, getattr(node, 'lineno', None),
+                           getattr(node, 'col_offset', None), parent)
+
+    # Not used in Python 3.8+.
     def visit_str(self, node, parent):
         """visit a String/Bytes node by returning a fresh instance of Const"""
         return nodes.Const(node.s, getattr(node, 'lineno', None),
                            getattr(node, 'col_offset', None), parent)
     visit_bytes = visit_str
 
+    # Not used in Python 3.8+.
     def visit_num(self, node, parent):
         """visit a Num node by returning a fresh instance of Const"""
         return nodes.Const(node.n, getattr(node, 'lineno', None),
@@ -854,6 +864,7 @@ class TreeRebuilder3(TreeRebuilder):
         """visit an arg node by returning a fresh AssName instance"""
         return self.visit_assignname(node, parent, node.arg)
 
+    # Not used in Python 3.8+.
     def visit_nameconstant(self, node, parent):
         # in Python 3.4 we have NameConstant for True / False / None
         return nodes.Const(node.value, getattr(node, 'lineno', None),

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -158,8 +158,8 @@ def function(var):
         self.assertEqual(ast.as_string(), 'a[...]')
 
     def test_slices(self):
-        for code in ('a[0]', 'a[1:3]', 'a[:-1:step]', 'a[:,newaxis]',
-                     'a[newaxis,:]', 'del L[::2]', 'del A[1]', 'del Br[:]'):
+        for code in ('a[0]', 'a[1:3]', 'a[:-1:step]', 'a[:, newaxis]',
+                     'a[newaxis, :]', 'del L[::2]', 'del A[1]', 'del Br[:]'):
             ast = abuilder.string_build(code).body[0]
             self.assertEqual(ast.as_string(), code)
 
@@ -170,7 +170,7 @@ del bree[3:d]
 bord[2:]
 del av[d::f], a[df:]
 a[:1] = bord[2:]
-del SRC[::1,newaxis,1:]
+del SRC[::1, newaxis, 1:]
 tous[vals] = 1010
 del thousand[key]
 del a[::2], a[:-1:step]
@@ -546,7 +546,7 @@ class AnnAssignNodeTest(unittest.TestCase):
             print()
             test: int = 5
             test2: str
-            test3: List[Dict[(str, str)]] = []
+            test3: List[Dict[str, str]] = []
         """)
         ast = abuilder.string_build(code)
         self.assertEqual(ast.as_string().strip(), code.strip())


### PR DESCRIPTION
## Steps

- [x] Add a ChangeLog entry describing what your PR does
- [x] Write a good description on what the PR does

## Description

There will be several changes in AST in Python 3.8.

* `ast.Num`, `ast.Str`, `ast.Bytes`, `ast.Ellipsis` and `ast.NameConstant` are replaced with `ast.Constant`.
  (https://bugs.python.org/issue32892)

  `ast.Constant` can be used since Python 3.6, it is just that `ast.parse()` didn't produce it.

  This PR adds a handler for `ast.Constant` in `TreeRebuilder`.

* Simplified AST for subscriptions. `ast.Index` is replaced with its value, `ast.ExtSlice` is replaced with `ast.Tuple`.
  (https://bugs.python.org/issue34822)

  *This change is not merged yet.*

  Since the code like `a[(::1, 1:)]` is invalid syntax, tuples should be handled specially in `as_string()` when used as indices in subscription. As side effect, a comma with a space instead of a just comma is now used for separating slices in the `as_string()` output.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

Closes #617.