### PR TITLE
handle deprecation warnings when walking module members

### DIFF
--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -25,6 +25,7 @@ import inspect
 import os
 import sys
 import types
+import warnings
 
 from astroid import bases
 from astroid import manager
@@ -324,8 +325,10 @@ class InspectBuilder:
         self._done[obj] = node
         for name in dir(obj):
             try:
-                member = getattr(obj, name)
-            except AttributeError:
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("error")
+                    member = getattr(obj, name)
+            except (AttributeError, DeprecationWarning):
                 # damned ExtensionClass.Base, I know you're there !
                 attach_dummy_node(node, name)
                 continue


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description
This change prevents `DeprecationWarning`s that arise from dynamically walking a module's members from propagating. Specifically, it changes the member walking portion to treat warnings as errors, and specifically handles `DeprecationWarning`s to halt their propagation.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #770 
-->
Closes #770 
