### PR TITLE
`FunctionDef.is_generator` properly handles `yield` nodes in `If` tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,10 @@ Release Date: TBA
 
   Close PyCQA/pylint#3639
 
+* `FunctionDef.is_generator` properly handles `yield` nodes in `If` tests
+
+  Close PyCQA/pylint#3583
+
 
 What's New in astroid 2.4.2?
 ============================

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -3508,6 +3508,11 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
     def has_elif_block(self):
         return len(self.orelse) == 1 and isinstance(self.orelse[0], If)
 
+    def _get_yield_nodes_skip_lambdas(self):
+        """An If node can contain a Yield node in the test"""
+        yield from self.test._get_yield_nodes_skip_lambdas()
+        yield from super()._get_yield_nodes_skip_lambdas()
+
 
 class IfExp(NodeNG):
     """Class representing an :class:`ast.IfExp` node.

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1347,5 +1347,18 @@ def test_is_generator_for_yield_in_while():
     assert bool(node.is_generator())
 
 
+def test_is_generator_for_yield_in_if():
+    code = """
+    import asyncio
+
+    def paused_iter(iterable):
+        if (yield from asyncio.sleep(0.01)):
+            pass
+            return
+    """
+    node = astroid.extract_node(code)
+    assert bool(node.is_generator())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Close PyCQA/pylint#3583
