### PR TITLE
Changed `python_requires` to use ">=" syntax

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,13 +8,6 @@ What's New in astroid 2.5.0?
 Release Date: TBA
 
 
-What's New in astroid 2.4.2?
-============================
-Release Date: TBA
-
-* Changed setup.py to work with [distlib](https://pypi.org/project/distlib)
-
-
 What's New in astroid 2.4.1?
 ============================
 Release Date: TBA
@@ -27,6 +20,10 @@ Release Date: TBA
 
   Close PyCQA/pylint#3540
   Close #773
+
+* Changed setup.py to work with [distlib](https://pypi.org/project/distlib)
+
+  Close #779
 
 
 What's New in astroid 2.4.0?

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,13 @@ What's New in astroid 2.5.0?
 Release Date: TBA
 
 
+What's New in astroid 2.4.2?
+============================
+Release Date: TBA
+
+* Changed setup.py to work with [distlib](https://pypi.org/project/distlib)
+
+
 What's New in astroid 2.4.1?
 ============================
 Release Date: TBA

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def install():
         author=author,
         author_email=author_email,
         url=web,
-        python_requires=">=3.5.*",
+        python_requires=">=3.5",
         install_requires=install_requires,
         extras_require=extras_require,
         packages=find_packages() + ["astroid.brain"],


### PR DESCRIPTION
## Description
At the moment, astroid cannot be read using distlib (0.3.0 or 0.2.9.post0). This PR aims to fix this.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes https://github.com/PyCQA/astroid/issues/779