### PR TITLE
Add missing __class_getitem__ to deque.

### DIFF
--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -60,7 +60,9 @@ def _deque_mock():
         def __iadd__(self, other): pass
         def __mul__(self, other): pass
         def __imul__(self, other): pass
-        def __rmul__(self, other): pass"""
+        def __rmul__(self, other): pass
+        @classmethod
+        def __class_getitem__(self, item): pass"""
     return base_deque_class
 
 


### PR DESCRIPTION
## Description

Add a missing (introduced in Python 3.9) classmethod to deque.

Feel like it should be marked as introduced in 3.9 so astroid won't tell it exists while reading 3.8 code, any hint?


## Type of Changes

Single line of code, won't name it a bug fix nor a new feature.


## Related Issue

Closes: https://github.com/PyCQA/astroid/issues/855

