### PR TITLE
Fix as_string for f-strings

### DIFF
--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -593,14 +593,11 @@ class AsStringVisitor3(AsStringVisitor):
             # But strip the quotes off the ends
             # (they will always be one character: ' or ")
             repr(value.value)[1:-1]
-
             # Literal braces must be doubled to escape them
-            .replace('{', '{{').replace('}', '}}')
-
+            .replace("{", "{{").replace("}", "}}")
             # Each value in values is either a string literal (Const)
             # or a FormattedValue
-            if type(value).__name__ == "Const"
-            else value.accept(self)
+            if type(value).__name__ == "Const" else value.accept(self)
             for value in node.values
         )
 
@@ -611,7 +608,7 @@ class AsStringVisitor3(AsStringVisitor):
             if quote not in string:
                 break
 
-        return 'f' + quote + string + quote
+        return "f" + quote + string + quote
 
     def visit_formattedvalue(self, node):
         result = node.value.accept(self)

--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -587,16 +587,42 @@ class AsStringVisitor3(AsStringVisitor):
         return "async %s" % self.visit_for(node)
 
     def visit_joinedstr(self, node):
-        # Special treatment for constants,
-        # as we want to join literals not reprs
         string = "".join(
-            value.value if type(value).__name__ == "Const" else value.accept(self)
+            # Use repr on the string literal parts
+            # to get proper escapes, e.g. \n, \\, \"
+            # But strip the quotes off the ends
+            # (they will always be one character: ' or ")
+            repr(value.value)[1:-1]
+
+            # Literal braces must be doubled to escape them
+            .replace('{', '{{').replace('}', '}}')
+
+            # Each value in values is either a string literal (Const)
+            # or a FormattedValue
+            if type(value).__name__ == "Const"
+            else value.accept(self)
             for value in node.values
         )
-        return "f'%s'" % string
+
+        # Try to find surrounding quotes that don't appear at all in the string.
+        # Because the formatted values inside {} can't contain backslash (\)
+        # using a triple quote is sometimes necessary
+        for quote in ["'", '"', '"""', "'''"]:
+            if quote not in string:
+                break
+
+        return 'f' + quote + string + quote
 
     def visit_formattedvalue(self, node):
-        return "{%s}" % node.value.accept(self)
+        result = node.value.accept(self)
+        if node.conversion and node.conversion >= 0:
+            # e.g. if node.conversion == 114: result += "!r"
+            result += "!" + chr(node.conversion)
+        if node.format_spec:
+            # The format spec is itself a JoinedString, i.e. an f-string
+            # We strip the f and quotes of the ends
+            result += ":" + node.format_spec.accept(self)[2:-1]
+        return "{%s}" % result
 
     def visit_comprehension(self, node):
         """return an astroid.Comprehension node as string"""

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1233,7 +1233,7 @@ def test_get_doc():
 def test_parse_fstring_debug_mode():
     node = astroid.extract_node('f"{3=}"')
     assert isinstance(node, nodes.JoinedStr)
-    assert node.as_string() == "f'3={3}'"
+    assert node.as_string() == "f'3={3!r}'"
 
 
 @pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -246,6 +246,21 @@ class D(metaclass=abc.ABCMeta):
         ast = abuilder.string_build(code)
         self.assertEqual(ast.as_string().strip(), code.strip())
 
+    @pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="needs f-string support")
+    def test_f_strings(self):
+        code = r'''
+a = f"{'a'}"
+b = f'{{b}}'
+c = f""" "{'c'}" """
+d = f'{d!r} {d!s} {d!a}'
+e = f'{e:.3}'
+f = f'{f:{x}.{y}}'
+n = f'\n'
+everything = f""" " \' \r \t \\ {{ }} {'x' + x!r:a} {["'"]!s:{a}}"""
+'''
+        ast = abuilder.string_build(code)
+        self.assertEqual(ast.as_string().strip(), code.strip())
+
 
 class _NodeTest(unittest.TestCase):
     """test transformation of If Node"""


### PR DESCRIPTION
:bug: Bug fix

as_string currently has very poor support for f-strings:

1. Conversions (e.g. `!r`) and format specifiers (e.g. `:.3`) are left out.
2. Quotes easily clash leading to syntax errors.
3. Escape sequences such as `\n` are not handled.
4. Literal braces are not escaped.

Here is the diff from the new test without the fixes:

```diff
- a = f'{'a'}'
?      ^     ^
+ a = f"{'a'}"
?      ^     ^
- b = f'{b}'
+ b = f'{{b}}'
?        + +
- c = f' "{'c'}" '
?      ^         ^
+ c = f""" "{'c'}" """
?      ^^^         ^^^
- d = f'{d} {d} {d}'
+ d = f'{d!r} {d!s} {d!a}'
?         ++    ++    ++
- e = f'{e}'
+ e = f'{e:.3}'
?         +++
- f = f'{f}'
+ f = f'{f:{x}.{y}}'
- n = f'
+ n = f'\n'
?       +++
+ everything = f""" " \' \r \t \\ {{ }} {'x' + x!r:a} {["'"]!s:{a}}"""- '
-  	 \ { } {'x' + x} {["'"]}'
``` 