### PR TITLE
Optimize _is_python_file check

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -679,10 +679,7 @@ def _is_python_file(filename):
 
     .pyc and .pyo are ignored
     """
-    for ext in (".py", ".so", ".pyd", ".pyw"):
-        if filename.endswith(ext):
-            return True
-    return False
+    return filename.endswith((".py", ".so", ".pyd", ".pyw"))
 
 
 def _has_init(directory):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

This PR optimizes the `_is_python_file` method by checking against a tuple instead of looping over it, since `str.endswith` accepts a tuple.

Performance:
```
$ python -m timeit '"foobar.py".endswith((".py", ".so", ".pyd", ".pyw"))'
2000000 loops, best of 5: 138 nsec per loop
$ python -m timeit 'for ext in (".py", ".so", ".pyd", ".pyw"):' '    if "foobar.py".endswith(ext):' '        break'
2000000 loops, best of 5: 195 nsec per loop
$ python -m timeit 'for ext in (".py", ".so", ".pyd", ".pyw"):' '    if "foobar.so".endswith(ext):' '        break'
1000000 loops, best of 5: 330 nsec per loop
$ python -m timeit 'for ext in (".py", ".so", ".pyd", ".pyw"):' '    if "foobar.pyd".endswith(ext):' '        break'
500000 loops, best of 5: 474 nsec per loop
$ python -m timeit 'for ext in (".py", ".so", ".pyd", ".pyw"):' '    if "foobar.pyw".endswith(ext):' '        break'
500000 loops, best of 5: 620 nsec per loop
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
