### PR TITLE
Fix exception causes in helpers.py

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -190,9 +190,9 @@ def _type_check(type1, type2):
         return False
     try:
         return type1 in type2.mro()[:-1]
-    except exceptions.MroError:
+    except exceptions.MroError as e:
         # The MRO is invalid.
-        raise exceptions._NonDeducibleTypeHierarchy
+        raise exceptions._NonDeducibleTypeHierarchy from e
 
 
 def is_subtype(type1, type2):
@@ -261,10 +261,10 @@ def object_len(node, context=None):
 
     try:
         len_call = next(node_type.igetattr("__len__", context=context))
-    except exceptions.AttributeInferenceError:
+    except exceptions.AttributeInferenceError as e:
         raise exceptions.AstroidTypeError(
             "object of type '{}' has no len()".format(node_type.pytype())
-        )
+        ) from e
 
     result_of_len = next(len_call.infer_call_result(node, context))
     if (


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 