### PR TITLE
Remove dependency on imp.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,11 @@ Release Date: TBA
 
 * Reduce memory usage of astroid's module cache.
 
+* Remove dependency on `imp`.
+
+  Close #594
+  Close #681
+
 What's New in astroid 2.4.3?
 ============================
 Release Date: TBA

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -12,17 +12,11 @@ import abc
 import collections
 import distutils
 import enum
-import imp
 import os
 import sys
 import zipimport
 
-try:
-    import importlib.machinery
-
-    _HAS_MACHINERY = True
-except ImportError:
-    _HAS_MACHINERY = False
+import importlib.machinery
 
 try:
     from functools import lru_cache
@@ -37,22 +31,6 @@ ModuleType = enum.Enum(
     "PY_CODERESOURCE PY_COMPILED PY_FROZEN PY_RESOURCE "
     "PY_SOURCE PY_ZIPMODULE PY_NAMESPACE",
 )
-_ImpTypes = {
-    imp.C_BUILTIN: ModuleType.C_BUILTIN,
-    imp.C_EXTENSION: ModuleType.C_EXTENSION,
-    imp.PKG_DIRECTORY: ModuleType.PKG_DIRECTORY,
-    imp.PY_COMPILED: ModuleType.PY_COMPILED,
-    imp.PY_FROZEN: ModuleType.PY_FROZEN,
-    imp.PY_SOURCE: ModuleType.PY_SOURCE,
-}
-if hasattr(imp, "PY_RESOURCE"):
-    _ImpTypes[imp.PY_RESOURCE] = ModuleType.PY_RESOURCE
-if hasattr(imp, "PY_CODERESOURCE"):
-    _ImpTypes[imp.PY_CODERESOURCE] = ModuleType.PY_CODERESOURCE
-
-
-def _imp_type_to_module_type(imp_type):
-    return _ImpTypes[imp_type]
 
 
 _ModuleSpec = collections.namedtuple(
@@ -114,26 +92,59 @@ class Finder:
         """Get a list of extra paths where this finder can search."""
 
 
-class ImpFinder(Finder):
-    """A finder based on the imp module."""
+class ImportlibFinder(Finder):
+    """A finder based on the importlib module."""
+
+    _SUFFIXES = (
+        [(s, ModuleType.C_EXTENSION) for s in importlib.machinery.EXTENSION_SUFFIXES]
+        + [(s, ModuleType.PY_SOURCE) for s in importlib.machinery.SOURCE_SUFFIXES]
+        + [(s, ModuleType.PY_COMPILED) for s in importlib.machinery.BYTECODE_SUFFIXES]
+    )
 
     def find_module(self, modname, module_parts, processed, submodule_path):
+        if not isinstance(modname, str):
+            raise TypeError("'modname' must be a str, not {}".format(type(modname)))
         if submodule_path is not None:
             submodule_path = list(submodule_path)
-        try:
-            stream, mp_filename, mp_desc = imp.find_module(modname, submodule_path)
-        except ImportError:
-            return None
+        else:
+            try:
+                spec = importlib.util.find_spec(modname)
+                if spec:
+                    if spec.loader is importlib.machinery.BuiltinImporter:
+                        return ModuleSpec(
+                            name=modname,
+                            location=None,
+                            module_type=ModuleType.C_BUILTIN,
+                        )
+                    if spec.loader is importlib.machinery.FrozenImporter:
+                        return ModuleSpec(
+                            name=modname,
+                            location=None,
+                            module_type=ModuleType.PY_FROZEN,
+                        )
+            except ValueError:
+                pass
+            submodule_path = sys.path
 
-        # Close resources.
-        if stream:
-            stream.close()
-
-        return ModuleSpec(
-            name=modname,
-            location=mp_filename,
-            module_type=_imp_type_to_module_type(mp_desc[2]),
-        )
+        for entry in submodule_path:
+            package_directory = os.path.join(entry, modname)
+            for suffix in [".py", importlib.machinery.BYTECODE_SUFFIXES[0]]:
+                package_file_name = "__init__" + suffix
+                file_path = os.path.join(package_directory, package_file_name)
+                if os.path.isfile(file_path):
+                    return ModuleSpec(
+                        name=modname,
+                        location=package_directory,
+                        module_type=ModuleType.PKG_DIRECTORY,
+                    )
+            for suffix, type_ in ImportlibFinder._SUFFIXES:
+                file_name = modname + suffix
+                file_path = os.path.join(entry, file_name)
+                if os.path.isfile(file_path):
+                    return ModuleSpec(
+                        name=modname, location=file_path, module_type=type_
+                    )
+        return None
 
     def contribute_to_path(self, spec, processed):
         if spec.location is None:
@@ -159,7 +170,7 @@ class ImpFinder(Finder):
         return path
 
 
-class ExplicitNamespacePackageFinder(ImpFinder):
+class ExplicitNamespacePackageFinder(ImportlibFinder):
     """A finder for the explicit namespace packages, generated through pkg_resources."""
 
     def find_module(self, modname, module_parts, processed, submodule_path):
@@ -229,10 +240,12 @@ class PathSpecFinder(Finder):
         return None
 
 
-_SPEC_FINDERS = (ImpFinder, ZipFinder)
-if _HAS_MACHINERY:
-    _SPEC_FINDERS += (PathSpecFinder,)
-_SPEC_FINDERS += (ExplicitNamespacePackageFinder,)
+_SPEC_FINDERS = (
+    ImportlibFinder,
+    ZipFinder,
+    PathSpecFinder,
+    ExplicitNamespacePackageFinder,
+)
 
 
 def _is_setuptools_namespace(location):

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1448,6 +1448,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                             decorators.append(assign.value)
         return decorators
 
+    # pylint: disable=invalid-overridden-method
     @decorators_mod.cachedproperty
     def type(
         self

--- a/tests/testdata/python3/data/nonregr.py
+++ b/tests/testdata/python3/data/nonregr.py
@@ -16,9 +16,7 @@ def toto(value):
         print(v.get('yo'))
 
 
-import imp
-fp, mpath, desc = imp.find_module('optparse',a)
-s_opt = imp.load_module('std_optparse', fp, mpath, desc)
+import optparse as s_opt
 
 class OptionParser(s_opt.OptionParser):
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -540,8 +540,10 @@ class MultiprocessingBrainTest(unittest.TestCase):
             obj = next(module[attr].infer())
             self.assertEqual(obj.qname(), "{}.{}".format(bases.BUILTINS, attr))
 
-        array = next(module["array"].infer())
-        self.assertEqual(array.qname(), "array.array")
+        # pypy's implementation of array.__spec__ return None. This causes problems for this inference.
+        if not hasattr(sys, "pypy_version_info"):
+            array = next(module["array"].infer())
+            self.assertEqual(array.qname(), "array.array")
 
         manager = next(module["manager"].infer())
         # Verify that we have these attributes

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -541,18 +541,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(ancestor.root().name, BUILTINS)
         self.assertRaises(StopIteration, partial(next, ancestors))
 
-    def test_qqch(self):
-        code = """
-            from astroid.modutils import load_module_from_name
-            xxx = load_module_from_name('__pkginfo__')
-        """
-        ast = parse(code, __name__)
-        xxx = ast["xxx"]
-        self.assertSetEqual(
-            {n.__class__ for n in xxx.inferred()},
-            {nodes.Const, util.Uninferable.__class__},
-        )
-
     def test_method_argument(self):
         code = '''
             class ErudiEntitySchema:

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -82,7 +82,7 @@ class LoadModuleFromNameTest(unittest.TestCase):
 
     def test_raise_load_module_from_name_1(self):
         self.assertRaises(
-            ImportError, modutils.load_module_from_name, "os.path", use_sys=0
+            ImportError, modutils.load_module_from_name, "_this_module_does_not_exist_"
         )
 
 
@@ -296,6 +296,23 @@ class IsRelativeTest(unittest.TestCase):
 
     def test_knownValues_is_relative_3(self):
         self.assertFalse(modutils.is_relative("astroid", astroid.__path__[0]))
+
+    def test_deep_relative(self):
+        self.assertTrue(modutils.is_relative("ElementTree", xml.etree.__path__[0]))
+
+    def test_deep_relative2(self):
+        self.assertFalse(modutils.is_relative("ElementTree", xml.__path__[0]))
+
+    def test_deep_relative3(self):
+        self.assertTrue(modutils.is_relative("etree.ElementTree", xml.__path__[0]))
+
+    def test_deep_relative4(self):
+        self.assertTrue(modutils.is_relative("etree.gibberish", xml.__path__[0]))
+
+    def test_is_relative_bad_path(self):
+        self.assertFalse(
+            modutils.is_relative("ElementTree", os.path.join(xml.__path__[0], "ftree"))
+        )
 
 
 class GetModuleFilesTest(unittest.TestCase):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Removes all usage of the `imp` module, which has been deprecated since python 3.4.

This is a continuation of @degustaf's excellent work in #686. I've rebased, addressed review comments from that PR, fixed pylint warnings, and implemented the solution for modutils as discussed in #686.

The test_qqch test is removed as it seems to behave differently depending on whether modutils imports anything from stdlib, and it’s not clear what the objective of that test actually is.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #594 and #681 