### PR TITLE
Don't crash upon invalid contex on attr. inference

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -307,6 +307,8 @@ def infer_attribute(self, context=None):
                 except exceptions._NonDeducibleTypeHierarchy:
                     # Can't determine anything useful.
                     pass
+        elif not context:
+            context = contextmod.InferenceContext()
 
         try:
             context.boundnode = owner


### PR DESCRIPTION
## Description

This is an attempt to fix [this issue](https://github.com/PyCQA/astroid/issues/745). Sorry for the succinct PR... I'm not an astroid developer and this still needs testing and (likely) further elaboration. I'd just like to give some primary input.

 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

