### PR TITLE
Fix ClassDef.as_string() with keyword arguments, especially the metaclass

### DIFF
--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -153,20 +153,16 @@ class AsStringVisitor:
     def visit_classdef(self, node):
         """return an astroid.ClassDef node as string"""
         decorate = node.decorators.accept(self) if node.decorators else ""
-        bases = ", ".join(n.accept(self) for n in node.bases)
-        metaclass = node.metaclass()
-        if metaclass and not node.has_metaclass_hack():
-            if bases:
-                bases = "(%s, metaclass=%s)" % (bases, metaclass.name)
-            else:
-                bases = "(metaclass=%s)" % metaclass.name
-        else:
-            bases = "(%s)" % bases if bases else ""
+        args = [n.accept(self) for n in node.bases]
+        if node._metaclass and not node.has_metaclass_hack():
+            args.append("metaclass=" + node._metaclass.accept(self))
+        args += [n.accept(self) for n in node.keywords]
+        args = "(%s)" % ", ".join(args) if args else ""
         docs = self._docs_dedent(node.doc) if node.doc else ""
         return "\n\n%sclass %s%s:%s\n%s\n" % (
             decorate,
             node.name,
-            bases,
+            args,
             docs,
             self._stmt_list(node.body),
         )

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -220,6 +220,32 @@ if all[1] == bord[0:]:
         assert pre_repr == post_repr
         assert pre.as_string().strip() == code.strip()
 
+    def test_class_def(self):
+        code = """
+import abc
+
+
+class A:
+    pass
+
+
+
+class B(metaclass=A, x=1):
+    pass
+
+
+
+class C(B):
+    pass
+
+
+
+class D(metaclass=abc.ABCMeta):
+    pass
+"""
+        ast = abuilder.string_build(code)
+        self.assertEqual(ast.as_string().strip(), code.strip())
+
 
 class _NodeTest(unittest.TestCase):
     """test transformation of If Node"""


### PR DESCRIPTION
This is about ensuring that `ClassDef.as_string()` produces code with same structure as the input. I'm starting this PR with a failing test to demo the issues, will push a fix shortly. Here is the relevant diff from the test:

```diff
- class B(metaclass=A):
+ class B(metaclass=A, x=1):
?                    +++++
      pass
  
  
  
- class C(B, metaclass=A):
+ class C(B):
      pass
  
  
  
- class D(metaclass=ABCMeta):
+ class D(metaclass=abc.ABCMeta):
?                   ++++
      pass
```

This shows that the current code:

1. Doesn't include other keyword arguments
2. Adds a `metaclass=` argument when the metaclass is implicitly inherited
3. Converts an attribute to a node.

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Closes #705 