### PR TITLE
Add support for inferring properties

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,8 @@ Release Date: TBA
 
 * Added transform for ``scipy.gaussian``
 
+* Add suport for inferring properties.
+
 * Added a brain for ``responses``
 
 * Allow inferring positional only arguments.

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -58,13 +58,12 @@ POSSIBLE_PROPERTIES = {
 }
 
 
-def _is_property(meth):
-    if PROPERTIES.intersection(meth.decoratornames()):
+def _is_property(meth, context=None):
+    decoratornames = meth.decoratornames(context=context)
+    if PROPERTIES.intersection(decoratornames):
         return True
     stripped = {
-        name.split(".")[-1]
-        for name in meth.decoratornames()
-        if name is not util.Uninferable
+        name.split(".")[-1] for name in decoratornames if name is not util.Uninferable
     }
     if any(name in stripped for name in POSSIBLE_PROPERTIES):
         return True
@@ -73,7 +72,7 @@ def _is_property(meth):
     if not meth.decorators:
         return False
     for decorator in meth.decorators.nodes or ():
-        inferred = helpers.safe_infer(decorator)
+        inferred = helpers.safe_infer(decorator, context=context)
         if inferred is None or inferred is util.Uninferable:
             continue
         if inferred.__class__.__name__ == "ClassDef":

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -735,3 +735,48 @@ class DictModel(ObjectModel):
 
         obj = objects.DictValues(obj)
         return self._generic_dict_attribute(obj, "values")
+
+
+class PropertyModel(ObjectModel):
+    """Model for a builtin property"""
+
+    # pylint: disable=import-outside-toplevel
+    @property
+    def attr_fget(self):
+        from astroid.scoped_nodes import FunctionDef
+
+        func = self._instance
+
+        class PropertyFuncAccessor(FunctionDef):
+            def infer_call_result(self, caller=None, context=None):
+                nonlocal func
+                if caller and len(caller.args) != 1:
+                    raise exceptions.InferenceError(
+                        "fget() needs a single argument", target=self, context=context
+                    )
+
+                yield from func.function.infer_call_result(
+                    caller=caller, context=context
+                )
+
+        return PropertyFuncAccessor(name="fget", parent=self._instance)
+
+    @property
+    def attr_setter(self):
+        from astroid.scoped_nodes import FunctionDef
+
+        return FunctionDef(name="setter", parent=self._instance)
+
+    @property
+    def attr_deleter(self):
+        from astroid.scoped_nodes import FunctionDef
+
+        return FunctionDef(name="deleter", parent=self._instance)
+
+    @property
+    def attr_getter(self):
+        from astroid.scoped_nodes import FunctionDef
+
+        return FunctionDef(name="getter", parent=self._instance)
+
+    # pylint: enable=import-outside-toplevel

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -464,7 +464,7 @@ def _infer_context_manager(self, mgr, context):
             )
 
         for decorator_node in func.decorators.nodes:
-            decorator = next(decorator_node.infer(context))
+            decorator = next(decorator_node.infer(context=context))
             if isinstance(decorator, nodes.FunctionDef):
                 if decorator.qname() == _CONTEXTLIB_MGR:
                     break

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -273,7 +273,7 @@ def test():
         """
         )
         inferred = next(node.infer())
-        self.assertEqual(inferred.decoratornames(), set())
+        self.assertEqual(inferred.decoratornames(), {".Parent.foo.getter"})
 
     def test_ssl_protocol(self):
         node = extract_node(

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -29,7 +29,7 @@ from functools import partial
 import unittest
 
 import pytest
-from astroid import builder
+from astroid import builder, objects
 from astroid import nodes
 from astroid import scoped_nodes
 from astroid import util
@@ -1730,7 +1730,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         #   from the class that uses the metaclass, the value
         #   of the property
         property_meta = next(module["Metaclass"].igetattr("meta_property"))
-        self.assertIsInstance(property_meta, UnboundMethod)
+        self.assertIsInstance(property_meta, objects.Property)
         wrapping = scoped_nodes.get_wrapping_class(property_meta)
         self.assertEqual(wrapping, module["Metaclass"])
 


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
These new capabilities will allow inferring both the `property` builtin
as well as property attributes such as  `.deleter` and `.setter`.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
