### PR TITLE
Feature: teach astroid about Hypothesis' `@st.composite` decorator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
 
+* Added a brain for ``hypothesis.strategies.composite``
+
 * Added a brain for ``sqlalchemy.orm.session``
 
 * Separate string and bytes classes patching

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -1,0 +1,53 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
+"""
+Astroid hook for the Hypothesis library.
+
+Without this hook pylint reports no-value-for-parameter for use of strategies
+defined using the `@hypothesis.strategies.composite` decorator.  For example:
+
+    from hypothesis import strategies as st
+
+    @st.composite
+    def a_strategy(draw):
+        return draw(st.integers())
+
+    a_strategy()
+
+"""
+
+import astroid
+
+COMPOSITE_NAMES = (
+    "composite",
+    "st.composite",
+    "strategies.composite",
+    "hypothesis.strategies.composite",
+)
+
+
+def is_decorated_with_st_composite(node):
+    """Return True if a decorated node has @st.composite applied."""
+    if node.decorators and node.args.args and node.args.args[0].name == "draw":
+        for decorator_attribute in node.decorators.nodes:
+            if decorator_attribute.as_string() in COMPOSITE_NAMES:
+                return True
+    return False
+
+
+def remove_draw_parameter_from_composite_strategy(node):
+    """Given that the FunctionDef is decorated with @st.composite, remove the
+    first argument (`draw`) - it's always supplied by Hypothesis so we don't
+    need to emit the no-value-for-parameter lint.
+    """
+    del node.args.args[0]
+    del node.args.annotations[0]
+    del node.args.type_comment_args[0]
+    return node
+
+
+astroid.MANAGER.register_transform(
+    node_class=astroid.FunctionDef,
+    transform=remove_draw_parameter_from_composite_strategy,
+    predicate=is_decorated_with_st_composite,
+)


### PR DESCRIPTION
Hypothesis' `@st.composite` decorator removes (ie supplies for the caller) the first argument of the decorated function.  This has been a small frustration for many people, and caused a large number of `# pylint: disable=no-value-for-parameter` comments.

Recently, with https://github.com/HypothesisWorks/hypothesis/issues/2498, I personally got annoyed on behalf of our users (and, OK, at being repeatedly asked about it) enough to look up Pylint's plugin system, and a few hours later here we are!  I must say it's a very smooth extension API :smile:

Imitating the boto3 brain there aren't any tests, but I've confirmed it's working locally - just let me know what if anything else I need to do.