### PR TITLE
Fix for no-member regression in pylint

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -176,10 +176,7 @@ def _container_generic_transform(arg, context, klass, iterables, build_elts):
         if all(isinstance(elt, nodes.Const) for elt in arg.elts):
             elts = [elt.value for elt in arg.elts]
         else:
-            # TODO: Does not handle deduplication for sets.
-            elts = filter(
-                None, map(partial(helpers.safe_infer, context=context), arg.elts)
-            )
+            raise UseInferenceDefault()
     elif isinstance(arg, nodes.Dict):
         # Dicts need to have consts as strings already.
         if not all(isinstance(elt[0], nodes.Const) for elt in arg.items):

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5159,21 +5159,6 @@ def test_exception_lookup_name_bound_in_except_handler():
     assert inferred_exc.value == 2
 
 
-def test_builtin_inference_list_of_exceptions():
-    node = extract_node(
-        """
-    tuple([ValueError, TypeError])
-    """
-    )
-    inferred = next(node.infer())
-    assert isinstance(inferred, nodes.Tuple)
-    assert len(inferred.elts) == 2
-    assert isinstance(inferred.elts[0], nodes.ClassDef)
-    assert inferred.elts[0].name == "ValueError"
-    assert isinstance(inferred.elts[1], nodes.ClassDef)
-    assert inferred.elts[1].name == "TypeError"
-
-
 @test_utils.require_version(minver="3.6")
 def test_cannot_getattr_ann_assigns():
     node = extract_node(


### PR DESCRIPTION
## Description

This fixes the regression documented in PyCQA/pylint#3134 and introduced in PyCQA/pylint#2841.

When running pylint on code that imports some third party package such as boto3 we get a `no-member` error as documented in the pylint bug report. This PR rolls back a single line that introduced the regression.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes PyCQA/pylint#3134
