### PR TITLE
If a generic class is subscripted, infer that class itself

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,11 @@ Release Date: TBA
   Close PyCQA/pylint#3540
   Close #773
 
+* If a generic class is subscripted, infer that class itself
+
+  Closes PyCQA/pylint#3131
+  Closes PyCQA/pylint#3505
+
 
 What's New in astroid 2.4.0?
 ============================

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -84,7 +84,9 @@ def infer_typing_attr(node, context=None):
     except InferenceError as exc:
         raise UseInferenceDefault from exc
 
-    node = extract_node(TYPING_TYPE_TEMPLATE.format(value.qname().split(".")[-1]))
+    node = extract_node(
+        TYPING_TYPE_TEMPLATE.format(value.qname().split(".")[-1]), "typing"
+    )
     return node.infer(context=context)
 
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -75,12 +75,14 @@ def _looks_like_typing_subscript(node):
 def infer_typing_attr(node, context=None):
     """Infer a typing.X[...] subscript"""
     try:
-        value = next(node.value.infer())
+        for value in node.value.infer():
+            if value.qname().startswith("typing."):
+                break
+        else:
+            raise UseInferenceDefault
+
     except InferenceError as exc:
         raise UseInferenceDefault from exc
-
-    if not value.qname().startswith("typing."):
-        raise UseInferenceDefault
 
     node = extract_node(TYPING_TYPE_TEMPLATE.format(value.qname().split(".")[-1]))
     return node.infer(context=context)

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -368,6 +368,10 @@ def infer_subscript(self, context=None):
         if value is util.Uninferable:
             yield util.Uninferable
             return None
+        if isinstance(value, nodes.ClassDef):
+            if value.is_subtype_of("typing.Generic"):
+                yield value
+                found_one = True
         for index in self.slice.infer(context):
             if index is util.Uninferable:
                 yield util.Uninferable

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1080,6 +1080,17 @@ class TypingBrain(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, astroid.Instance)
 
+    def test_generic_subscript(self):
+        node = builder.extract_node(
+            """
+        from typing import Generic, TypeVar
+        T = TypeVar('T')
+        Generic[T]  #@
+        """
+        )
+        inferred = next(node.infer())
+        self.assertEqual(inferred.qname(), "typing.Generic")
+
 
 class ReBrainTest(unittest.TestCase):
     def test_regex_flags(self):

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -374,6 +374,30 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIs(a2_ancestors[0], b)
         self.assertIs(a2_ancestors[1], a1)
 
+    @pytest.mark.skipif(sys.version_info < (3, 5), reason="Needs 'typing' module")
+    def test_ancestors_generic(self):
+        code = """
+            from typing import Generic, TypeVar
+
+            T = TypeVar('T')
+
+            class A(Generic[T]):  #@
+                pass
+
+            class B(A[T]):  #@
+                pass
+
+            class C(B[int]):  #@
+                pass
+        """
+        a, b, c = extract_node(code, __name__)
+        ancestors = list(c.ancestors())
+        self.assertEqual(len(ancestors), 4)
+        self.assertIs(ancestors[0], b)
+        self.assertIs(ancestors[1], a)
+        self.assertEqual(ancestors[2].name, "Generic")
+        self.assertEqual(ancestors[3].name, "object")
+
     def test_f_arg_f(self):
         code = """
             def f(f=1):


### PR DESCRIPTION
## Description

Ideally, when a generic class is subscripted, the value for the type variable would be remembered and used in later inference. However, just interring the subscripted class itself already solves multiple false positives in pylint, so this seems like a useful first step.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes PyCQA/pylint#3131
Closes PyCQA/pylint#3505

It might also solve PyCQA/pylint#3129, but I'm having trouble reproducing that issue on Python 3.8 even without this PR applied.
