### PR TITLE
Make use of cache while transform builtin containers

### DIFF
--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5502,5 +5502,19 @@ def test_property_callable_inference():
     assert inferred.value == 42
 
 
+def test_recursion_error_inferring_builtin_containers():
+    node = extract_node(
+        """
+    class Foo:
+        a = "foo"
+    inst = Foo()
+
+    b = tuple([inst.a]) #@
+    inst.a = b
+    """
+    )
+    helpers.safe_infer(node.targets[0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->


## Description
As of now, the transformation of builtin containers which
members, in turn, are containers relies on `safe_infer`
helper. `safe_infer` tries to infer the node to get its
values. Doing this without a cache containing a previously
inferred nodes lead to infinite recursion, for example, on
resolving a class attribute.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
Closes https://github.com/PyCQA/pylint/issues/3245
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:


-->
