### PR TITLE
Don't clone the underlying path when cloning contexts for performance reasons

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -122,7 +122,7 @@ def _infer_stmts(stmts, context, frame=None):
     inferred = False
     if context is not None:
         name = context.lookupname
-        context = context.clone()
+        context = context.clone(branch_path=False)
     else:
         name = None
         context = contextmod.InferenceContext()
@@ -254,7 +254,7 @@ class BaseInstance(Proxy):
 
     def infer_call_result(self, caller, context=None):
         """infer what a class instance is returning when called"""
-        context = contextmod.bind_context_to_node(context, self)
+        context = contextmod.bind_context_to_node(context, self, False)
         inferred = False
         for node in self._proxied.igetattr("__call__", context):
             if node is util.Uninferable or not node.callable():
@@ -473,7 +473,7 @@ class BoundMethod(UnboundMethod):
         return cls
 
     def infer_call_result(self, caller, context=None):
-        context = contextmod.bind_context_to_node(context, self.bound)
+        context = contextmod.bind_context_to_node(context, self.bound, False)
         if (
             self.bound.__class__.__name__ == "ClassDef"
             and self.bound.name == "type"

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -168,7 +168,11 @@ def infer_named_tuple(node, context=None):
         node, tuple_base_name, context=context
     )
     call_site = arguments.CallSite.from_call(node)
-    func = next(extract_node("import collections; collections.namedtuple").infer())
+    func = next(
+        extract_node("import collections; collections.namedtuple").infer(
+            context=context
+        )
+    )
     try:
         rename = next(call_site.infer_argument(func, "rename", context)).bool_value()
     except InferenceError:
@@ -387,7 +391,7 @@ def infer_typing_namedtuple(node, context=None):
     # This is essentially a namedtuple with different arguments
     # so we extract the args and infer a named tuple.
     try:
-        func = next(node.func.infer())
+        func = next(node.func.infer(context=context))
     except InferenceError:
         raise UseInferenceDefault
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -71,7 +71,7 @@ def _looks_like_typing_subscript(node):
 def infer_typing_attr(node, context=None):
     """Infer a typing.X[...] subscript"""
     try:
