### PR TITLE
Fix as_string for attribute nodes with integer values

### DIFF
--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -327,7 +327,10 @@ class AsStringVisitor:
 
     def visit_attribute(self, node):
         """return an astroid.Getattr node as string"""
-        return "%s.%s" % (self._precedence_parens(node, node.expr), node.attrname)
+        left = self._precedence_parens(node, node.expr)
+        if left.isdigit():  # TODO
+            left = "(%s)" % left
+        return "%s.%s" % (left, node.attrname)
 
     def visit_global(self, node):
         """return an astroid.Global node as string"""

--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -328,7 +328,7 @@ class AsStringVisitor:
     def visit_attribute(self, node):
         """return an astroid.Getattr node as string"""
         left = self._precedence_parens(node, node.expr)
-        if left.isdigit():  # TODO
+        if left.isdigit():
             left = "(%s)" % left
         return "%s.%s" % (left, node.attrname)
 

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -200,6 +200,14 @@ if all[1] == bord[0:]:
         ast = abuilder.string_build(code)
         self.assertEqual(ast.as_string(), code)
 
+    def test_int_attribute(self):
+        code = """
+x = (-3).real
+y = (3).imag
+        """
+        ast = abuilder.string_build(code)
+        self.assertEqual(ast.as_string().strip(), code.strip())
+
     def test_operator_precedence(self):
         with open(resources.find("data/operator_precedence.py")) as f:
             for code in f:


### PR DESCRIPTION
:bug: Bug fix

This PR fixes as_string producing invalid syntax like `3.real` (similar code exists in the standard library).