### PR TITLE
Protect against ``infer_call_result`` failing with `InferenceError` in `Super.getattr()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,10 @@ Release Date: TBA
 
   Close PyCQA/pylint#3549
 
+* Protect against ``infer_call_result`` failing with `InferenceError` in `Super.getattr()`
+
+  Close PyCQA/pylint#3529
+
 
 What's New in astroid 2.4.0?
 ============================

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -187,7 +187,12 @@ class Super(node_classes.NodeNG):
                     yield inferred
                 elif isinstance(inferred, Property):
                     function = inferred.function
-                    yield from function.infer_call_result(caller=self, context=context)
+                    try:
+                        yield from function.infer_call_result(
+                            caller=self, context=context
+                        )
+                    except exceptions.InferenceError:
+                        yield util.Uninferable
                 elif bases._is_property(inferred):
                     # TODO: support other descriptors as well.
                     try:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5818,5 +5818,33 @@ def test_implicit_parameters_bound_method():
     assert dunder_new.implicit_parameters() == 0
 
 
+def test_super_inference_of_abstract_property():
+    code = """
+    from abc import abstractmethod
+
+    class A:
+       @property
+       def test(self):
+           return "super"
+
+    class C:
+       @property
+       @abstractmethod
+       def test(self):
+           "abstract method"
+
+    class B(A, C):
+
+       @property
+       def test(self):
+            super() #@
+
+    """
+    node = extract_node(code)
+    inferred = next(node.infer())
+    test = inferred.getattr("test")
+    assert len(test) == 2
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

``infer_call_result`` can raise InferenceError but we were not handling that when retrieving
objects from the Super instance.

Close PyCQA/pylint#3529


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
