### PR TITLE
Drop tracebacks on Astroid import errors for caches

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,7 @@ Release Date: TBA
 
 * Fixed exception-chaining error messages.
 
+* Reduce memory usage of astroid's module cache.
 
 What's New in astroid 2.4.3?
 ============================

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -240,7 +240,7 @@ def _is_setuptools_namespace(location):
         with open(os.path.join(location, "__init__.py"), "rb") as stream:
             data = stream.read(4096)
     except IOError:
-        pass
+        return None
     else:
         extend_path = b"pkgutil" in data and b"extend_path" in data
         declare_namespace = (

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -236,11 +236,13 @@ class AstroidManager:
                 value = exceptions.AstroidImportError(
                     "Failed to import module {modname} with error:\n{error}.",
                     modname=modname,
-                    error=ex,
+                    # we remove the traceback here to save on memory usage (since these exceptions are cached)
+                    error=ex.with_traceback(None),
                 )
             self._mod_file_cache[(modname, contextfile)] = value
         if isinstance(value, exceptions.AstroidBuildingError):
-            raise value
+            # we remove the traceback here to save on memory usage (since these exceptions are cached)
+            raise value.with_traceback(None)
         return value
 
     def ast_from_module(self, module, modname=None):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -968,7 +968,7 @@ class Statement(NodeNG):
         try:
             return stmts[index + 1]
         except IndexError:
-            pass
+            return None
 
     def previous_sibling(self):
         """The previous sibling statement.


### PR DESCRIPTION
This is a variant on #837, which drops tracebacks instead of introducing a messy workaround
 (thanks @pstch @char101 for the suggestion!)

 Before this change, when there were import failures by Astroid, it
 would store the error in the module cache (for example a "module not
 found" error), including tracebacks. These tracebacks would take up a
 lot of memory, and don't seem to be used for any sort of purpose
 beyond debugging value.

 On one project stripping this value entirely reduces memory usage by
 75%.

For the memory analysis itself, this variant uses a _bit_ more memory than my original solution, but I think that the non-weirdness of the solution makes this solution better

![image](https://user-images.githubusercontent.com/1408472/97136857-a32bf680-1797-11eb-9bb4-5d3432f06048.png)

