### PR TITLE
Fix finding of docstring under python3.8

### DIFF
--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -133,9 +133,11 @@ class TreeRebuilder:
             if (
                 node.body
                 and isinstance(node.body[0], self._parser_module.Expr)
-                and isinstance(node.body[0].value, self._parser_module.Str)
+                and isinstance(node.body[0].value,
+                               self._parser_module.Constant if PY38 else self._parser_module.Str)
             ):
-                doc = node.body[0].value.s
+                value = node.body[0].value
+                doc = value.value if PY38 else value.s
                 node.body = node.body[1:]
                 return node, doc
         except IndexError:


### PR DESCRIPTION
It is stored as a Constant, not a Str, so we get the value a bit differently.

Fixes one test failure in https://github.com/gristlabs/asttokens/issues/28.
