### PR TITLE
backport: make is_standard_module() properly classify extensions (#659)

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -106,7 +106,7 @@ if os.name == 'posix':
         # https://github.com/PyCQA/pylint/issues/712#issuecomment-163178753
         STD_LIB_DIRS.add(_posix_path('lib64'))
 
-EXT_LIB_DIR = get_python_lib()
+EXT_LIB_DIRS = {get_python_lib(), get_python_lib(True)}
 IS_JYTHON = platform.python_implementation() == 'Jython'
 BUILTIN_MODULES = dict.fromkeys(sys.builtin_module_names, True)
 
@@ -542,8 +542,9 @@ def is_standard_module(modname, std_path=None):
         # we assume there are no namespaces in stdlib
         return not util.is_namespace(modname)
     filename = _normalize_path(filename)
-    if filename.startswith(_cache_normalize_path(EXT_LIB_DIR)):
-        return False
+    for path in EXT_LIB_DIRS:
+        if filename.startswith(_cache_normalize_path(path)):
+            return False
     if std_path is None:
         std_path = STD_LIB_DIRS
     for path in std_path:

--- a/astroid/tests/unittest_modutils.py
+++ b/astroid/tests/unittest_modutils.py
@@ -200,7 +200,7 @@ class StandardLibModuleTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_custom_path(self):
         datadir = resources.find('')
-        if datadir.startswith(modutils.EXT_LIB_DIR):
+        if any(datadir.startswith(p) for p in modutils.EXT_LIB_DIRS):
             self.skipTest('known breakage of is_standard_module on installed package')
 
         self.assertTrue(modutils.is_standard_module('data.module', (datadir,)))


### PR DESCRIPTION
Extensions can be installed in either a platform independent or specific
location[1]. The search is updated to include both paths. Previously, an
extension in the platform specific location would be misclassified because
only the independent location was considered and the platform specific location
shared a prefix with the standard lib.

[1] http://docs.python.org/3/distutils/apiref.html#distutils.sysconfig.get_python_lib

Fixes Issue: #658
Co-authored-by: Matt Story <s.matt.story@gmail.com>

(cherry picked from commit 70ed2cfd68e71a98697b1c13c337499732a801dc)

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ X] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
