### PR TITLE
Fix starred_assigned_stmts elts cast (introduced in d68f2935)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,10 +11,13 @@ Release Date: TBA
 
   Fixes PyCQA/pylint#3640
 
-* Fixes a bug in the signature of the ``ndarray.__or__`` method, 
+* Fixes a bug in the signature of the ``ndarray.__or__`` method,
   in the ``brain_numpy_ndarray.py`` module.
 
   Fixes #815
+
+* Fixes a to-list cast bug in ``starred_assigned_stmts`` method,
+  in the ``protocols.py` module.
 
 * Added a brain for ``hypothesis.strategies.composite``
 

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -686,11 +686,10 @@ def starred_assigned_stmts(self, node=None, context=None, assign_path=None):
                     continue
 
                 # We're done unpacking.
-                elts = list(elts)
                 packed = nodes.List(
                     ctx=Store, parent=self, lineno=lhs.lineno, col_offset=lhs.col_offset
                 )
-                packed.postinit(elts=elts)
+                packed.postinit(elts=list(elts))
                 yield packed
                 break
 


### PR DESCRIPTION
Don't replace elts (deque) used in loop with list

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
I recently upgraded pylint (and thus astroid) to: `astroid==2.4.2 pylint==2.5.3` (Python 3.8.5) and now I get this exception when running pylint:
```
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/lint/check_parallel.py", line 69, in _worker_check_single_file
    _worker_linter.check_single_file(name, filepath, modname)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 889, in check_single_file
    self._check_file(
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 930, in _check_file
    check_astroid_module(ast_node)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 1062, in check_astroid_module
    retval = self._check_astroid_module(
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 1107, in _check_astroid_module
    walker.walk(ast_node)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  [Previous line repeated 1 more time]
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/checkers/typecheck.py", line 1856, in visit_generatorexp
    self._check_iterable(gen.iter, check_async=gen.is_async)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/checkers/typecheck.py", line 1800, in _check_iterable
    inferred = safe_infer(node)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/pylint/checkers/utils.py", line 1119, in safe_infer
    value = next(infer_gen)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/decorators.py", line 132, in raise_if_nothing_inferred
    yield next(generator)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/decorators.py", line 96, in wrapped
    res = next(generator)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/bases.py", line 136, in _infer_stmts
    for inferred in stmt.infer(context=context):
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/util.py", line 160, in limit_inference
    yield from islice(iterator, size)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/context.py", line 113, in cache_generator
    for result in generator:
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/decorators.py", line 132, in raise_if_nothing_inferred
    yield next(generator)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/decorators.py", line 93, in wrapped
    generator = _func(node, context, **kwargs)
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/inference.py", line 850, in infer_assign
    stmts = list(self.assigned_stmts(context=context))
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/decorators.py", line 124, in yes_if_nothing_inferred
    yield from generator
  File "/<SNIP>/.tox/lint/lib/python3.8/site-packages/astroid/protocols.py", line 678, in starred_assigned_stmts
    elts.popleft()
AttributeError: 'list' object has no attribute 'popleft'
```
(Previously with `astroid==2.3.3 pylint==2.4.4` I didn't see this.)

Now I have to admit I haven't look at the astroid codebase before, so I might have got this completely wrong, but:

It appears to me that because of the "cast" of `elts` from `deque` to `list` [here](https://github.com/PyCQA/astroid/blob/184b591ec79468d75be03835ee0d6fd12343d93a/astroid/protocols.py#L689-L693), the next time round the outer loop, if there are still more items left in `elts`, the above exception will trigger. With this patch, pylint runs again successfully for me.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
