### PR TITLE
brain_mechanize: Add missing methods to transform

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,9 @@ Release Date: TBA
 
 * Added a brain for ``sqlalchemy.orm.session``
 
+* Added missing methods to the brain for ``mechanize``, to fix pylint false positives
+
+  Close #793
 
 
 What's New in astroid 2.4.2?

--- a/astroid/brain/brain_mechanize.py
+++ b/astroid/brain/brain_mechanize.py
@@ -15,13 +15,70 @@ def mechanize_transform():
         """
 
 class Browser(object):
+    def __getattr__(self, name):
+        return None
+    def __getitem__(self, name):
+        return None
+    def __setitem__(self, name, val):
+        return None
+    def back(self, n=1):
+        return None
+    def clear_history(self):
+        return None
+    def click(self, *args, **kwds):
+        return None
+    def click_link(self, link=None, **kwds):
+        return None
+    def close(self):
+        return None
+    def encoding(self):
+        return None
+    def find_link(self, text=None, text_regex=None, name=None, name_regex=None, url=None, url_regex=None, tag=None, predicate=None, nr=0):
+        return None
+    def follow_link(self, link=None, **kwds):
+        return None
+    def forms(self):
+        return None
+    def geturl(self):
+        return None
+    def global_form(self):
+        return None
+    def links(self, **kwds):
+        return None
+    def open_local_file(self, filename):
+        return None
     def open(self, url, data=None, timeout=None):
         return None
     def open_novisit(self, url, data=None, timeout=None):
         return None
     def open_local_file(self, filename):
         return None
-
+    def reload(self):
+        return None
+    def response(self):
+        return None
+    def select_form(self, name=None, predicate=None, nr=None, **attrs):
+        return None
+    def set_cookie(self, cookie_string):
+        return None
+    def set_handle_referer(self, handle):
+        return None
+    def set_header(self, header, value=None):
+        return None
+    def set_html(self, html, url="http://example.com/"):
+        return None
+    def set_response(self, response):
+        return None
+    def set_simple_cookie(self, name, value, domain, path='/'):
+        return None
+    def submit(self, *args, **kwds):
+        return None
+    def title(self):
+        return None
+    def viewing_html(self):
+        return None
+    def visit_response(self, response, request=None):
+        return None
 """
     )
 


### PR DESCRIPTION

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
The brain transform for `mechanize` was missing most methods for the `Browser` class, leading to false positives in `pylint`, such as:

E1101: Instance of 'Browser' has no 'select_form' member (no-member)
E1137: 'browser' does not support item assignment (unsupported-assignment-operation)

Add missing methods to align with `mechanize` 0.4.5.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #793.
