### PR TITLE
Avoid a call to `getcwd` if it is not needed

### DIFF
--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -128,8 +128,8 @@ class AstroidManager:
             return self.astroid_cache[modname]
         if modname == "__main__":
             return self._build_stub_module(modname)
-        old_cwd = os.getcwd()
         if context_file:
+            old_cwd = os.getcwd()
             os.chdir(os.path.dirname(context_file))
         try:
             found_spec = self.file_from_module_name(modname, context_file)
@@ -183,7 +183,8 @@ class AstroidManager:
                     pass
             raise e
         finally:
-            os.chdir(old_cwd)
+            if context_file:
+                os.chdir(old_cwd)
 
     def zip_import_data(self, filepath):
         if zipimport is None:


### PR DESCRIPTION
## Description

When profiling locally, approximately 7% of a full pylint run is spent in `os.getcwd` (within `ast_from_module_name`).

This result is not actually used in cases where the `context_file` parameter is set to `None`, though (or rather, a no-op directory change gets sent in).

A quick grep over this project and others seem to indicate that `context_file` is rarely used, so this should almost entirely get rid of this system call. Local profiling seems to indicate this.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: Performance fix  |
