### PR TITLE
Add brain for sqlalchemy.orm.session

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
 
+* Added a brain for ``sqlalchemy.orm.session``
+
 
 What's New in astroid 2.4.1?
 ============================

--- a/astroid/brain/brain_sqlalchemy.py
+++ b/astroid/brain/brain_sqlalchemy.py
@@ -1,0 +1,31 @@
+import astroid
+
+
+def _session_transform():
+    return astroid.parse('''
+    from sqlalchemy.orm.session import Session
+
+    class sessionmaker:
+        def __init__(
+            self,
+            bind=None,
+            class_=Session,
+            autoflush=True,
+            autocommit=False,
+            expire_on_commit=True,
+            info=None,
+            **kw
+        ):
+            return
+
+        def __call__(self, **local_kw):
+            return Session()
+
+        def configure(self, **new_kw):
+            return
+
+        return Session()
+    ''')
+
+
+astroid.register_module_extender(astroid.MANAGER, 'sqlalchemy.orm.session', _session_transform)


### PR DESCRIPTION
## Steps

```python
from sqlalchemy.orm.session import Session, sessionmaker

MySession = sessionmaker()
S = MySession()
S.add()  # pylint: "Na, this does not exist"
S.close()  # pylint: "This does neither exist"

S = Session()
S.add()  # pylint: "This works!"
```

## Description

The lastest versions of astroid/pylint don't know what sqlalchemy's `sessionmaker()` returns (or at least they now know that they don't know this ;-)). This brain fixes that.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue
-