### PR TITLE
AstroidManager: Expose ast_from_string method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Release Date: TBA
 * Expose a ast_from_string method in AstroidManager, which will accept
   source code as a string and return the corresponding astroid object
 
-	Closes PyCQA/astroid#725
+  Closes PyCQA/astroid#725
 
 * Numpy `datetime64.astype` return value is inferred as a `ndarray`.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in astroid 2.4.0?
 ============================
 Release Date: TBA
 
+* Expose a ast_from_string method in AstroidManager, which will accept
+  source code as a string and return the corresponding astroid object
+
+	Closes PyCQA/astroid#725
+
 * Numpy `datetime64.astype` return value is inferred as a `ndarray`.
 
   Close PyCQA/pylint#3332

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -101,6 +101,7 @@ class AstroidManager:
 
     def ast_from_string(self, data, modname, filepath):
         """ Given some source code as a string, return its corresponding astroid object"""
+        # pylint: disable=import-outside-toplevel; circular import
         from astroid.builder import AstroidBuilder
 
         return AstroidBuilder(self).string_build(data, modname, filepath)

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -99,6 +99,12 @@ class AstroidManager:
             "Unable to build an AST for {path}.", path=filepath
         )
 
+    def ast_from_string(self, data, modname, filepath):
+        """ Given some source code as a string, return its corresponding astroid object"""
+        from astroid.builder import AstroidBuilder
+
+        return AstroidBuilder(self).string_build(data, modname, filepath)
+
     def _build_stub_module(self, modname):
         # pylint: disable=import-outside-toplevel; circular import
         from astroid.builder import AstroidBuilder

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -99,7 +99,7 @@ class AstroidManager:
             "Unable to build an AST for {path}.", path=filepath
         )
 
-    def ast_from_string(self, data, modname, filepath):
+    def ast_from_string(self, data, modname="", filepath=None):
         """ Given some source code as a string, return its corresponding astroid object"""
         # pylint: disable=import-outside-toplevel; circular import
         from astroid.builder import AstroidBuilder

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -67,6 +67,17 @@ class AstroidManagerTest(
             exceptions.AstroidBuildingError, self.manager.ast_from_file, "unhandledName"
         )
 
+    def test_ast_from_string(self):
+        filepath = unittest.__file__
+        dirname = os.path.dirname(filepath)
+        modname = os.path.basename(dirname)
+        with open(filepath, 'r') as file:
+            data = file.read()
+            ast = self.manager.ast_from_string(data, modname, filepath)
+            self.assertEqual(ast.name, "unittest")
+            self.assertEqual(ast.file, filepath)
+            self.assertIn("unittest", self.manager.astroid_cache)
+
     def test_do_not_expose_main(self):
         obj = self.manager.ast_from_module_name("__main__")
         self.assertEqual(obj.name, "__main__")

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -71,7 +71,7 @@ class AstroidManagerTest(
         filepath = unittest.__file__
         dirname = os.path.dirname(filepath)
         modname = os.path.basename(dirname)
-        with open(filepath, 'r') as file:
+        with open(filepath, "r") as file:
             data = file.read()
             ast = self.manager.ast_from_string(data, modname, filepath)
             self.assertEqual(ast.name, "unittest")


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR exposes a new method `ast_from_string` in `AstroidManager`, which accepts source code as a string and returns the corresponding Astroid object. 

This method can be used directly instead of `AstroidBuilder.string_build`

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Fixes #725 
