### PR TITLE
Changes the way `flat` attribute of `numpy` array is inferred

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ astroid's ChangeLog
 What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
+* The flat attribute of ``numpy.ndarray`` is now inferred as an ``numpy.ndarray`` itself.
+  It should be a ``numpy.flatiter`` instance, but this class is not yet available in the numpy brain.
+
+  Fixes PyCQA/pylint#3640
 
 * Added a brain for ``sqlalchemy.orm.session``
 

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -25,7 +25,9 @@ def numpy_core_numerictypes_transform():
             self.data = None
             self.dtype = None
             self.flags = None
-            self.flat = None
+            # Should be a numpy.flatiter instance but not available for now
+            # Putting an array instead so that iteration and indexing are authorized
+            self.flat = np.ndarray([0, 0])
             self.imag = None
             self.itemsize = None
             self.nbytes = None

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -23,7 +23,9 @@ def infer_numpy_ndarray(node, context=None):
             self.data = None
             self.dtype = None
             self.flags = None
-            self.flat = None
+            # Should be a numpy.flatiter instance but not available for now
+            # Putting an array instead so that iteration and indexing are authorized
+            self.flat = np.ndarray([0, 0])
             self.imag = np.ndarray([0, 0])
             self.itemsize = None
             self.nbytes = None


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This PR solves the pylint bug PyCQA/pylint#3640. 
It was due to the fact that in the `brain_numpy_ndarray` the `flat` attribute was `None`.
Rigorously it should be a `numpy.flatiter` instance, but as for now this class doesn't exist in the brain, i choose to replace it by just a `numpy.ndarray`. This way, iteration and indexation on the return value of the `flat` attribute is allowed.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes PyCQA/pylint#3640

