### PR TITLE
Add qname method to Super objects (backport; refs #537)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 Change log for the astroid package (used to be astng)
 =====================================================
 
+2020-01-06 -- 1.6.7
+
+   * Add qname method to Super object preventing potential errors in upstream
+     pylint (cherry-pick from 2.x)
+
+     Close #533
+     
 2019-04-09 -- 1.6.6
 
 * Add cPickle to the list of available imports for six.moves in Python2

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -16,7 +16,7 @@ distname = 'astroid'
 
 modname = 'astroid'
 
-version = '1.6.6'
+version = '1.6.7'
 numversion = tuple(map(int, version.split('.')))
 
 extras_require = {}

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -16,7 +16,7 @@ distname = 'astroid'
 
 modname = 'astroid'
 
-version = '1.6.7'
+version = '1.6.6'
 numversion = tuple(map(int, version.split('.')))
 
 extras_require = {}

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -118,6 +118,9 @@ class Super(node_classes.NodeNG):
         """Get the name of the MRO pointer."""
         return self.mro_pointer.name
 
+    def qname(self):
+        return "super"
+
     def igetattr(self, name, context=None):
         """Retrieve the inferred values of the given attribute name."""
 

--- a/astroid/tests/unittest_objects.py
+++ b/astroid/tests/unittest_objects.py
@@ -502,6 +502,19 @@ class SuperTests(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 42)
 
+    def test_super_qname(self):
+        """Make sure a Super object generates a qname
+        equivalent to super.__qname__
+        """
+        # See issue 533
+        code = """
+        class C:
+           def foo(self): return super()
+        C().foo() #@
+        """
+        super_obj = next(builder.extract_node(code).infer())
+        self.assertEqual(super_obj.qname(), "super")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
   six
   wrapt
   pylint: git+https://github.com/pycqa/pylint@master
-  coverage
+  coverage<5
 
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage.{envname}
@@ -43,7 +43,7 @@ setenv =
 passenv =
     *
 deps =
-    coverage
+    coverage<5
     coveralls
 skip_install = true
 commands =
@@ -56,7 +56,7 @@ changedir = {toxinidir}
 setenv =
     COVERAGE_FILE = {toxinidir}/.coverage
 deps =
-    coverage
+    coverage<5
 skip_install = true
 commands =
     python {envsitepackagesdir}/coverage erase


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

This is a backport of the #537 to the 1.6 branch, targeting a 1.6.7 patch release.
The reason for this change is to support python2 porting using `pylint --py3k` that still needs to run under the python2 interpreter.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Refs #537 #533 
