### PR TITLE
Allow wrapt 1.12

### DIFF
--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -28,7 +28,7 @@ extras_require = {}
 install_requires = [
     "lazy_object_proxy==1.4.*",
     "six~=1.12",
-    "wrapt~=1.11",
+    "wrapt>=1.11,<1.13",
     'typed-ast>=1.4.0,<1.5;implementation_name== "cpython" and python_version<"3.8"',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
   python-dateutil
   pypy: singledispatch
   six~=1.12
-  wrapt~=1.11
+  wrapt>=1.11,<1.13
   coverage<5
 
 setenv =


### PR DESCRIPTION
By merging this release support for wrapt 1.12 will be enabled.
This would help migrating astroid to `osx-arm64` as `wrapt 1.11` is not available for that architecture.
See https://github.com/PyCQA/astroid/issues/859

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Allow support for wrapt 1.12.*

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

https://github.com/PyCQA/astroid/issues/859
