### PR TITLE
Refactoring chained comparison

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -244,7 +244,6 @@ class BaseInstance(Proxy):
                 # Unfortunately, we can't do an isinstance check here,
                 # because of the circular dependency between astroid.bases
                 # and astroid.scoped_nodes.
-                # import ipdb; ipdb.set_trace()
                 if attr.statement().scope() == self._proxied:
                     if attr.args.args and attr.args.args[0].name == "self":
                         yield BoundMethod(attr, self)

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -244,6 +244,7 @@ class BaseInstance(Proxy):
                 # Unfortunately, we can't do an isinstance check here,
                 # because of the circular dependency between astroid.bases
                 # and astroid.scoped_nodes.
+                # import ipdb; ipdb.set_trace()
                 if attr.statement().scope() == self._proxied:
                     if attr.args.args and attr.args.args[0].name == "self":
                         yield BoundMethod(attr, self)

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4166,8 +4166,7 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         if (
             isinstance(child, TryExcept)
             and child.fromlineno == self.fromlineno
-            and lineno > self.fromlineno
-            and lineno <= child.tolineno
+            and child.tolineno >= lineno > self.fromlineno
         ):
             return child.block_range(lineno)
         return self._elsed_block_range(lineno, self.finalbody)


### PR DESCRIPTION
## Steps

- [ ] Add a ChangeLog entry describing what your PR does: not useful here

## Description
This PR is just a small refactoring of a chained comparison in `node_classes.py` so that 
no more `chained-comparison` warning is emitted. Thus the Travis CI won't block anymore during 
the linting process.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

This PR is related to another one : #632.
