### PR TITLE
Added 2 more missing _ssl constants

### DIFF
--- a/astroid/brain/brain_ssl.py
+++ b/astroid/brain/brain_ssl.py
@@ -66,7 +66,7 @@ def ssl_transform():
     from _ssl import HAS_SNI, HAS_ECDH, HAS_NPN, HAS_ALPN
     from _ssl import _OPENSSL_API_VERSION
     from _ssl import PROTOCOL_SSLv23, PROTOCOL_TLSv1, PROTOCOL_TLSv1_1, PROTOCOL_TLSv1_2
-    from _ssl import PROTOCOL_TLS
+    from _ssl import PROTOCOL_TLS, PROTOCOL_TLS_CLIENT, PROTOCOL_TLS_SERVER
     """
     )
 


### PR DESCRIPTION
## Description
Adds 2 more missing _ssl constants which were introduced in Python 3.6.
These are designed to depreceate the protocols on the line above.

(Sorry if this isn't done right it is my first pull request)

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |