### PR TITLE
Can access per argument type comments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,10 @@ Release Date: TBA
   Close PyCQA/pylint#2734
   Close PyCQA/pylint#2740
 
+* Can access per argument type comments through new ``Arguments.type_comment_args`` attribute.
+
+  Close #665
+
 
 What's New in astroid 2.2.0?
 ============================

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1425,6 +1425,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         "varargannotation",
         "kwargannotation",
         "kwonlyargs_annotations",
+        "type_comment_args",
     )
     varargannotation = None
     """The type annotation for the variable length arguments.
@@ -1499,6 +1500,15 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         :type: list(NodeNG)
         """
 
+        self.type_comment_args = []
+        """The type annotation, passed by a type comment, of each argument.
+
+        If an argument does not have a type comment,
+        the value for that argument will be None.
+
+        :type: list(NodeNG or None)
+        """
+
     def postinit(
         self,
         args,
@@ -1509,6 +1519,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         kwonlyargs_annotations=None,
         varargannotation=None,
         kwargannotation=None,
+        type_comment_args=None,
     ):
         """Do some setup after initialisation.
 
@@ -1543,6 +1554,10 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         :param kwargannotation: The type annotation for the variable length
             keyword arguments.
         :type kwargannotation: NodeNG
+
+        :param type_comment_args: The type annotation,
+            passed by a type comment, of each argument.
+        :type type_comment_args: list(NodeNG or None)
         """
         self.args = args
         self.defaults = defaults
@@ -1552,6 +1567,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         self.kwonlyargs_annotations = kwonlyargs_annotations
         self.varargannotation = varargannotation
         self.kwargannotation = kwargannotation
+        self.type_comment_args = type_comment_args
 
     def _infer_name(self, frame, name):
         if self.parent is frame:

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -220,6 +220,7 @@ class TreeRebuilder:
             kw_defaults = []
             annotations = []
             kwonlyargs_annotations = []
+        type_comment_args = [self.check_type_comment(child) for child in node.args]
 
         newnode.postinit(
             args=args,
@@ -230,6 +231,7 @@ class TreeRebuilder:
             kwonlyargs_annotations=kwonlyargs_annotations,
             varargannotation=varargannotation,
             kwargannotation=kwargannotation,
+            type_comment_args=type_comment_args,
         )
         # save argument names in locals:
         if vararg:


### PR DESCRIPTION
## Description

Adds a new `type_comment_args` attribute to `Arguments` nodes so that per argument type comments can be accessed:

```python
>>> import astroid
>>> func = astroid.extract_node('''
... def sum(
...         a,  # type: int
...         b,  # type: int
... ):
...     # type: (...) -> int
...     return a + b
... ''')
>>> func.args.type_comment_args
[<Name.int l.1 at 0x7ff60a46fd30>, <Name.int l.1 at 0x7ff60a46fda0>]
```

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue

Closes #665
