### PR TITLE
Fixed being unable to find distutils submodules by name when in a virtualenv

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -59,6 +59,9 @@ Release Date: TBA
 
   Close PyCQA/pylint#1628
 
+* Fixed being unable to find distutils submodules by name when in a virtualenv.
+
+  Close PyCQA/pylint#73
 
 What's New in astroid 2.2.0?
 ============================

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -8,6 +8,7 @@
 
 import abc
 import collections
+import distutils
 import enum
 import imp
 import os
@@ -145,6 +146,12 @@ class ImpFinder(Finder):
                 for p in sys.path
                 if os.path.isdir(os.path.join(p, *processed))
             ]
+        # We already import distutils elsewhere in astroid,
+        # so if it is the same module, we can use it directly.
+        elif spec.name == "distutils" and spec.location in distutils.__path__:
+            # distutils is patched inside virtualenvs to pick up submodules
+            # from the original Python, not from the virtualenv itself.
+            path = list(distutils.__path__)
         else:
             path = [spec.location]
         return path

--- a/astroid/tests/unittest_modutils.py
+++ b/astroid/tests/unittest_modutils.py
@@ -14,6 +14,7 @@
 """
 unit tests for module modutils (module manipulation utilities)
 """
+import distutils.version
 import email
 import os
 import sys
@@ -59,6 +60,10 @@ class ModuleFileTest(unittest.TestCase):
             found_spec.location.split(os.sep)[-3:],
             ["data", "MyPyPa-0.1.0-py2.5.egg", self.package],
         )
+
+    def test_find_distutils_submodules_in_virtualenv(self):
+        found_spec = spec.find_spec(["distutils", "version"])
+        self.assertEqual(found_spec.location, distutils.version.__file__)
 
 
 class LoadModuleFromNameTest(unittest.TestCase):


### PR DESCRIPTION
## Description
When in a virtualenv, distutils is patched to pick up submodules from the original Python and not from the virtualenv. This is done by prepending the location of the outside distutils to the `__path__` of the module.
Because astroid already uses distutils, it is already imported. Therefore we can use the already imported module to find what `__path__` should be, and use that to look for submodules.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes PyCQA/pylint#73