### PR TITLE
Handle StopIteration error in infer_int.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -69,6 +69,10 @@ Release Date: TBA
 
   Clean up the setup.py file, resolving a handful of minor warnings with it.
 
+* Handle StopIteration error in infer_int.
+
+  Close PyCQA/pylint#3274
+
 What's New in astroid 2.3.2?
 ============================
 Release Date: TBA

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -743,7 +743,7 @@ def infer_int(node, context=None):
     if call.positional_arguments:
         try:
             first_value = next(call.positional_arguments[0].infer(context=context))
-        except InferenceError as exc:
+        except (InferenceError, StopIteration) as exc:
             raise UseInferenceDefault(str(exc)) from exc
 
         if first_value is util.Uninferable:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4928,6 +4928,24 @@ def test_regression_infinite_loop_decorator():
     assert result.value == 1
 
 
+def test_stop_iteration_in_int():
+    """Handle StopIteration error in infer_int."""
+    code = """
+    def f(lst):
+        if lst[0]:
+            return f(lst)
+        else:
+            args = lst[:1]
+            return int(args[0])
+
+    f([])
+    """
+    [first_result, second_result] = extract_node(code).inferred()
+    assert first_result is util.Uninferable
+    assert isinstance(second_result, Instance)
+    assert second_result.name == "int"
+
+
 def test_call_on_instance_with_inherited_dunder_call_method():
     """Stop inherited __call__ method from incorrectly returning wrong class
 


### PR DESCRIPTION
## Steps

- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

This fixes https://github.com/PyCQA/pylint/issues/3274. Prior to Python 3.7, `StopIteration` errors bubbled up through generators, so this wasn't an issue for astroid because the `StopIteration` error was handled later. Now `StopIteration` errors are converted to `RuntimeError`s ([PEP 479]), so the same error handling doesn't work.

**Note**: based on the above issue, I was able to come up with a minimal code example where calling `.inferred()` raises an error on Python 3.7+ (see the test I added), but I wasn't actually able to determine out *why* a `StopIteration` error occurred at all. I'm not familiar enough with astroid's inference to tell whether raising `StopIteration` is the intended behaviour or not, so there might be a better fix.

[PEP 479]: https://www.python.org/dev/peps/pep-0479/

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
