### PR TITLE
Remove else after return/raise to make pylint happy

### DIFF
--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -132,7 +132,6 @@ def raise_if_nothing_inferred(func, instance, args, kwargs):
             if error.args:
                 # pylint: disable=not-a-mapping
                 raise exceptions.InferenceError(**error.args[0])
-            else:
-                raise exceptions.InferenceError(
-                    "StopIteration raised without any error information."
-                )
+            raise exceptions.InferenceError(
+                "StopIteration raised without any error information."
+            )

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -982,7 +982,7 @@ class TreeRebuilder3(TreeRebuilder):
                 body = [self.visit(child, newnode) for child in node.body]
             newnode.postinit(body, [self.visit(n, newnode) for n in node.finalbody])
             return newnode
-        elif node.handlers:
+        if node.handlers:
             return self.visit_tryexcept(node, parent)
         return None
 


### PR DESCRIPTION
## Steps

- Not adding a changelog entry - only cosmetic changes
- [x] Write a good description on what the PR does

## Description

The PR removes one `else` and changes `elif` to `if` to address the following pylint errors in travis. No functional change, the code should be equivalent in all cases to the old one.

```
************* Module astroid.decorators
astroid/decorators.py:132:12: R1720: Unnecessary "else" after "raise" (no-else-raise)
************* Module astroid.rebuilder
astroid/rebuilder.py:977:8: R1705: Unnecessary "elif" after "return" (no-else-return)
```

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

