### PR TITLE
Bug pylint 3387

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ astroid.egg-info/
 .cache/
 .eggs/
 .pytest_cache/
+.mypy_cache/

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
 
+* The transpose of a ``numpy.ndarray`` is also a ``numpy.ndarray``
+
+  Fixes PyCQA/pylint#3387
+
 * Added a brain for ``sqlalchemy.orm.session``
 
 * Separate string and bytes classes patching

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -20,7 +20,7 @@ def numpy_core_numerictypes_transform():
     # different types defined in numerictypes.py
     class generic(object):
         def __init__(self, value):
-            self.T = None
+            self.T = np.ndarray([0, 0])
             self.base = None
             self.data = None
             self.dtype = None

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -17,7 +17,7 @@ def infer_numpy_ndarray(node, context=None):
     class ndarray(object):
         def __init__(self, shape, dtype=float, buffer=None, offset=0,
                      strides=None, order=None):
-            self.T = None
+            self.T = numpy.ndarray([0, 0])
             self.base = None
             self.ctypes = None
             self.data = None

--- a/tests/unittest_brain_numpy_ndarray.py
+++ b/tests/unittest_brain_numpy_ndarray.py
@@ -154,7 +154,7 @@ class NumpyBrainNdarrayTest(unittest.TestCase):
         Test that some numpy ndarray attributes are inferred as numpy.ndarray
         """
         licit_array_types = ".ndarray"
-        for attr_ in ("real", "imag"):
+        for attr_ in ("real", "imag", "shape", "T"):
             with self.subTest(typ=attr_):
                 inferred_values = list(self._inferred_ndarray_attribute(attr_))
                 self.assertTrue(


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ x ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ x ] Write a good description on what the PR does.

## Description
This PR is an answer to PyCQA/pylint#3387.
The ``brain_numpy_ndarray`` has been modified. The return type of the `T` attribute is now a ``numpy.ndarray``.
The `T` attribute of a ``numpy.ndarray`` is now inferred as a ``numpy.ndarray`` itself.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes PyCQA/pylint#3387

