### PR TITLE
Properly construct the arguments of inferred property descriptors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,10 @@ Release Date: TBA
 
   Close PyCQA/pylint#3519
 
+* Properly construct the arguments of infered property descriptors
+
+  Close PyCQA/pylint#3648
+
 
 What's New in astroid 2.4.1?
 ============================

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -743,6 +743,27 @@ class PropertyModel(ObjectModel):
     """Model for a builtin property"""
 
     # pylint: disable=import-outside-toplevel
+    def _init_function(self, name):
+        from astroid.node_classes import Arguments
+        from astroid.scoped_nodes import FunctionDef
+
+        args = Arguments()
+        args.postinit(
+            args=[],
+            defaults=[],
+            kwonlyargs=[],
+            kw_defaults=[],
+            annotations=[],
+            posonlyargs=[],
+            posonlyargs_annotations=[],
+            kwonlyargs_annotations=[],
+        )
+
+        function = FunctionDef(name=name, parent=self._instance)
+
+        function.postinit(args=args, body=[])
+        return function
+
     @property
     def attr_fget(self):
         from astroid.scoped_nodes import FunctionDef
@@ -767,20 +788,14 @@ class PropertyModel(ObjectModel):
 
     @property
     def attr_setter(self):
-        from astroid.scoped_nodes import FunctionDef
-
-        return FunctionDef(name="setter", parent=self._instance)
+        return self._init_function("setter")
 
     @property
     def attr_deleter(self):
-        from astroid.scoped_nodes import FunctionDef
-
-        return FunctionDef(name="deleter", parent=self._instance)
+        return self._init_function("deleter")
 
     @property
     def attr_getter(self):
-        from astroid.scoped_nodes import FunctionDef
-
-        return FunctionDef(name="getter", parent=self._instance)
+        return self._init_function("getter")
 
     # pylint: enable=import-outside-toplevel

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5846,5 +5846,22 @@ def test_super_inference_of_abstract_property():
     assert len(test) == 2
 
 
+def test_infer_generated_setter():
+    code = """
+    class A:
+        @property
+        def test(self):
+            pass
+    A.test.setter
+    """
+    node = extract_node(code)
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.FunctionDef)
+    assert isinstance(inferred.args, nodes.Arguments)
+    # This line used to crash because property generated functions
+    # did not have args properly set
+    assert list(inferred.nodes_of_class(nodes.Const)) == []
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Close PyCQA/pylint#3648
