### PR TITLE
Bug pylint 2594

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.2.0?
 ============================
 Release Date: TBA
 
+* Fix a bug where a method, which is a lambda built from a function, is not inferred as ``BoundMethod``
+
+  Close PyCQA/pylint#2594
+
 * ``brain_numpy`` returns an undefined type for ``numpy`` methods to avoid ``assignment-from-no-return``
 
   Close PyCQA/pylint#2694

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -239,11 +239,6 @@ class BaseInstance(Proxy):
                 else:
                     yield BoundMethod(attr, self)
             elif hasattr(attr, "name") and attr.name == "<lambda>":
-                # This is a lambda function defined at class level,
-                # since its scope is the underlying _proxied class.
-                # Unfortunately, we can't do an isinstance check here,
-                # because of the circular dependency between astroid.bases
-                # and astroid.scoped_nodes.
                 if attr.args.args and attr.args.args[0].name == "self":
                     yield BoundMethod(attr, self)
                     continue

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -244,10 +244,9 @@ class BaseInstance(Proxy):
                 # Unfortunately, we can't do an isinstance check here,
                 # because of the circular dependency between astroid.bases
                 # and astroid.scoped_nodes.
-                if attr.statement().scope() == self._proxied:
-                    if attr.args.args and attr.args.args[0].name == "self":
-                        yield BoundMethod(attr, self)
-                        continue
+                if attr.args.args and attr.args.args[0].name == "self":
+                    yield BoundMethod(attr, self)
+                    continue
                 yield attr
             else:
                 yield attr

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -1855,22 +1855,22 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
 
     def test_instance_bound_method_lambdas_2(self):
         ast_nodes = builder.extract_node(
-            """
-        class Test(object): #@
-            lam = lambda self: self
-            not_method = lambda xargs: xargs
-        Test() #@
+        """
+        def lambda_factory(): 
+            return lambda self: print("Hello world")
+
+        class MyClass(object): #@
+            f2 = lambda_factory()
+
+        MyClass() #@
         """
         )
         cls = next(ast_nodes[0].infer())
-        self.assertIsInstance(next(cls.igetattr("lam")), scoped_nodes.Lambda)
-        self.assertIsInstance(next(cls.igetattr("not_method")), scoped_nodes.Lambda)
+        self.assertIsInstance(next(cls.igetattr("f2")), scoped_nodes.Lambda)
 
         instance = next(ast_nodes[1].infer())
-        lam = next(instance.igetattr("lam"))
-        self.assertIsInstance(lam, BoundMethod)
-        not_method = next(instance.igetattr("not_method"))
-        self.assertIsInstance(not_method, scoped_nodes.Lambda)
+        f2 = next(instance.igetattr("f2"))
+        self.assertIsInstance(f2, BoundMethod)
 
     def test_class_extra_decorators_frame_is_not_class(self):
         ast_node = builder.extract_node(

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -1853,6 +1853,25 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         not_method = next(instance.igetattr("not_method"))
         self.assertIsInstance(not_method, scoped_nodes.Lambda)
 
+    def test_instance_bound_method_lambdas_2(self):
+        ast_nodes = builder.extract_node(
+            """
+        class Test(object): #@
+            lam = lambda self: self
+            not_method = lambda xargs: xargs
+        Test() #@
+        """
+        )
+        cls = next(ast_nodes[0].infer())
+        self.assertIsInstance(next(cls.igetattr("lam")), scoped_nodes.Lambda)
+        self.assertIsInstance(next(cls.igetattr("not_method")), scoped_nodes.Lambda)
+
+        instance = next(ast_nodes[1].infer())
+        lam = next(instance.igetattr("lam"))
+        self.assertIsInstance(lam, BoundMethod)
+        not_method = next(instance.igetattr("not_method"))
+        self.assertIsInstance(not_method, scoped_nodes.Lambda)
+
     def test_class_extra_decorators_frame_is_not_class(self):
         ast_node = builder.extract_node(
             """

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -1859,7 +1859,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         a factory is well infered as a bound method (bug pylint 2594)
         """
         ast_nodes = builder.extract_node(
-        """
+            """
         def lambda_factory(): 
             return lambda self: print("Hello world")
 

--- a/astroid/tests/unittest_scoped_nodes.py
+++ b/astroid/tests/unittest_scoped_nodes.py
@@ -1854,6 +1854,10 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         self.assertIsInstance(not_method, scoped_nodes.Lambda)
 
     def test_instance_bound_method_lambdas_2(self):
+        """
+        Test the fact that a method which is a lambda built from 
+        a factory is well infered as a bound method (bug pylint 2594)
+        """
         ast_nodes = builder.extract_node(
         """
         def lambda_factory(): 


### PR DESCRIPTION
## Description
This PR fixes the PyCQA/pylint#2594. 
The problem arises in the `BaseInstance` class of the `astroid.bases` module in the method `_wrap_attr` at line 248. The test
```
if attr.statement().scope() == self._proxied:
```
failed, preventing the return of a `BoundMethod` instance.

Despite the fact that i'm uncomfortable with this, I deleted this test and all unit tests are ok. 
I added a unittest which makes sure that a method wich is a lambda built from a function is well infered as a `BoundMethod`.  

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Closes PyCQA/pylint#2594
