### PR TITLE
Add None check on inferred_node

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -252,6 +252,7 @@ def object_len(node, context=None):
     if (
         isinstance(node_frame, scoped_nodes.FunctionDef)
         and node_frame.name == "__len__"
+        and inferred_node is not None
         and inferred_node._proxied == node_frame.parent
     ):
         message = (


### PR DESCRIPTION
## Description
Adds a None check for inferred_node in the `astroid.helpers.object_len` method.

This is the stacktrace from the error I encountered:
```
Traceback (most recent call last):
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/__init__.py", line 93, in _inference_tip_cached
    return iter(_cache[func, node])
KeyError: (<function register_builtin_transform.<locals>._transform_wrapper at 0x7fa30eb99950>, <Call l.49 at 0x7fa2f0f270d0>)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/__init__.py", line 93, in _inference_tip_cached
    return iter(_cache[func, node])
KeyError: (<function register_builtin_transform.<locals>._transform_wrapper at 0x7fa30eb99950>, <Call l.1103 at 0x7fa2f5f0a3d0>)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/__init__.py", line 22, in run_pylint
    PylintRun(sys.argv[1:])
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/lint/run.py", line 349, in __init__
    linter.check(args)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/lint/pylinter.py", line 863, in check
    self.get_ast, self._iterate_file_descrs(files_or_modules)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/lint/pylinter.py", line 896, in _check_files
    self._check_file(get_ast, check_astroid_module, name, filepath, modname)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/lint/pylinter.py", line 922, in _check_file
    check_astroid_module(ast_node)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/lint/pylinter.py", line 1055, in check_astroid_module
    ast_node, walker, rawcheckers, tokencheckers
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/lint/pylinter.py", line 1099, in _check_astroid_module
    walker.walk(ast_node)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/checkers/base.py", line 2447, in visit_compare
    self._check_callable_comparison(node)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/checkers/base.py", line 2431, in _check_callable_comparison
    for operand in (left_operand, right_operand)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/checkers/base.py", line 2432, in <genexpr>
    if isinstance(utils.safe_infer(operand), bare_callables)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/pylint/checkers/utils.py", line 1143, in safe_infer
    value = next(infer_gen)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/node_classes.py", line 357, in infer
    yield from self._explicit_inference(self, context, **kwargs)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/__init__.py", line 95, in _inference_tip_cached
    result = func(*args, **kwargs)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/brain/brain_builtin_inference.py", line 173, in _transform_wrapper
    result = transform(node, context=context)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/brain/brain_builtin_inference.py", line 764, in infer_len
    return nodes.Const(helpers.object_len(argument_node, context=context))
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/helpers.py", line 287, in object_len
    result_of_len = next(len_call.infer_call_result(node, context))
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/scoped_nodes.py", line 1722, in infer_call_result
    yield from returnnode.value.infer(context)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/node_classes.py", line 357, in infer
    yield from self._explicit_inference(self, context, **kwargs)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/__init__.py", line 95, in _inference_tip_cached
    result = func(*args, **kwargs)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/brain/brain_builtin_inference.py", line 173, in _transform_wrapper
    result = transform(node, context=context)
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/brain/brain_builtin_inference.py", line 764, in infer_len
    return nodes.Const(helpers.object_len(argument_node, context=context))
  File "/home/simon/.pyenv/versions/3.7.8/envs/reserved-ai/lib/python3.7/site-packages/astroid/helpers.py", line 255, in object_len
    and inferred_node._proxied == node_frame.parent
AttributeError: 'NoneType' object has no attribute '_proxied'
```

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

