### PR TITLE
Extend attrs brain to support provisional APIs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,8 @@ Release Date: TBA
 
 * Fixed exception-chaining error messages.
 
+* Extended attrs brain to support the provisional APIs
+
 
 What's New in astroid 2.4.3?
 ============================

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -11,8 +11,8 @@ import astroid
 from astroid import MANAGER
 
 
-ATTRIB_NAMES = frozenset(("attr.ib", "attrib", "attr.attrib"))
-ATTRS_NAMES = frozenset(("attr.s", "attrs", "attr.attrs", "attr.attributes"))
+ATTRIB_NAMES = frozenset(("attr.ib", "attrib", "attr.attrib", "attr.field", "field"))
+ATTRS_NAMES = frozenset(("attr.s", "attrs", "attr.attrs", "attr.attributes", "attr.define", "attr.mutable", "attr.frozen"))
 
 
 def is_decorated_with_attrs(node, decorator_names=ATTRS_NAMES):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1155,7 +1155,7 @@ class AttrsTest(unittest.TestCase):
         module = astroid.parse(
             """
         import attr
-        from attr import attrs, attrib
+        from attr import attrs, attrib, field
 
         @attr.s
         class Foo:
@@ -1185,10 +1185,31 @@ class AttrsTest(unittest.TestCase):
 
         i = Bai()
         i.d['answer'] = 42
+
+        @attr.define
+        class Spam:
+            d = field(default=attr.Factory(dict))
+
+        j = Spam(d=1)
+        j.d['answer'] = 42
+
+        @attr.mutable
+        class Eggs:
+            d = attr.field(default=attr.Factory(dict))
+
+        k = Eggs(d=1)
+        k.d['answer'] = 42        
+
+        @attr.frozen
+        class Eggs:
+            d = attr.field(default=attr.Factory(dict))
+
+        l = Eggs(d=1)
+        l.d['answer'] = 42  
         """
         )
 
-        for name in ("f", "g", "h", "i"):
+        for name in ("f", "g", "h", "i", "j", "k", "l"):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Description

With attrs 20, new "provisional" APIs were added (see https://www.attrs.org/en/stable/api.html?highlight=field#provisional-apis).

This PR adds support to those new functions in the existing attrs brain.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

