### PR TITLE
Extend detection of classes defined with attr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,10 @@ Release Date: TBA
 
   Close PyCQA/pylint#2534
 
+* Extend detection of data classes defined with attr
+
+  Close #628
+
 
 What's New in astroid 2.1.0?
 ============================

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -11,12 +11,11 @@ import astroid
 from astroid import MANAGER
 
 
-ATTR_IB = "attr.ib"
+ATTRIB_NAMES = frozenset(("attr.ib", "attrib", "attr.attrib"))
+ATTRS_NAMES = frozenset(("attr.s", "attrs", "attr.attrs", "attr.attributes"))
 
 
-def is_decorated_with_attrs(
-    node, decorator_names=("attr.s", "attr.attrs", "attr.attributes")
-):
+def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES):
     """Return True if a decorated node has
     an attr decorator applied."""
     if not node.decorators:
@@ -41,7 +40,7 @@ def attr_attributes_transform(node):
         if not isinstance(cdefbodynode, astroid.Assign):
             continue
         if isinstance(cdefbodynode.value, astroid.Call):
-            if cdefbodynode.value.func.as_string() != ATTR_IB:
+            if cdefbodynode.value.func.as_string() not in ATTRIB_NAMES:
                 continue
         else:
             continue

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1030,6 +1030,7 @@ class AttrsTest(unittest.TestCase):
         module = astroid.parse(
             """
         import attr
+        from attr import attrs, attrib
 
         @attr.s
         class Foo:
@@ -1045,10 +1046,24 @@ class AttrsTest(unittest.TestCase):
 
         g = Bar()
         g.d['answer'] = 42
+
+        @attrs
+        class Bah:
+            d = attrib(attr.Factory(dict))
+
+        h = Bah()
+        h.d['answer'] = 42
+
+        @attr.attrs
+        class Bai:
+            d = attr.attrib(attr.Factory(dict))
+
+        i = Bai()
+        i.d['answer'] = 42
         """
         )
 
-        for name in ("f", "g"):
+        for name in ("f", "g", "h", "i"):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 


### PR DESCRIPTION
## Steps

- [x] Add a ChangeLog entry describing what your PR does
- [x] Write a good description on what the PR does

## Description

Extends detection of classes defined with attr to `attr.attrs`, `attrs`, `attr.attrib` and `attrib`.
Extends the `test_attr_transform` test.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #628 
