### PR TITLE
Drop support for Python 2 in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,8 @@ Python Versions
 ---------------
 
 astroid 2.0 is currently available for Python 3 only. If you want Python 2
-support, older versions of astroid will still supported until 2020.
+support, use an older version of astroid (though note that these versions
+are no longer supported).
 
 Test
 ----


### PR DESCRIPTION
It's 2020 and Python 2 has officially reached its EOL. Update the README to note that Python 2 is no longer officially supported by astroid.

## Description


## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |
