### PR TITLE
Fixed being unable to access class attributes on a NamedTuple

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,10 @@ Release Date: TBA
 
   Close #665
 
+* Fix being unable to access class attributes on a NamedTuple.
+
+  Close PyCQA/pylint#1628
+
 
 What's New in astroid 2.2.0?
 ============================

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -381,6 +381,15 @@ def infer_typing_namedtuple_class(class_node, context=None):
     generated_class_node = next(infer_named_tuple(node, context))
     for method in class_node.mymethods():
         generated_class_node.locals[method.name] = [method]
+
+    for assign in class_node.body:
+        if not isinstance(assign, nodes.Assign):
+            continue
+
+        for target in assign.targets:
+            attr = target.name
+            generated_class_node.locals[attr] = class_node.locals[attr]
+
     return iter((generated_class_node,))
 
 

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1006,6 +1006,7 @@ class TypingBrain(unittest.TestCase):
         from typing import NamedTuple
 
         class Example(NamedTuple):
+            CLASS_ATTR = "class_attr"
             mything: int
 
         Example(mything=1)
@@ -1013,6 +1014,11 @@ class TypingBrain(unittest.TestCase):
         )
         inferred = next(result.infer())
         self.assertIsInstance(inferred, astroid.Instance)
+
+        class_attr = inferred.getattr("CLASS_ATTR")[0]
+        self.assertIsInstance(class_attr, astroid.AssignName)
+        const = next(class_attr.infer())
+        self.assertEqual(const.value, "class_attr")
 
     def test_typing_types(self):
         ast_nodes = builder.extract_node(


### PR DESCRIPTION
## Description
In the case of an assignment to a NamedTuple without a type, the attribute becomes a class attribute.

```python
>>> from typing import NamedTuple
>>> class MyTuple(NamedTuple):
...     CLASS_ATTR = "class_attr"
...     instance_attr: str
...     default_attr: str = "default"
... 
>>> my_tuple = MyTuple("instance")
>>> my_tuple
MyTuple(instance_attr='instance', default_attr='default')
>>> my_tuple.CLASS_ATTR
'class_attr'
>>> MyTuple.CLASS_ATTR
'class_attr'
```

This pull request adds the copying of class attributes to subclasses of `NamedTuple` .

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Close PyCQA/pylint#1628