### PR TITLE
Add brain for "responses"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in astroid 2.4.0?
 Release Date: TBA
 
 * Added transform for ``scipy.gaussian``
+* Added a brain for ``responses``
+
 
 What's New in astroid 2.3.2?
 ============================

--- a/astroid/brain/brain_responses.py
+++ b/astroid/brain/brain_responses.py
@@ -70,4 +70,4 @@ def responses_funcs():
     )
 
 
-astroid.register_module_extender(astroid.MANAGER, 'responses', responses_funcs)
+astroid.register_module_extender(astroid.MANAGER, "responses", responses_funcs)

--- a/astroid/brain/brain_responses.py
+++ b/astroid/brain/brain_responses.py
@@ -1,0 +1,73 @@
+"""
+Astroid hooks for responses.
+
+It might need to be manually updated from the public methods of
+:class:`responses.RequestsMock`.
+
+See: https://github.com/getsentry/responses/blob/master/responses.py
+
+"""
+import astroid
+
+
+def responses_funcs():
+    return astroid.parse(
+        """
+        DELETE = "DELETE"
+        GET = "GET"
+        HEAD = "HEAD"
+        OPTIONS = "OPTIONS"
+        PATCH = "PATCH"
+        POST = "POST"
+        PUT = "PUT"
+        response_callback = None
+
+        def reset():
+            return
+
+        def add(
+            method=None,  # method or ``Response``
+            url=None,
+            body="",
+            adding_headers=None,
+            *args,
+            **kwargs
+        ):
+            return
+
+        def add_passthru(prefix):
+            return
+
+        def remove(method_or_response=None, url=None):
+            return
+
+        def replace(method_or_response=None, url=None, body="", *args, **kwargs):
+            return
+
+        def add_callback(
+            method, url, callback, match_querystring=False, content_type="text/plain"
+        ):
+            return
+
+        calls = []
+
+        def __enter__():
+            return
+
+        def __exit__(type, value, traceback):
+            success = type is None
+            return success
+
+        def activate(func):
+            return func
+
+        def start():
+            return
+
+        def stop(allow_assert=True):
+            return
+        """
+    )
+
+
+astroid.register_module_extender(astroid.MANAGER, 'responses', responses_funcs)


### PR DESCRIPTION
Fixes: #716

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

[Responses](https://github.com/getsentry/responses/) exposes the “public” methods of `responses.RequestsMock` as module level functions.  Astroid cannot pick those up automatically. This brains adds their stubs.  It may need to be updated from time to time, when reponses changes.

## Type of Changes

| ✓  | :sparkles: New feature |

## Related Issue

Closes #716

