### PR TITLE
Squash one-use inference utility functions to reduce recursion errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,11 @@ Release Date: TBA
 
 * Added more supported parameters to ``subprocess.check_output``
 
+* Fix recursion errors with pandas
+
+  Fixes PyCQA/pylint#2843
+  Fixes PyCQA/pylint#2811
+
 * Added exception inference for `UnicodeDecodeError`
 
   Close PyCQA/pylint#3639

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -105,17 +105,6 @@ class InferenceContext:
         clone.extra_context = self.extra_context
         return clone
 
-    def cache_generator(self, key, generator):
-        """Cache result of generator into dictionary
-
-        Used to cache inference results"""
-        results = []
-        for result in generator:
-            results.append(result)
-            yield result
-
-        self.inferred[key] = tuple(results)
-
     @contextlib.contextmanager
     def restore_path(self):
         path = set(self.path)

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -7,7 +7,6 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
 
 import warnings
-from itertools import islice
 
 import importlib
 import lazy_object_proxy
@@ -139,26 +138,3 @@ def proxy_alias(alias_name, node_type):
         },
     )
     return proxy(lambda: node_type)
-
-
-def limit_inference(iterator, size):
-    """Limit inference amount.
-
-    Limit inference amount to help with performance issues with
-    exponentially exploding possible results.
-
-    :param iterator: Inference generator to limit
-    :type iterator: Iterator(NodeNG)
-
-    :param size: Maximum mount of nodes yielded plus an
-        Uninferable at the end if limit reached
-    :type size: int
-
-    :yields: A possibly modified generator
-    :rtype param: Iterable
-    """
-    yield from islice(iterator, size)
-    has_more = next(iterator, False)
-    if has_more is not False:
-        yield Uninferable
-        return

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -428,7 +428,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             del undefined_attr
         """
         delete = extract_node(code, __name__)
-        self.assertRaises(InferenceError, delete.infer)
+        self.assertRaises(InferenceError, next, delete.infer())
 
     def test_del2(self):
         code = """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Squash single-use inference utility functions to reduce recursion errors by squashing generators together. This change stops recursion errors from occuring for some complex code.

This also makes debugging a lot simpler by reducing the complexity of the function stack.

I've been unable to create a regression test due to the nature of this issue however I have manually tested that this change fixes the below mentioned issues.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
## Related Issue
Fixes PyCQA/pylint#2843
Fixes PyCQA/pylint#2811
Changes PyCQA/pylint#3602 error into a MemoryError for me (which makes the underlying issue more apparent I suppose)
