### PR TITLE
Add more supported parameters to subprocess.check_output().

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Release Date: TBA
 
 * Added a brain for ``sqlalchemy.orm.session``
 
+* Added more supported parameters to ``subprocess.check_output``
+
 
 
 What's New in astroid 2.4.2?

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -77,6 +77,11 @@ def _subprocess_transform():
             preexec_fn=None,
             pass_fds=(),
             input=None,
+            bufsize=0,
+            executable=None,
+            close_fds=False,
+            startupinfo=None,
+            creationflags=0,
             start_new_session=False
         ):
         """.strip()
@@ -97,6 +102,11 @@ def _subprocess_transform():
             preexec_fn=None,
             pass_fds=(),
             input=None,
+            bufsize=0,
+            executable=None,
+            close_fds=False,
+            startupinfo=None,
+            creationflags=0,
             start_new_session=False
         ):
         """.strip()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

The definitions for the ``subprocess.check_output()`` prototypes are missing the `bufsize`, `executable`, `close_fds`, `startupinfo`, and `creationflags` parameters. This leads to e.g. pylint flagging these parameters as unexpected.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/3645