### PR TITLE
Update method docstring

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in astroid 2.3.0?
 ============================
 Release Date: TBA
 
+* Updated `NodeNG.nodes_of_class` documentation to match actual usage.
+
 * Allow importing wheel files. Close #541
 
 * Annotated AST follows PEP8 coding style when converted to string.

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,8 +6,6 @@ What's New in astroid 2.3.0?
 ============================
 Release Date: TBA
 
-* Updated `NodeNG.nodes_of_class` documentation to match actual usage.
-
 * Allow importing wheel files. Close #541
 
 * Annotated AST follows PEP8 coding style when converted to string.

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -695,7 +695,7 @@ class NodeNG:
             subclasses of :attr:`klass`.
         :type skip_klass: builtins.type or tuple(builtins.type)
 
-        :returns: The node of the given type.
+        :returns: The node of the given types.
         :rtype: iterable(NodeNG)
         """
         if isinstance(self, klass):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -689,11 +689,11 @@ class NodeNG:
         """Get the nodes (including this one or below) of the given types.
 
         :param klass: The types of node to search for.
-        :type klass: builtins.type or tuple(builtin.type)
+        :type klass: builtins.type or tuple(builtins.type)
 
         :param skip_klass: The types of node to ignore. This is useful to ignore
             subclasses of :attr:`klass`.
-        :type skip_klass: builtins.type or tuple(builtin.type)
+        :type skip_klass: builtins.type or tuple(builtins.type)
 
         :returns: The node of the given type.
         :rtype: iterable(NodeNG)

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -686,14 +686,14 @@ class NodeNG:
         self.parent.set_local(name, stmt)
 
     def nodes_of_class(self, klass, skip_klass=None):
-        """Get the nodes (including this one or below) of the given type.
+        """Get the nodes (including this one or below) of the given types.
 
-        :param klass: The type of node to search for.
-        :type klass: builtins.type
+        :param klass: The types of node to search for.
+        :type klass: builtins.type or tuple(builtin.type)
 
-        :param skip_klass: A type of node to ignore. This is useful to ignore
+        :param skip_klass: The types of node to ignore. This is useful to ignore
             subclasses of :attr:`klass`.
-        :type skip_klass: builtins.type
+        :type skip_klass: builtins.type or tuple(builtin.type)
 
         :returns: The node of the given type.
         :rtype: iterable(NodeNG)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description
This PR updates the docstring of the `NodeNG.nodes_of_class` method found in `astroid.node_classes.py` to match the actual usage.

This method's actual docstring is: 
<img width="673" alt="Screen Shot 2019-08-25 at 5 09 23 PM" src="https://user-images.githubusercontent.com/18351436/63655842-26e4f000-c75b-11e9-8b08-b6261a057f9d.png">

In the docstring, the types for parameters `klass` and `skip_klass` only allow for one `node type`, however, due to nature of the implementation, it can actually support multiple node types (where the type of both parameters can also be a tuple of `builtins.type`). This kind of usage is already taking place in pylint's source code in the following places:

https://github.com/PyCQA/pylint/blob/6b3afd4f6d75debd7f286f0d3c760ed10ab1e79f/pylint/checkers/base.py#L268

https://github.com/PyCQA/pylint/blob/6b3afd4f6d75debd7f286f0d3c760ed10ab1e79f/pylint/checkers/base.py#L190

Updated Docstring:
<img width="691" alt="Screen Shot 2019-08-25 at 5 06 56 PM" src="https://user-images.githubusercontent.com/18351436/63655850-39f7c000-c75b-11e9-9d16-cb6ab4819df4.png">



## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
