### PR TITLE
Don't collect testdata

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["testdata"]


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This fixes the current test failures in master:

```
============================= test session starts ==============================
platform linux -- Python 3.8.0, pytest-5.2.3, py-1.8.0, pluggy-0.13.0
rootdir: /build/python-astroid/src/astroid-astroid-2.3.3, inifile: pytest.ini
collected 905 items / 2 errors / 903 selected

==================================== ERRORS ====================================
____ ERROR collecting astroid/tests/testdata/python2/data/SSL1/__init__.py _____
ImportError while importing test module '/build/python-astroid/src/astroid-astroid-2.3.3/astroid/tests/testdata/python2/data/SSL1/__init__.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
astroid/tests/testdata/python2/data/SSL1/__init__.py:1: in <module>
    from Connection1 import Connection
E   ModuleNotFoundError: No module named 'Connection1'
____ ERROR collecting astroid/tests/testdata/python3/data/SSL1/__init__.py _____
ImportError while importing test module '/build/python-astroid/src/astroid-astroid-2.3.3/astroid/tests/testdata/python3/data/SSL1/__init__.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
astroid/tests/testdata/python2/data/SSL1/__init__.py:1: in <module>
    from Connection1 import Connection
E   ModuleNotFoundError: No module named 'Connection1'
=============================== warnings summary ===============================
astroid/interpreter/_import/spec.py:13
  /build/python-astroid/src/astroid-astroid-2.3.3/astroid/interpreter/_import/spec.py:13: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 warnings, 2 error in 1.41s =========================
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
