### PR TITLE
Fix non-existing pytest --pyarg option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
     ; installed astroid package
     ; This is important for tests' test data which create files
     ; inside the package
-    python -Wi {envsitepackagesdir}/coverage run -m pytest --pyarg astroid/tests {posargs:}
+    python -Wi {envsitepackagesdir}/coverage run -m pytest --pyargs astroid/tests {posargs:}
 
 [testenv:formatting]
 basepython = python3


### PR DESCRIPTION
Fixes a typo introduced in
18591e5e3e18026c770c48cbc044a77333231fc5

Without this fix I can't run tox locally, because pytest complains about an unknown option:

```
python -Wi /home/thomas/gitrepos/astroid/.tox/py38/lib/python3.8/site-packages/coverage run -m pytest --pyarg astroid/tests
ERROR: usage: pytest.py [options] [file_or_dir] [file_or_dir] [...]
pytest.py: error: unrecognized arguments: --pyarg
  inifile: /home/thomas/gitrepos/astroid/pytest.ini
  rootdir: /home/thomas/gitrepos/astroid
```

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
