### PR TITLE
Fix incorrect MRO being calculated for scoped multiple inheritance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,10 @@ Release Date: TBA
 
 * Fixed exception-chaining error messages.
 
+* Fix failure to infer base class type with multiple inheritance and qualified names
+
+  Fixes #843
+
 
 What's New in astroid 2.4.3?
 ============================

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -2858,7 +2858,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         for stmt in self.bases:
             try:
-                baseobj = next(stmt.infer(context=context))
+                baseobj = next(stmt.infer(context=context.clone()))
             except exceptions.InferenceError:
                 continue
             if isinstance(baseobj, bases.Instance):

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1431,15 +1431,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             pass
         """
         )
-        self.assertEqualMro(
-            cls,
-            [
-                "C",
-                "A",
-                "B",
-                "object"
-            ]
-        )
+        self.assertEqualMro(cls, ["C", "A", "B", "object"])
 
     def test_generator_from_infer_call_result_parent(self):
         func = builder.extract_node(

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1417,6 +1417,30 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             ],
         )
 
+    def test_mro_with_attribute_classes(self):
+        cls = builder.extract_node(
+            """
+        class A:
+            pass
+        class B:
+            pass
+        scope = object()
+        scope.A = A
+        scope.B = B
+        class C(scope.A, scope.B):
+            pass
+        """
+        )
+        self.assertEqualMro(
+            cls,
+            [
+                "C",
+                "A",
+                "B",
+                "object"
+            ]
+        )
+
     def test_generator_from_infer_call_result_parent(self):
         func = builder.extract_node(
             """


### PR DESCRIPTION
Clone the context used in `ClassDef._inferred_bases` before using it to infer the type of base classes.

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

If a class inherits from two bases and the classes are expressed as a
non-trivial expression such as qualified with a module name, classes
after the first could not be inferred due to reusing the context
object in `_inferred_bases`

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #843 
