### PR TITLE
Bug 666

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in astroid 2.4.0?
 ============================
 Release Date: TBA
 
+* Added a call to ``register_transform`` for all functions of the ``brain_numpy_core_multiarray``
+  module in case the current node is an instance of ``astroid.Name``
+
+  Close #666
+
 * Added some functions of the ``numpy.core.multiarray`` module
 
   Close PyCQA/pylint#3208

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -10,7 +10,10 @@ import functools
 import astroid
 from brain_numpy_utils import infer_numpy_member
 
-
+# None is present inside the inferred values of the call to sum function because
+# the variable out in the sum function is not correctly inferred.
+# This module is here to help astroid to determine the exact type of this variable and
+# thus to infer correctly the result of the call to sum function (i.e without None in the inferred values).
 def looks_like_out_name_in_numpy_sum(member_name: str, node: astroid.node_classes.NodeNG) -> bool:
     if (isinstance(node, astroid.Name)
         and node.name == "out"

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -11,16 +11,21 @@ import astroid
 from brain_numpy_utils import infer_numpy_member
 
 # None is present inside the inferred values of the call to sum function because
-# the variable out in the sum function is not correctly inferred.
+#  the variable out in the sum function is not correctly inferred.
 # This module is here to help astroid to determine the exact type of this variable and
 # thus to infer correctly the result of the call to sum function (i.e without None in the inferred values).
-def looks_like_out_name_in_numpy_sum(member_name: str, node: astroid.node_classes.NodeNG) -> bool:
-    if (isinstance(node, astroid.Name)
+def looks_like_out_name_in_numpy_sum(
+    member_name: str, node: astroid.node_classes.NodeNG
+) -> bool:
+    if (
+        isinstance(node, astroid.Name)
         and node.name == "out"
         and node.frame().name == "sum"
-        and node.frame().parent.name.startswith('numpy')):
+        and node.frame().parent.name.startswith("numpy")
+    ):
         return True
     return False
+
 
 inference_function = functools.partial(infer_numpy_member, "out = np.ndarray([0, 0])")
 astroid.MANAGER.register_transform(

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -11,6 +11,9 @@ import astroid
 from brain_numpy_utils import looks_like_numpy_member, infer_numpy_member
 
 
+# TODO: In fact there is obviously a less intrusive way to correctly infer those functions.
+#       They are all defined in a .py file thus there is no need to redefine them here.
+#       See what is done in brain_numpy_core_fromnumeric module
 METHODS_TO_BE_INFERRED = {
     "linspace": """def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):
             return numpy.ndarray([0, 0])""",

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -85,3 +85,8 @@ for method_name, function_src in METHODS_TO_BE_INFERRED.items():
         astroid.inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),
     )
+    astroid.MANAGER.register_transform(
+        astroid.Name,
+        astroid.inference_tip(inference_function),
+        functools.partial(looks_like_numpy_member, method_name),
+    )

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -101,6 +101,7 @@ def numpy_core_umath_transform():
     trunc = FakeUfuncOneArg()
 
     # Two args functions with optional kwargs
+    add = FakeUfuncTwoArgs()
     bitwise_and = FakeUfuncTwoArgs()
     bitwise_or = FakeUfuncTwoArgs()
     bitwise_xor = FakeUfuncTwoArgs()
@@ -123,6 +124,7 @@ def numpy_core_umath_transform():
     logical_xor = FakeUfuncTwoArgs()
     maximum = FakeUfuncTwoArgs()
     minimum = FakeUfuncTwoArgs()
+    multiply = FakeUfuncTwoArgs()
     nextafter = FakeUfuncTwoArgs()
     not_equal = FakeUfuncTwoArgs()
     power = FakeUfuncTwoArgs()

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -48,9 +48,13 @@ def looks_like_numpy_member(
     :param node: node to test
     :return: True if the node is a member of numpy
     """
-    return (
-        isinstance(node, astroid.Attribute)
+    if (isinstance(node, astroid.Attribute)
         and node.attrname == member_name
         and isinstance(node.expr, astroid.Name)
-        and _is_a_numpy_module(node.expr)
-    )
+        and _is_a_numpy_module(node.expr)):
+        return True
+    if (isinstance(node, astroid.Name)
+        and node.name == member_name 
+        and node.root().name.startswith('numpy')):
+        return True
+    return False

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -48,13 +48,17 @@ def looks_like_numpy_member(
     :param node: node to test
     :return: True if the node is a member of numpy
     """
-    if (isinstance(node, astroid.Attribute)
+    if (
+        isinstance(node, astroid.Attribute)
         and node.attrname == member_name
         and isinstance(node.expr, astroid.Name)
-        and _is_a_numpy_module(node.expr)):
+        and _is_a_numpy_module(node.expr)
+    ):
         return True
-    if (isinstance(node, astroid.Name)
-        and node.name == member_name 
-        and node.root().name.startswith('numpy')):
+    if (
+        isinstance(node, astroid.Name)
+        and node.name == member_name
+        and node.root().name.startswith("numpy")
+    ):
         return True
     return False

--- a/tests/unittest_brain_numpy_core_fromnumeric.py
+++ b/tests/unittest_brain_numpy_core_fromnumeric.py
@@ -42,15 +42,18 @@ class BrainNumpyCoreFromNumericTest(unittest.TestCase):
         licit_array_types = set([".ndarray", Uninferable])
         for func_ in self.numpy_functions:
             with self.subTest(typ=func_):
-                inferred_values = set([v.pytype() for v in self._inferred_numpy_func_call(*func_)])
+                inferred_values = set(
+                    [v.pytype() for v in self._inferred_numpy_func_call(*func_)]
+                )
                 self.assertTrue(
                     len(inferred_values) == 2,
-                    msg="Too much inferred values {} for {:s}".format(inferred_values, func_[1]),
+                    msg="Too much inferred values {} for {:s}".format(
+                        inferred_values, func_[1]
+                    ),
                 )
                 self.assertTrue(
                     inferred_values == licit_array_types,
-                    msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values),
+                    msg="Illicit type for {:s} ({})".format(func_[0], inferred_values),
                 )
 
 

--- a/tests/unittest_brain_numpy_core_fromnumeric.py
+++ b/tests/unittest_brain_numpy_core_fromnumeric.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     HAS_NUMPY = False
 
-from astroid import builder
+from astroid import builder, Uninferable
 
 
 @unittest.skipUnless(HAS_NUMPY, "This test requires the numpy library.")
@@ -39,19 +39,18 @@ class BrainNumpyCoreFromNumericTest(unittest.TestCase):
         """
         Test that calls to numpy functions are inferred as numpy.ndarray
         """
-        licit_array_types = (".ndarray",)
+        licit_array_types = set([".ndarray", Uninferable])
         for func_ in self.numpy_functions:
             with self.subTest(typ=func_):
-                inferred_values = list(self._inferred_numpy_func_call(*func_))
+                inferred_values = set([v.pytype() for v in self._inferred_numpy_func_call(*func_)])
                 self.assertTrue(
-                    len(inferred_values) == 1,
-                    msg="Too much inferred value for {:s}".format(func_[0]),
+                    len(inferred_values) == 2,
+                    msg="Too much inferred values {} for {:s}".format(inferred_values, func_[1]),
                 )
                 self.assertTrue(
-                    inferred_values[-1].pytype() in licit_array_types,
+                    inferred_values == licit_array_types,
                     msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values[-1].pytype()
-                    ),
+                        func_[0], inferred_values),
                 )
 
 

