### PR TITLE
Multiple "value" or "slice" values on subscript inference.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,10 @@ Release Date: TBA
 
    * Make compatible with AST changes in Python 3.8.
 
+   * Subscript inference (e.g. "`a[i]`") now pays attention to multiple inferred values for value
+     (e.g. "`a`") and slice (e.g. "`i`")
+
+     Close #614
 
 What's New in astroid 2.0.4?
 ============================

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -355,54 +355,51 @@ def infer_subscript(self, context=None):
     handle each supported index type accordingly.
     """
 
-    try:
-        value = next(self.value.infer(context))
-    except StopIteration:
-        return None
-    if value is util.Uninferable:
-        yield util.Uninferable
-        return None
+    found_one = False
+    for value in self.value.infer(context):
+        if value is util.Uninferable:
+            yield util.Uninferable
+            return None
+        for index in self.slice.infer(context):
+            if index is util.Uninferable:
+                yield util.Uninferable
+                return None
 
-    try:
-        index = next(self.slice.infer(context))
-    except StopIteration:
-        return None
-    if index is util.Uninferable:
-        yield util.Uninferable
-        return None
+            # Try to deduce the index value.
+            index_value = _SUBSCRIPT_SENTINEL
+            if value.__class__ == bases.Instance:
+                index_value = index
+            else:
+                if index.__class__ == bases.Instance:
+                    instance_as_index = helpers.class_instance_as_index(index)
+                    if instance_as_index:
+                        index_value = instance_as_index
+                else:
+                    index_value = index
+            if index_value is _SUBSCRIPT_SENTINEL:
+                raise exceptions.InferenceError(node=self, context=context)
 
-    # Try to deduce the index value.
-    index_value = _SUBSCRIPT_SENTINEL
-    if value.__class__ == bases.Instance:
-        index_value = index
-    else:
-        if index.__class__ == bases.Instance:
-            instance_as_index = helpers.class_instance_as_index(index)
-            if instance_as_index:
-                index_value = instance_as_index
-        else:
-            index_value = index
-    if index_value is _SUBSCRIPT_SENTINEL:
-        raise exceptions.InferenceError(node=self, context=context)
+            try:
+                assigned = value.getitem(index_value, context)
+            except (
+                exceptions.AstroidTypeError,
+                exceptions.AstroidIndexError,
+                exceptions.AttributeInferenceError,
+                AttributeError,
+            ) as exc:
+                raise exceptions.InferenceError(node=self, context=context) from exc
 
-    try:
-        assigned = value.getitem(index_value, context)
-    except (
-        exceptions.AstroidTypeError,
-        exceptions.AstroidIndexError,
-        exceptions.AttributeInferenceError,
-        AttributeError,
-    ) as exc:
-        raise exceptions.InferenceError(node=self, context=context) from exc
+            # Prevent inferring if the inferred subscript
+            # is the same as the original subscripted object.
+            if self is assigned or assigned is util.Uninferable:
+                yield util.Uninferable
+                return None
+            yield from assigned.infer(context)
+            found_one = True
 
-    # Prevent inferring if the inferred subscript
-    # is the same as the original subscripted object.
-    if self is assigned or assigned is util.Uninferable:
-        yield util.Uninferable
-        return None
-    yield from assigned.infer(context)
-
-    return dict(node=self, context=context)
+    if found_one:
+        return dict(node=self, context=context)
+    return None
 
 
 nodes.Subscript._infer = decorators.path_wrapper(infer_subscript)

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -747,6 +747,40 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 97)
 
+    def test_subscript_multi_value(self):
+        code = """
+            def do_thing_with_subscript(magic_flag):
+                src = [3, 2, 1]
+                if magic_flag:
+                    src = [1, 2, 3]
+                something = src[0]
+                return something
+        """
+        ast = parse(code, __name__)
+        values = [
+            i.value for i in test_utils.get_name_node(ast, "something", -1).infer()
+        ]
+        self.assertEqual(list(sorted(values)), [1, 3])
+
+    def test_subscript_multi_slice(self):
+        code = """
+            def zero_or_one(magic_flag):
+                if magic_flag:
+                    return 1
+                return 0
+
+            def do_thing_with_subscript(magic_flag):
+                src = [3, 2, 1]
+                index = zero_or_one(magic_flag)
+                something = src[index]
+                return something
+        """
+        ast = parse(code, __name__)
+        values = [
+            i.value for i in test_utils.get_name_node(ast, "something", -1).infer()
+        ]
+        self.assertEqual(list(sorted(values)), [2, 3])
+
     def test_simple_tuple(self):
         module = parse(
             """


### PR DESCRIPTION
Fixes astroid bug #614.

## Description
Changes subscript inference to iterate over inferred possibilities for `value` and `slice` rather than simply calling `next` once and taking the first answer as the only possibility.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #614
