### PR TITLE
brain_gi: Don't ignore special methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.4.0?
 ============================
 Release Date: TBA
 
+* Don't ignore special methods when inspecting gi classes
+
+  Close #728
+
 * Added transform for ``scipy.gaussian``
 
 * Added a brain for ``responses``

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -29,6 +29,36 @@ _inspected_modules = {}
 
 _identifier_re = r"^[A-Za-z_]\w*$"
 
+_special_methods = frozenset(
+    {
+        "__lt__",
+        "__le__",
+        "__eq__",
+        "__ne__",
+        "__ge__",
+        "__gt__",
+        "__iter__",
+        "__getitem__",
+        "__setitem__",
+        "__delitem__",
+        "__len__",
+        "__bool__",
+        "__nonzero__",
+        "__next__",
+        "__str__",
+        "__len__",
+        "__contains__",
+        "__enter__",
+        "__exit__",
+        "__repr__",
+        "__getattr__",
+        "__setattr__",
+        "__delattr__",
+        "__del__",
+        "__hash__",
+    }
+)
+
 
 def _gi_build_stub(parent):
     """
@@ -40,7 +70,7 @@ def _gi_build_stub(parent):
     constants = {}
     methods = {}
     for name in dir(parent):
-        if name.startswith("__"):
+        if name.startswith("__") and name not in _special_methods:
             continue
 
         # Check if this is a valid name in python


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

brain_gi iterates over all gi classes imported via gi.repository and builds source code from it which astroid afterwards can use to infer properties.

For some reason it explicitly leaves out all magic methods, which leads to astroid not being able to detect all properties, e.g. that objects are iterable or subscriptable


## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

https://gitlab.gnome.org/GNOME/pygobject/issues/361

Closes #728 

