### PR TITLE
Add support for new Popen kwarg 'text' in Python 3.7

### DIFF
--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -13,8 +13,9 @@ import six
 import astroid
 
 
-PY34 = sys.version_info >= (3, 4)
+PY37 = sys.version_info >= (3, 7)
 PY36 = sys.version_info >= (3, 6)
+PY34 = sys.version_info >= (3, 4)
 PY33 = sys.version_info >= (3, 3)
 
 
@@ -22,7 +23,18 @@ def _subprocess_transform():
     if six.PY3:
         communicate = (bytes("string", "ascii"), bytes("string", "ascii"))
         communicate_signature = "def communicate(self, input=None, timeout=None)"
-        if PY36:
+        if PY37:
+            init = """
+            def __init__(self, args, bufsize=0, executable=None,
+                         stdin=None, stdout=None, stderr=None,
+                         preexec_fn=None, close_fds=False, shell=False,
+                         cwd=None, env=None, universal_newlines=False,
+                         startupinfo=None, creationflags=0, restore_signals=True,
+                         start_new_session=False, pass_fds=(), *,
+                         encoding=None, errors=None, text=None):
+                pass
+            """
+        elif PY36:
             init = """
             def __init__(self, args, bufsize=0, executable=None,
                          stdin=None, stdout=None, stderr=None,


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] Add a ChangeLog entry describing what your PR does
- [x] Write a good description on what the PR does

## Description
Python 3.7 adds the keyword argument `text` to `subprocess.Popen` as a less-wordy alternative to `universal_newlines` ([link to doc](https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen)), leaving the current subprocess brain incomplete. This PR adds the missing code.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
