### PR TITLE
`FunctionDef.is_generator` properly handles `yield` nodes in `While` tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.4.2?
 ============================
 Release Date: TBA
 
+* `FunctionDef.is_generator` properly handles `yield` nodes in `While` tests
+
+  Close PyCQA/pylint#3519
+
 
 What's New in astroid 2.4.1?
 ============================

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4500,6 +4500,11 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         yield from self.body
         yield from self.orelse
 
+    def _get_yield_nodes_skip_lambdas(self):
+        """A While node can contain a Yield node in the test"""
+        yield from self.test._get_yield_nodes_skip_lambdas()
+        yield from super()._get_yield_nodes_skip_lambdas()
+
 
 class With(
     mixins.MultiLineBlockMixin,

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1661,7 +1661,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         :returns: True is this is a generator function, False otherwise.
         :rtype: bool
         """
-        return next(self._get_yield_nodes_skip_lambdas(), False)
+        return bool(next(self._get_yield_nodes_skip_lambdas(), False))
 
     def infer_call_result(self, caller=None, context=None):
         """Infer what the function returns when called.

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1335,5 +1335,17 @@ def test_const_itered():
     assert [elem.value for elem in itered] == list("string")
 
 
+def test_is_generator_for_yield_in_while():
+    code = """
+    def paused_iter(iterable):
+        while True:
+            # Continue to yield the same item until `next(i)` or `i.send(False)`
+            while (yield value):
+                pass
+    """
+    node = astroid.extract_node(code)
+    assert bool(node.is_generator())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Close PyCQA/pylint#3519