### PR TITLE
Allow annotated assign with attrs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -116,6 +116,10 @@ Release Date: TBA
 
   Close PyCQA/pylint#73
 
+* Update attr brain to partly understand annotated attributes
+
+  Close #656
+
 What's New in astroid 2.2.0?
 ============================
 Release Date: 2019-02-27

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -44,7 +44,11 @@ def attr_attributes_transform(node):
                 continue
         else:
             continue
-        targets = cdefbodynode.targets if hasattr(cdefbodynode, "targets") else [cdefbodynode.target]
+        targets = (
+            cdefbodynode.targets
+            if hasattr(cdefbodynode, "targets")
+            else [cdefbodynode.target]
+        )
         for target in targets:
 
             rhs_node = astroid.Unknown(

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -37,14 +37,15 @@ def attr_attributes_transform(node):
     node.locals["__attrs_attrs__"] = [astroid.Unknown(parent=node)]
 
     for cdefbodynode in node.body:
-        if not isinstance(cdefbodynode, astroid.Assign):
+        if not isinstance(cdefbodynode, (astroid.Assign, astroid.AnnAssign)):
             continue
         if isinstance(cdefbodynode.value, astroid.Call):
             if cdefbodynode.value.func.as_string() not in ATTRIB_NAMES:
                 continue
         else:
             continue
-        for target in cdefbodynode.targets:
+        targets = cdefbodynode.targets if hasattr(cdefbodynode, "targets") else [cdefbodynode.target]
+        for target in targets:
 
             rhs_node = astroid.Unknown(
                 lineno=cdefbodynode.lineno,
@@ -52,6 +53,7 @@ def attr_attributes_transform(node):
                 parent=cdefbodynode,
             )
             node.locals[target.name] = [rhs_node]
+            node.instance_attrs[target.name] = [rhs_node]
 
 
 MANAGER.register_transform(

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1189,6 +1189,7 @@ class AttrsTest(unittest.TestCase):
         # Prevents https://github.com/PyCQA/pylint/issues/1884
         assert isinstance(attr_node, nodes.Unknown)
 
+    @test_utils.require_version(minver="3.6")
     def test_attrs_with_annotation(self):
         code = """
         import attr

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1159,6 +1159,20 @@ class AttrsTest(unittest.TestCase):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
+    def test_dont_consider_assignments_but_without_attrs(self):
+        code = """
+        import attr
+
+        class Cls: pass
+        @attr.s
+        class Foo:
+            temp = Cls()
+            temp.prop = 5
+            bar_thing = attr.ib(default=temp)
+        Foo()
+        """
+        next(astroid.extract_node(code).infer())
+
     def test_special_attributes(self):
         """Make sure special attrs attributes exist"""
 
@@ -1175,19 +1189,17 @@ class AttrsTest(unittest.TestCase):
         # Prevents https://github.com/PyCQA/pylint/issues/1884
         assert isinstance(attr_node, nodes.Unknown)
 
-    def test_dont_consider_assignments_but_without_attrs(self):
+    def test_attrs_with_annotation(self):
         code = """
         import attr
 
-        class Cls: pass
         @attr.s
         class Foo:
-            temp = Cls()
-            temp.prop = 5
-            bar_thing = attr.ib(default=temp)
+            bar: int = attr.ib(default=5)
         Foo()
         """
-        next(astroid.extract_node(code).infer())
+        should_be_unknown = next(astroid.extract_node(code).infer()).getattr("bar")[0]
+        self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
 
 class RandomSampleTest(unittest.TestCase):

--- a/astroid/tests/unittest_brain.py
+++ b/astroid/tests/unittest_brain.py
@@ -1159,20 +1159,6 @@ class AttrsTest(unittest.TestCase):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
-    def test_dont_consider_assignments_but_without_attrs(self):
-        code = """
-        import attr
-
-        class Cls: pass
-        @attr.s
-        class Foo:
-            temp = Cls()
-            temp.prop = 5
-            bar_thing = attr.ib(default=temp)
-        Foo()
-        """
-        next(astroid.extract_node(code).infer())
-
     def test_special_attributes(self):
         """Make sure special attrs attributes exist"""
 
@@ -1188,6 +1174,20 @@ class AttrsTest(unittest.TestCase):
         [attr_node] = foo_inst.getattr("__attrs_attrs__")
         # Prevents https://github.com/PyCQA/pylint/issues/1884
         assert isinstance(attr_node, nodes.Unknown)
+
+    def test_dont_consider_assignments_but_without_attrs(self):
+        code = """
+        import attr
+
+        class Cls: pass
+        @attr.s
+        class Foo:
+            temp = Cls()
+            temp.prop = 5
+            bar_thing = attr.ib(default=temp)
+        Foo()
+        """
+        next(astroid.extract_node(code).infer())
 
     @test_utils.require_version(minver="3.6")
     def test_attrs_with_annotation(self):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Update attrs brain to naively support annotated assigns as well (relates to #656). Annotated assigns are different astroid class.
Moreover every attr.ib() creates new instance attribute - let add it. (the class level attributes shall be deleted but it would produce "attribute-defined-outside-init" so I left it there).

The attr library in fact builds the `__init__` function with assignments to `self.given_attribute` and _deletes_ the original class level attributes. If I understand well, the best solution would be to synthetise such `__init__` function instead of writing node.locals (what is moreover wrong I think) or node.instance_attrs. If you have a good example how to do it, I can try to do something simple. But in another branch obviously.

Any feedback is welcome, thank you.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
Closes #656
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
