### PR TITLE
Handle the case where the raw builder fails to retrieve the ``__all__`` attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
 astroid's ChangeLog
 ===================
 
+What's New in astroid 2.4.1?
+============================
+Release Date: TBA
+
+* Handle the case where the raw builder fails to retrieve the ``__all__`` attribute
+
+  Close #772
+
+
 What's New in astroid 2.4.0?
 ============================
 Release Date: 2020-04-27

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -276,6 +276,13 @@ def _build_from_function(node, name, member, module):
         object_build_function(node, member, name)
 
 
+def _safe_has_attribute(obj, member):
+    try:
+        return hasattr(obj, member)
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
 class InspectBuilder:
     """class for building nodes from living object
 
@@ -357,7 +364,7 @@ class InspectBuilder:
                 # This should be called for Jython, where some builtin
                 # methods aren't caught by isbuiltin branch.
                 _build_from_function(node, name, member, self._module)
-            elif hasattr(member, "__all__"):
+            elif _safe_has_attribute(member, "__all__"):
                 module = build_module(name)
                 _attach_local_node(node, module, name)
                 # recursion


### PR DESCRIPTION
PyQT does something special with their objects and retrieving some of
them (such as `__all__`) at runtime results in a RuntimeError.
This patch simply swallows all the exceptions that accessing `__all__`
might raise.

Close #772
