### PR TITLE
Fix python39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ jobs:
     env: TOXENV=py37
   - python: 3.8
     env: TOXENV=py38
+  - python: 3.9
+    env: TOXENV=py39
 before_install:
 - python --version
 - uname -a

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ astroid's ChangeLog
 What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
+* Add `python 3.9` support.
+
 * The flat attribute of ``numpy.ndarray`` is now inferred as an ``numpy.ndarray`` itself.
   It should be a ``numpy.flatiter`` instance, but this class is not yet available in the numpy brain.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,12 @@ environment:
     - PYTHON: "C:\\Python37"
       TOXENV: "py37"
 
+    - PYTHON: "C:\\Python38"
+      TOXENV: "py38"
+
+    - PYTHON: "C:\\Python39"
+      TOXENV: "py39"
+
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ environment:
     - PYTHON: "C:\\Python38"
       TOXENV: "py38"
 
-    - PYTHON: "C:\\Python39"
-      TOXENV: "py39"
-
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -173,7 +173,7 @@ class CallSite:
 
         # Too many arguments given and no variable arguments.
         if len(self.positional_arguments) > len(funcnode.args.args):
-            if not funcnode.args.vararg:
+            if not funcnode.args.vararg and not funcnode.args.posonlyargs:
                 raise exceptions.InferenceError(
                     "Too many positional arguments "
                     "passed to {func!r} that does "

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -399,6 +399,21 @@ def infer_typing_namedtuple_class(class_node, context=None):
     return iter((generated_class_node,))
 
 
+def infer_typing_namedtuple_function(node, context=None):
+    """
+    Starting with python3.9, NamedTuple is a function of the typing module.
+    The class NamedTuple is build dynamically through a call to `type` during
+    initialization of the `_NamedTuple` variable.
+    """
+    klass = extract_node(
+        """
+        from typing import _NamedTuple
+        _NamedTuple
+        """
+    )
+    return klass.infer(context)
+
+
 def infer_typing_namedtuple(node, context=None):
     """Infer a typing.NamedTuple(...) call."""
     # This is essentially a namedtuple with different arguments
@@ -449,6 +464,10 @@ MANAGER.register_transform(
 )
 MANAGER.register_transform(
     nodes.ClassDef, inference_tip(infer_typing_namedtuple_class), _has_namedtuple_base
+)
+MANAGER.register_transform(
+    nodes.FunctionDef, inference_tip(infer_typing_namedtuple_function),
+    lambda node: node.name == "NamedTuple" and node.parent.name == "typing"
 )
 MANAGER.register_transform(
     nodes.Call, inference_tip(infer_typing_namedtuple), _looks_like_typing_namedtuple

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -466,8 +466,9 @@ MANAGER.register_transform(
     nodes.ClassDef, inference_tip(infer_typing_namedtuple_class), _has_namedtuple_base
 )
 MANAGER.register_transform(
-    nodes.FunctionDef, inference_tip(infer_typing_namedtuple_function),
-    lambda node: node.name == "NamedTuple" and node.parent.name == "typing"
+    nodes.FunctionDef,
+    inference_tip(infer_typing_namedtuple_function),
+    lambda node: node.name == "NamedTuple" and node.parent.name == "typing",
 )
 MANAGER.register_transform(
     nodes.Call, inference_tip(infer_typing_namedtuple), _looks_like_typing_namedtuple

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5667,6 +5667,10 @@ def test_custom_decorators_for_classmethod_and_staticmethods(code, obj, obj_type
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Needs dataclasses available")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 9),
+    reason="Exact inference with dataclasses (replace function) in python3.9",
+)
 def test_dataclasses_subscript_inference_recursion_error():
     code = """
     from dataclasses import dataclass, replace
@@ -5685,6 +5689,31 @@ def test_dataclasses_subscript_inference_recursion_error():
     node = extract_node(code)
     # Reproduces only with safe_infer()
     assert helpers.safe_infer(node) is None
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Exact inference with dataclasses (replace function) in python3.9",
+)
+def test_dataclasses_subscript_inference_recursion_error_39():
+    code = """
+    from dataclasses import dataclass, replace
+
+    @dataclass
+    class ProxyConfig:
+        auth: str = "/auth"
+
+
+    a = ProxyConfig("")
+    test_dict = {"proxy" : {"auth" : "", "bla" : "f"}}
+
+    foo = test_dict['proxy']
+    replace(a, **test_dict['proxy']) # This fails
+    """
+    node = extract_node(code)
+    infer_val = helpers.safe_infer(node)
+    assert isinstance(infer_val, Instance)
+    assert infer_val.pytype() == ".ProxyConfig"
 
 
 def test_self_reference_infer_does_not_trigger_recursion_error():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy, pylint
+envlist = py35, py36, py37, py38, py39, pypy, pylint
 skip_missing_interpreters = true
 
 [testenv:pylint]
@@ -18,9 +18,9 @@ deps =
   ; we have a brain for nose
   ; we use pytest for tests
   nose
-  py35,py36,py37: numpy
-  py35,py36,py37: attr
-  py35,py36,py37: typed_ast>=1.4.0,<1.5
+  py35,py36,py37,py38,py39: numpy
+  py35,py36,py37,py38,py39: attr
+  py35,py36,py37,py38,py39: typed_ast>=1.4.0,<1.5
   pytest
   python-dateutil
   pypy: singledispatch


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR deals with python 3.9. The biggest change concerns the `NamedTuple` brain. With `python 3.9` `NamedTuple` is no more a class but instead it is now a function. The class `NamedTuple` is built dynamically that's why it is necessary to enhance the brain module to take this into account. 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

## Linked issues
Closes PyCQA/pylint#3876 and partially PyCQA/pylint#3895
