### PR TITLE
Docs: Fixing transformation example to be functional

### DIFF
--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -115,20 +115,20 @@ Now, with this knowledge, let's see how our transform might look::
             lineno=node.lineno,
             col_offset=node.col_offset,
             parent=node.parent,
-         )
-         formatted_value_node = astroid.FormattedValue(
+        )
+        formatted_value_node = astroid.FormattedValue(
             lineno=node.lineno,
             col_offset=node.col_offset,
             parent=node.parent,
-         )
-         new_node.postinit(value=node.args[0])
+        )
+        formatted_value_node.postinit(value=node.args[0])
 
-         # Need to extract the part of the string that doesn't
-         # have the formatting placeholders
-         string = extract_string_without_placeholder(node.func.expr)
+        # Removes the {} since it will be represented as
+        # formatted_value_node
+        string = astroid.Const(node.func.expr.value.replace('{}', ''))
 
-         f_string_node.postinit(values=[string, f_string_node])
-         return new_node
+        f_string_node.postinit(values=[string, formatted_value_node])
+        return f_string_node
 
     astroid.MANAGER.register_transform(
         astroid.Call,


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does. (Its neither)
- [x] Write a good description on what the PR does.

## Description
The previous example was referencing undefined variables and returning the wrong node.
Three major changes:
 - Return `f_string_node` instead of `formatted_value_node`
 - Change reference from `new_node` (which doesn't exist) to `formatted_value_node`
 - Define `string` inline instead of calling a nonexistent function
   - Note this doesn't change the functionality since this example is already limited to 
     only working with a format string with one argument.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