--- a/tests/unittest_brain_numpy_core_function_base.py
+++ b/tests/unittest_brain_numpy_core_function_base.py
@@ -49,7 +49,7 @@ class BrainNumpyCoreFunctionBaseTest(unittest.TestCase):
                 inferred_values = list(self._inferred_numpy_func_call(*func_))
                 self.assertTrue(
                     len(inferred_values) == 1,
-                    msg="Too much inferred value for {:s}".format(func_[0]),
+                    msg="Too much inferred values {} for {:s}".format(inferred_values, func_[0]),
                 )
                 self.assertTrue(
                     inferred_values[-1].pytype() in licit_array_types,

--- a/tests/unittest_brain_numpy_core_function_base.py
+++ b/tests/unittest_brain_numpy_core_function_base.py
@@ -49,7 +49,9 @@ class BrainNumpyCoreFunctionBaseTest(unittest.TestCase):
                 inferred_values = list(self._inferred_numpy_func_call(*func_))
                 self.assertTrue(
                     len(inferred_values) == 1,
-                    msg="Too much inferred values {} for {:s}".format(inferred_values, func_[0]),
+                    msg="Too much inferred values {} for {:s}".format(
+                        inferred_values, func_[0]
+                    ),
                 )
                 self.assertTrue(
                     inferred_values[-1].pytype() in licit_array_types,

--- a/tests/unittest_brain_numpy_core_umath.py
+++ b/tests/unittest_brain_numpy_core_umath.py
@@ -60,6 +60,7 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
     )
 
     two_args_ufunc = (
+        "add",
         "bitwise_and",
         "bitwise_or",
         "bitwise_xor",
@@ -82,6 +83,7 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
         "logical_xor",
         "maximum",
         "minimum",
+        "multiply",
         "nextafter",
         "not_equal",
         "power",

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -15,7 +15,7 @@ import sys
 import unittest
 import textwrap
 
-from astroid import MANAGER, Instance, nodes
+from astroid import MANAGER, Instance, nodes, util
 from astroid.bases import BUILTINS
 from astroid.builder import AstroidBuilder, extract_node
 from astroid import exceptions
@@ -92,12 +92,13 @@ class NonRegressionTests(resources.AstroidCacheSetupMixin, unittest.TestCase):
         data = """
 from numpy import multiply
 
-multiply(1, 2, 3)
+multiply([1, 2], [3, 4])
 """
         astroid = builder.string_build(data, __name__, __file__)
         callfunc = astroid.body[1].value.func
         inferred = callfunc.inferred()
-        self.assertEqual(len(inferred), 1)
+        self.assertEqual(len(inferred), 2)
+        self.assertTrue(inferred[-1].pytype() is util.Uninferable)
 
     @require_version("3.0")
     def test_nameconstant(self):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ * ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ * ] Write a good description on what the PR does.

## Description

This PR solves the issue #666.
The problem was that `astroid` could not infer the result of a call to `append` function because this function, itself, calls the `concatenate` function.
This last function is inferred thanks to the `brain_numpy_core_multiarray` module but only when the corresponding node is an `astroid.Attribute` (for example `numpy.concatenate`). It turns out that in the source of the `append` function the node that realises the call to `concatenate` is a `astroid.Name`. Thus the correction proposed here is to register the `concatenate` inference tip function in order to apply it, also, to `astroid.Name`.

This PR contains also a refactor of the `brain_numpy_core_fromnumeric` module in order to minimize the interaction with the inference engine. There is no need to redefine the `sum` function, but instead help `astroid` to correctly infer the variable `out` in the function `sum`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #666 
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
