### PR TITLE
Fix object_len infererence without context causing RecursionError

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,13 @@ Release Date: TBA
   Close PyCQA/pylint#2791
 
 
+* Fix recursion error involving ``len`` and self referential attributes
+
+  Close PyCQA/pylint#2736
+  Close PyCQA/pylint#2734
+  Close PyCQA/pylint#2740
+
+
 What's New in astroid 2.2.0?
 ============================
 Release Date: 2019-02-27

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -679,7 +679,7 @@ def infer_len(node, context=None):
         )
     [argument_node] = call.positional_arguments
     try:
-        return nodes.Const(helpers.object_len(argument_node))
+        return nodes.Const(helpers.object_len(argument_node, context=context))
     except (AstroidTypeError, InferenceError) as exc:
         raise UseInferenceDefault(str(exc)) from exc
 

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1652,6 +1652,26 @@ class TestLenBuiltinInference:
         except astroid.InferenceError:
             pass
 
+    def test_len_builtin_inference_recursion_error_self_referential_attribute(self):
+        """Make sure len calls do not trigger
+        recursion errors for self referential assignment
+
+        See https://github.com/PyCQA/pylint/issues/2734
+        """
+        code = """
+        class Data:
+            def __init__(self):
+                self.shape = []
+
+        data = Data()
+        data.shape = len(data.shape)
+        data.shape #@
+        """
+        try:
+            astroid.extract_node(code).inferred()
+        except RecursionError:
+            pytest.fail("Inference call should not trigger a recursion error")
+
 
 def test_infer_str():
     ast_nodes = astroid.extract_node(


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

The dropped context was causing RecursionErrors
in self referential assignment

Example:

    self.a = len(self.a)

There is a bigger problem of inference not understanding control flow
that this fix does not solve.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->


Close PyCQA/pylint#2736
Close PyCQA/pylint#2734
Close PyCQA/pylint#2740