### PR TITLE
Make pytest-runner a requirement with test only targets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,12 @@ Release Date: TBA
 
   Close PyCQA/pylint#3216
 
+* Clean up setup.py
+
+  Make pytest-runner a requirement only if running tests, similar to what was
+  done with McCabe.
+
+  Clean up the setup.py file, resolving a handful of minor warnings with it.
 
 What's New in astroid 2.3.2?
 ============================

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,12 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
 
-# pylint: disable=W0404,W0622,W0704,W0613
+# pylint: disable=W0404,W0622,W0613
 """Setup script for astroid."""
 import os
-from setuptools import setup, find_packages
-from setuptools.command import easy_install
-from setuptools.command import install_lib
-
+from setuptools import find_packages, setup
+from setuptools.command import easy_install  # pylint: disable=unused-import
+from setuptools.command import install_lib  # pylint: disable=unused-import
 
 real_path = os.path.realpath(__file__)
 astroid_dir = os.path.dirname(real_path)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # pylint: disable=W0404,W0622,W0613
 """Setup script for astroid."""
 import os
+import sys
 from setuptools import find_packages, setup
 from setuptools.command import easy_install  # pylint: disable=unused-import
 from setuptools.command import install_lib  # pylint: disable=unused-import
@@ -26,6 +27,9 @@ with open(pkginfo, "rb") as fobj:
 with open(os.path.join(astroid_dir, "README.rst")) as fobj:
     long_description = fobj.read()
 
+
+needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 def install():
     return setup(
@@ -42,7 +46,7 @@ def install():
         install_requires=install_requires,
         extras_require=extras_require,
         packages=find_packages() + ["astroid.brain"],
-        setup_requires=["pytest-runner"],
+        setup_requires=pytest_runner,
         test_suite="test",
         tests_require=["pytest"],
     )


### PR DESCRIPTION
## Description

The primary goal of this change was to remove an explicit requirement on pytest-runner for building/installing astroid, as it is only required when running tests. This change is similar to what was done in the McCabe project, starting with [PyCQA/mccabe@cf1c36f84](https://github.com/PyCQA/mccabe/commit/cf1c36f842e252b8efd9e8fe853584ce69020b7f).

While here, fix a variety of pylint warnings with `setup.py` that were being omitted with the latest copy of pylint.

Finally, add an entry to the ChangeLog for the change.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

This is loosely related to similar work I did with https://github.com/PyCQA/pylint/pull/3243 .