### PR TITLE
Fix recursion error from occuring on self referential length calls

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release Date: TBA
 
   Fixes PyCQA/pylint#3599
 
+* Prevent recursion error for self referential length calls
+
+  Close #777
+
 * Added missing methods to the brain for ``mechanize``, to fix pylint false positives
 
   Close #793

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -759,6 +759,7 @@ def infer_len(node, context=None):
             "({len}) given".format(len=len(call.positional_arguments))
         )
     [argument_node] = call.positional_arguments
+
     try:
         return nodes.Const(helpers.object_len(argument_node, context=context))
     except (AstroidTypeError, InferenceError) as exc:

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -2035,5 +2035,21 @@ def test_str_and_bytes(code, expected_class, expected_value):
     assert inferred.value == expected_value
 
 
+def test_no_recursionerror_on_self_referential_length_check():
+    """
+    Regression test for https://github.com/PyCQA/astroid/issues/777
+    """
+    with pytest.raises(astroid.InferenceError):
+        node = astroid.extract_node(
+            """
+        class Crash:
+            def __len__(self) -> int:
+                return len(self)
+        len(Crash()) #@
+        """
+        )
+        node.inferred()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Fix recursion error from occuring on self referential length calls

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
## Related Issue
Closes #777 