### PR TITLE
Bugfix/enum crash/pylint-3365

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 2.4.0?
 Release Date: TBA
 
 
+* Fix a `pylint` crash when using `with ... as` in an enum class.
+
+  Close PyCQA/pylint#3365
+
 * Added a call to ``register_transform`` for all functions of the ``brain_numpy_core_multiarray``
   module in case the current node is an instance of ``astroid.Name``
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -251,7 +251,10 @@ class LocalsDictNodeNG(node_classes.LookupMixIn, node_classes.NodeNG):
 
         :raises KeyError: If the name is not defined.
         """
-        return self.locals[item][0]
+        try:
+            return self.locals[item][0]
+        except IndexError:
+            return None
 
     def __iter__(self):
         """Iterate over the names of locals defined in this scoped node.


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Fixes a `pylint` crash caused by an `IndexError` exception when running `pylint` on any file that has a `with ... as` in an enum class.

Example:
```python
import enum

class Error(enum.Enum):
    Foo = "foo"
    Bar = "bar"
    with "error" as err:
        pass
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes PyCQA/pylint#3365

