### PR TITLE
Remove NodeNG.nearest method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,7 @@ What's New in astroid 2.3.0?
 ============================
 Release Date: TBA
 
-* Fixed NodeNG.nearest since it was not returning nodes that have a greater line number.
+* Remove NodeNG.nearest method because of lack of usage in astroid and pylint.
 
   Close #691
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in astroid 2.3.0?
 ============================
 Release Date: TBA
 
+* Fixed NodeNG.nearest since it was not returning nodes that have a greater line number.
+
 * Allow importing wheel files. Close #541
 
 * Annotated AST follows PEP8 coding style when converted to string.

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,8 @@ Release Date: TBA
 
 * Fixed NodeNG.nearest since it was not returning nodes that have a greater line number.
 
+  Close #691
+
 * Allow importing wheel files. Close #541
 
 * Annotated AST follows PEP8 coding style when converted to string.

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -579,34 +579,6 @@ class NodeNG:
         """
         return self.parent.previous_sibling()
 
-    def nearest(self, nodes):
-        """Get the node closest to this one from the given list of nodes.
-
-        :param nodes: The list of nodes to search. All of these nodes must
-            belong to the same module as this one. The list should be
-            sorted by the line number of the nodes, smallest first.
-        :type nodes: iterable(NodeNG)
-
-        :returns: The node closest to this one in the source code,
-            or None if one could not be found.
-        :rtype: NodeNG or None
-        """
-        myroot = self.root()
-        mylineno = self.fromlineno
-        nearest = None, 0
-        for node in nodes:
-            assert node.root() is myroot, (
-                "nodes %s and %s are not from the same module" % (self, node)
-            )
-            lineno = node.fromlineno
-            if lineno > mylineno:
-                if nearest[1] > 0 and lineno-mylineno >= mylineno-nearest[1]:
-                    break
-            if lineno > nearest[1]:
-                nearest = node, lineno
-        # FIXME: raise an exception if nearest is None ?
-        return nearest[0]
-
     # these are lazy because they're relatively expensive to compute for every
     # single node, and they rarely get looked at
 

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -599,8 +599,9 @@ class NodeNG:
                 "nodes %s and %s are not from the same module" % (self, node)
             )
             lineno = node.fromlineno
-            if node.fromlineno > mylineno:
-                break
+            if lineno > mylineno:
+                if nearest[1] > 0 and lineno-mylineno >= mylineno-nearest[1]:
+                    break
             if lineno > nearest[1]:
                 nearest = node, lineno
         # FIXME: raise an exception if nearest is None ?

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -1200,21 +1200,6 @@ def test_get_doc():
     assert node.doc is None
 
 
-def test_node_nearest():
-    src = """
-    print(before)
-    print(random)
-    print(middle)
-    print(after)
-    """
-    mod = astroid.parse(src)
-    before, random, middle, after = mod.body
-    assert before.nearest((middle, after)) is middle
-    assert middle.nearest((random, after)) is random
-    assert middle.nearest((before, after)) is after
-    assert random.nearest((before, after)) is before
-
-
 @test_utils.require_version(minver="3.8")
 def test_parse_fstring_debug_mode():
     node = astroid.extract_node('f"{3=}"')

--- a/astroid/tests/unittest_nodes.py
+++ b/astroid/tests/unittest_nodes.py
@@ -1200,6 +1200,21 @@ def test_get_doc():
     assert node.doc is None
 
 
+def test_node_nearest():
+    src = """
+    print(before)
+    print(random)
+    print(middle)
+    print(after)
+    """
+    mod = astroid.parse(src)
+    before, random, middle, after = mod.body
+    assert before.nearest((middle, after)) is middle
+    assert middle.nearest((random, after)) is random
+    assert middle.nearest((before, after)) is after
+    assert random.nearest((before, after)) is before
+
+
 @test_utils.require_version(minver="3.8")
 def test_parse_fstring_debug_mode():
     node = astroid.extract_node('f"{3=}"')


### PR DESCRIPTION
EDIT:
Based on the discussion on #691, we have decided to remove the `NodeNG.nearest` method instead of fixing it.

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description
The `NodeNG.nearest` method was not working properly as outlined in #691 and so this PR is a fix to the method.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Closes #691 