-        value = next(node.value.infer())
+        value = next(node.value.infer(context=context))
     except InferenceError as exc:
         raise UseInferenceDefault from exc
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -99,7 +99,7 @@ class InferenceContext:
         starts with the same context but diverge as each side is inferred
         so the InferenceContext will need be cloned"""
         # XXX copy lookupname/callcontext ?
-        clone = InferenceContext(set(self.path), inferred=self.inferred)
+        clone = InferenceContext(self.path, inferred=self.inferred)
         clone.callcontext = self.callcontext
         clone.boundnode = self.boundnode
         clone.extra_context = self.extra_context

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -20,7 +20,7 @@ from astroid import nodes
 from astroid import raw_building
 from astroid import scoped_nodes
 from astroid import util
-
+from astroid.context import copy_context
 
 BUILTINS = builtins_mod.__name__
 
@@ -205,14 +205,14 @@ def is_supertype(type1, type2):
     return _type_check(type1, type2)
 
 
-def class_instance_as_index(node):
+def class_instance_as_index(node, context=None):
     """Get the value as an index for the given instance.
 
     If an instance provides an __index__ method, then it can
     be used in some scenarios where an integer is expected,
     for instance when multiplying or subscripting a list.
     """
-    context = contextmod.InferenceContext()
+    context = copy_context(context, branch_path=False)
     context.callcontext = contextmod.CallContext(args=[node])
 
     try:

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -368,7 +368,9 @@ def infer_subscript(self, context=None):
                 index_value = index
             else:
                 if index.__class__ == bases.Instance:
-                    instance_as_index = helpers.class_instance_as_index(index)
+                    instance_as_index = helpers.class_instance_as_index(
+                        index, context=context
+                    )
                     if instance_as_index:
                         index_value = instance_as_index
                 else:

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -77,7 +77,7 @@ def _infer_sequence_helper(node, context=None):
 
 
 @decorators.raise_if_nothing_inferred
-@decorators.path_wrapper
+# @decorators.path_wrapper
 def infer_sequence(self, context=None):
     if not any(isinstance(e, nodes.Starred) for e in self.elts):
         yield self
@@ -187,15 +187,13 @@ def infer_name(self, context=None):
             raise exceptions.NameInferenceError(
                 name=self.name, scope=self.scope(), context=context
             )
-    context = contextmod.copy_context(context)
+    context = contextmod.copy_context(context, branch_path=False)
     context.lookupname = self.name
     return bases._infer_stmts(stmts, context, frame)
 
 
 # pylint: disable=no-value-for-parameter
-nodes.Name._infer = decorators.raise_if_nothing_inferred(
-    decorators.path_wrapper(infer_name)
-)
+nodes.Name._infer = decorators.raise_if_nothing_inferred(infer_name)
 nodes.AssignName.infer_lhs = infer_name  # won't work with a path wrapper
 
 
@@ -203,7 +201,7 @@ nodes.AssignName.infer_lhs = infer_name  # won't work with a path wrapper
 @decorators.path_wrapper
 def infer_call(self, context=None):
     """infer a Call node by trying to guess what the function returns"""
-    callcontext = contextmod.copy_context(context)
+    callcontext = contextmod.copy_context(context, branch_path=False)
     callcontext.callcontext = contextmod.CallContext(
         args=self.args, keywords=self.keywords
     )
@@ -271,7 +269,7 @@ def infer_import_from(self, context=None, asname=True):
         raise exceptions.InferenceError(node=self, context=context) from exc
 
     try:
-        context = contextmod.copy_context(context)
+        context = contextmod.copy_context(context, branch_path=False)
         context.lookupname = name
         stmts = module.getattr(name, ignore_locals=module is self.root())
         return bases._infer_stmts(stmts, context)
@@ -513,7 +511,7 @@ def _infer_unaryop(self, context=None):
                     if inferred is util.Uninferable or not inferred.callable():
                         continue
 
-                    context = contextmod.copy_context(context)
+                    context = contextmod.copy_context(context, branch_path=False)
                     context.callcontext = contextmod.CallContext(args=[operand])
                     call_results = inferred.infer_call_result(self, context=context)
                     result = next(call_results, None)
@@ -551,7 +549,7 @@ def _is_not_implemented(const):
 def _invoke_binop_inference(instance, opnode, op, other, context, method_name):
     """Invoke binary operation inference on the given instance."""
     methods = dunder_lookup.lookup(instance, method_name)
-    context = contextmod.bind_context_to_node(context, instance)
+    context = contextmod.bind_context_to_node(context, instance, branch_path=False)
     method = methods[0]
     inferred = next(method.infer(context=context))
     if inferred is util.Uninferable:
@@ -603,7 +601,7 @@ def _get_binop_contexts(context, left, right):
     # The order is important, since the first one should be
     # left.__op__(right).
     for arg in (right, left):
-        new_context = context.clone()
+        new_context = context.clone(branch_path=False)
         new_context.callcontext = contextmod.CallContext(args=[arg])
         new_context.boundnode = None
         yield new_context
@@ -747,8 +745,8 @@ def _infer_binop(self, context):
     # 1. evaluating lhs may leave some undesired entries in context.path
     #    which may not let us infer right value of rhs
     context = context or contextmod.InferenceContext()
-    lhs_context = contextmod.copy_context(context)
-    rhs_context = contextmod.copy_context(context)
+    lhs_context = contextmod.copy_context(context, branch_path=False)
+    rhs_context = contextmod.copy_context(context, branch_path=False)
     lhs_iter = left.infer(context=lhs_context)
     rhs_iter = right.infer(context=rhs_context)
     for lhs, rhs in itertools.product(lhs_iter, rhs_iter):
@@ -780,7 +778,7 @@ def _infer_augassign(self, context=None):
     if context is None:
         context = contextmod.InferenceContext()
 
-    rhs_context = context.clone()
+    rhs_context = context.clone(branch_path=False)
 
     lhs_iter = self.target.infer_lhs(context=context)
     rhs_iter = self.value.infer(context=rhs_context)
@@ -873,7 +871,7 @@ nodes.Index._infer = infer_index
 # will be solved.
 def instance_getitem(self, index, context=None):
     # Rewrap index to Const for this case
-    new_context = contextmod.bind_context_to_node(context, self)
+    new_context = contextmod.bind_context_to_node(context, self, branch_path=False)
     if not context:
         context = new_context
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -302,7 +302,7 @@ class FunctionModel(ObjectModel):
                         context=context,
                     )
 
-                context = contextmod.copy_context(context)
+                context = contextmod.copy_context(context, branch_path=False)
                 cls = next(caller.args[0].infer(context=context))
 
                 if cls is astroid.Uninferable:

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -353,7 +353,7 @@ def _arguments_infer_argname(self, name, context):
     # if there is a default value, yield it. And then yield Uninferable to reflect
     # we can't guess given argument value
     try:
-        context = contextmod.copy_context(context)
+        context = contextmod.copy_context(context, branch_path=False)
         yield from self.default_value(name).infer(context)
         yield util.Uninferable
     except exceptions.NoDefault:
@@ -364,7 +364,7 @@ def arguments_assigned_stmts(self, node=None, context=None, assign_path=None):
     if context.callcontext:
         # reset call context/name
         callcontext = context.callcontext
-        context = contextmod.copy_context(context)
+        context = contextmod.copy_context(context, branch_path=False)
         context.callcontext = None
         args = arguments.CallSite(callcontext)
         return args.infer_argument(self.parent, node.name, context)

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -190,7 +190,7 @@ def tl_infer_binary_op(self, opnode, operator, other, context, method):
         yield _multiply_seq_by_int(self, opnode, other, context)
     elif isinstance(other, bases.Instance) and operator == "*":
         # Verify if the instance supports __index__.
-        as_index = helpers.class_instance_as_index(other)
+        as_index = helpers.class_instance_as_index(other, context=context)
         if not as_index:
             yield util.Uninferable
         else:

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -544,7 +544,7 @@ class Module(LocalsDictNodeNG):
         """
         # set lookup name since this is necessary to infer on import nodes for
         # instance
