### PR TITLE
Relax upper bound on `wrapt`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -123,6 +123,10 @@ Release Date: TBA
   ``Arguments.type_comment_posonlyargs`` and
   ``Arguments.type_comment_kwonlyargs`` attributes respectively.
 
+* Relax upper bound on `wrapt`
+
+  Close #755
+
 What's New in astroid 2.3.2?
 ============================
 Release Date: TBA

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -24,7 +24,7 @@ extras_require = {}
 install_requires = [
     "lazy_object_proxy==1.4.*",
     "six~=1.12",
-    "wrapt==1.11.*",
+    "wrapt~=1.11",
     'typed-ast>=1.4.0,<1.5;implementation_name== "cpython" and python_version<"3.8"',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
   python-dateutil
   pypy: singledispatch
   six~=1.12
-  wrapt==1.11.*
+  wrapt~=1.11
   coverage<5
 
 setenv =


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Relax upper bound of `wrapt` from `<1.12` to `<2`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes PyCQA/astroid#755
