### PR TITLE
Fix python39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ jobs:
     env: TOXENV=py37
   - python: 3.8
     env: TOXENV=py38
+  - python: 3.9
+    env: TOXENV=py39
 before_install:
 - python --version
 - uname -a

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ astroid's ChangeLog
 What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
+* Add `python 3.9` support.
+
 * The flat attribute of ``numpy.ndarray`` is now inferred as an ``numpy.ndarray`` itself.
   It should be a ``numpy.flatiter`` instance, but this class is not yet available in the numpy brain.
 

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -173,7 +173,7 @@ class CallSite:
 
         # Too many arguments given and no variable arguments.
         if len(self.positional_arguments) > len(funcnode.args.args):
-            if not funcnode.args.vararg:
+            if not funcnode.args.vararg and not funcnode.args.posonlyargs:
                 raise exceptions.InferenceError(
                     "Too many positional arguments "
                     "passed to {func!r} that does "

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -973,8 +973,10 @@ class TypingBrain(unittest.TestCase):
         base = next(base for base in klass.ancestors() if base.name == "X")
         self.assertSetEqual({"a", "b", "c"}, set(base.instance_attrs))
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class that is easy to infer""")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9),
+        reason="""Before 3.9 NamedTuple was a class that is easy to infer""",
+    )
     def test_namedtuple_inference_nonliteral(self):
         # Note: NamedTuples in mypy only work with literals.
         klass = builder.extract_node(
@@ -990,9 +992,11 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, astroid.Instance)
         self.assertEqual(inferred.qname(), "typing.NamedTuple")
 
-    @pytest.mark.skipif(sys.version_info < (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class, it is now a function"""
-                               """ much more difficult to infer""")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="""Before 3.9 NamedTuple was a class, it is now a function"""
+        """ much more difficult to infer""",
+    )
     def test_namedtuple_inference_nonliteral_39(self):
         # Note: NamedTuples in mypy only work with literals.
         klass = builder.extract_node(
@@ -1008,9 +1012,11 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertSetEqual({"a", "b", "c"}, set(inferred.instance_attrs))
 
-    @pytest.mark.skipif(sys.version_info < (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class, it is now a function"""
-                               """ much more difficult to infer""")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="""Before 3.9 NamedTuple was a class, it is now a function"""
+        """ much more difficult to infer""",
+    )
     def test_namedtuple_inference_nonliteral_attrs_39(self):
         # Note: NamedTuples in mypy only work with literals.
         klass = builder.extract_node(
@@ -1048,9 +1054,11 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertSetEqual({"a", "b", "c"}, set(inferred.instance_attrs))
 
-    @pytest.mark.skipif(sys.version_info < (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class, it is now a function"""
-                               """ much more difficult to infer""")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="""Before 3.9 NamedTuple was a class, it is now a function"""
+        """ much more difficult to infer""",
+    )
     def test_namedtuple_few_args_39(self):
         result = builder.extract_node(
             """
@@ -1062,8 +1070,10 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertSetEqual(set(), set(inferred.instance_attrs))
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class that is easy to infer""")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9),
+        reason="""Before 3.9 NamedTuple was a class that is easy to infer""",
+    )
     def test_namedtuple_few_args(self):
         result = builder.extract_node(
             """
@@ -1075,8 +1085,10 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, astroid.Instance)
         self.assertEqual(inferred.qname(), "typing.NamedTuple")
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class that is easy to infer""")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9),
+        reason="""Before 3.9 NamedTuple was a class that is easy to infer""",
+    )
     def test_namedtuple_few_fields(self):
         result = builder.extract_node(
             """
@@ -1088,8 +1100,10 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, astroid.Instance)
         self.assertEqual(inferred.qname(), "typing.NamedTuple")
 
-    @pytest.mark.skipif(sys.version_info < (3, 9),
-                        reason="""Before 3.9 NamedTuple was a class that is easy to infer""")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="""Before 3.9 NamedTuple was a class that is easy to infer""",
+    )
     def test_namedtuple_few_fields_39(self):
         result = builder.extract_node(
             """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5667,7 +5667,10 @@ def test_custom_decorators_for_classmethod_and_staticmethods(code, obj, obj_type
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Needs dataclasses available")
-@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Exact inference with dataclasses (replace function) in python3.9")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 9),
+    reason="Exact inference with dataclasses (replace function) in python3.9",
+)
 def test_dataclasses_subscript_inference_recursion_error():
     code = """
     from dataclasses import dataclass, replace
@@ -5688,7 +5691,10 @@ def test_dataclasses_subscript_inference_recursion_error():
     assert helpers.safe_infer(node) is None
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Exact inference with dataclasses (replace function) in python3.9")
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Exact inference with dataclasses (replace function) in python3.9",
+)
 def test_dataclasses_subscript_inference_recursion_error_39():
     code = """
     from dataclasses import dataclass, replace
@@ -5708,6 +5714,7 @@ def test_dataclasses_subscript_inference_recursion_error_39():
     infer_val = helpers.safe_infer(node)
     assert isinstance(infer_val, Instance)
     assert infer_val.pytype() == ".ProxyConfig"
+
 
 def test_self_reference_infer_does_not_trigger_recursion_error():
     # Prevents https://github.com/PyCQA/pylint/issues/1285

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5667,6 +5667,7 @@ def test_custom_decorators_for_classmethod_and_staticmethods(code, obj, obj_type
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Needs dataclasses available")
+@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Exact inference with dataclasses (replace function) in python3.9")
 def test_dataclasses_subscript_inference_recursion_error():
     code = """
     from dataclasses import dataclass, replace
@@ -5686,6 +5687,27 @@ def test_dataclasses_subscript_inference_recursion_error():
     # Reproduces only with safe_infer()
     assert helpers.safe_infer(node) is None
 
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Exact inference with dataclasses (replace function) in python3.9")
+def test_dataclasses_subscript_inference_recursion_error_39():
+    code = """
+    from dataclasses import dataclass, replace
+
+    @dataclass
+    class ProxyConfig:
+        auth: str = "/auth"
+
+
+    a = ProxyConfig("")
+    test_dict = {"proxy" : {"auth" : "", "bla" : "f"}}
+
+    foo = test_dict['proxy']
+    replace(a, **test_dict['proxy']) # This fails
+    """
+    node = extract_node(code)
+    infer_val = helpers.safe_infer(node)
+    assert isinstance(infer_val, Instance)
+    assert infer_val.pytype() == ".ProxyConfig"
 
 def test_self_reference_infer_does_not_trigger_recursion_error():
     # Prevents https://github.com/PyCQA/pylint/issues/1285

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy, pylint
+envlist = py35, py36, py37, py38, py39, pypy, pylint
 skip_missing_interpreters = true
 
 [testenv:pylint]
@@ -18,9 +18,9 @@ deps =
   ; we have a brain for nose
   ; we use pytest for tests
   nose
-  py35,py36,py37: numpy
-  py35,py36,py37: attr
-  py35,py36,py37: typed_ast>=1.4.0,<1.5
+  py35,py36,py37,py38,py39: numpy
+  py35,py36,py37,py38,py39: attr
+  py35,py36,py37,py38,py39: typed_ast>=1.4.0,<1.5
   pytest
   python-dateutil
   pypy: singledispatch


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ x ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ x ] Write a good description on what the PR does.

## Description
This PR aims to enable python 3.9 in `astroid`. 4 unit tests where failing when passing from python 3.8 to python 3.9.
One concerning dataclasses. It was due to the fact that in python 3.9 the function `replace` in the `dataclasses` module is using positional only arguments  which was not the case before. Thus it appears that there was probably a lack in the `infer_argument` method of the `arguments` module.
The other failing tests concern the `NamedTuple` object. Prior to python 3.9 it is just a class inside the `typing` module. With python 3.9 it is now a function that create a new type. It is much more difficult to infer. In fact i spent few days trying to achieve something smart to enable astroid to infer the result of this function but i failed. Instead i decided to generalise the NamedTuple brain.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