-        context = contextmod.copy_context(context)
+        context = contextmod.copy_context(context, branch_path=False)
         context.lookupname = name
         try:
             return bases._infer_stmts(self.getattr(name, context), context, frame=self)
@@ -2103,7 +2103,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         except exceptions.AttributeInferenceError:
             pass
         if dunder_call and dunder_call.qname() != "builtins.type.__call__":
-            context = contextmod.bind_context_to_node(context, self)
+            context = contextmod.bind_context_to_node(context, self, branch_path=False)
             yield from dunder_call.infer_call_result(caller, context)
         else:
             # Call type.__call__ if not set metaclass
@@ -2417,7 +2417,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         """
         # set lookup name since this is necessary to infer on import nodes for
         # instance
-        context = contextmod.copy_context(context)
+        context = contextmod.copy_context(context, branch_path=False)
         context.lookupname = name
         try:
             attr = self.getattr(name, context, class_context=class_context)[0]
@@ -2489,7 +2489,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         method = methods[0]
 
         # Create a new callcontext for providing index as an argument.
-        new_context = contextmod.bind_context_to_node(context, self)
+        new_context = contextmod.bind_context_to_node(context, self, branch_path=False)
         new_context.callcontext = contextmod.CallContext(args=[index])
 
         try:

--- a/astroid/tests/unittest_inference.py
+++ b/astroid/tests/unittest_inference.py
@@ -1718,7 +1718,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         ast = extract_node(code, __name__)
         expr = ast.func.expr
-        self.assertRaises(InferenceError, next, expr.infer())
+        self.assertIs(next(expr.infer()), util.Uninferable)
 
     def test_tuple_builtin_inference(self):
         code = """


### PR DESCRIPTION
WIP PR for finding what caused the performance slowdown of https://github.com/PyCQA/pylint/issues/2198