### PR TITLE
Fix deprecated importlib methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ astroid's ChangeLog
 What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
+* Fix deprecated importlib methods
+
+  Closes #703
+
 * Add `python 3.9` support.
 
 * The flat attribute of ``numpy.ndarray`` is now inferred as an ``numpy.ndarray`` itself.

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -285,7 +285,7 @@ def _precache_zipimporters(path=None):
             pic[entry_path] = zipimport.zipimporter(entry_path)
         except zipimport.ZipImportError:
             continue
-    return pic
+    return {key: value for key, value in pic.items() if isinstance(value, zipimport.zipimporter)}
 
 
 def _search_zip(modpath, pic):

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -276,7 +276,7 @@ def _precache_zipimporters(path=None):
     """
     For each path that has not been already cached 
     in the sys.path_importer_cache, create a new zipimporter
-    instance and store it into the cache.
+    instance and add it into the cache.
     Return a dict associating all paths, stored into the cache, to corresponding
     zipimporter instances
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -281,7 +281,7 @@ def _precache_zipimporters(path=None):
     zipimporter instances.
 
     :param path: paths that has to be added into the cache
-    :return: association between paths stored into the cache and zipimporter instances
+    :return: association between paths stored in the cache and zipimporter instances
     """
     pic = sys.path_importer_cache
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -270,6 +270,16 @@ def _cached_set_diff(left, right):
 
 
 def _precache_zipimporters(path=None):
+    """
+    For each path that has not been already cached 
+    in the sys.path_importer_cache, create a new zipimporter
+    instance and store it into the cache.
+    Return a dict associating all paths, stored into the cache, to corresponding
+    zipimporter instances
+
+    :param path: paths that has to be added into the cache
+    :return: association between paths stored into the cache and zipimporter instances
+    """
     pic = sys.path_importer_cache
 
     # When measured, despite having the same complexity (O(n)),

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -7,6 +7,7 @@
 # Copyright (c) 2018 Nick Drozd <nicholasdrozd@gmail.com>
 # Copyright (c) 2019 Hugo van Kemenade <hugovk@users.noreply.github.com>
 # Copyright (c) 2019 Ashley Whetter <ashley@awhetter.co.uk>
+# Copyright (c) 2020 Gergely Kalmar <GergelyKalmar@users.noreply.github.com>
 
 import abc
 import collections

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -296,7 +296,11 @@ def _precache_zipimporters(path=None):
             pic[entry_path] = zipimport.zipimporter(entry_path)
         except zipimport.ZipImportError:
             continue
-    return {key: value for key, value in pic.items() if isinstance(value, zipimport.zipimporter)}
+    return {
+        key: value
+        for key, value in pic.items()
+        if isinstance(value, zipimport.zipimporter)
+    }
 
 
 def _search_zip(modpath, pic):

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -278,7 +278,7 @@ def _precache_zipimporters(path=None):
     in the sys.path_importer_cache, create a new zipimporter
     instance and add it into the cache.
     Return a dict associating all paths, stored in the cache, to corresponding
-    zipimporter instances
+    zipimporter instances.
 
     :param path: paths that has to be added into the cache
     :return: association between paths stored into the cache and zipimporter instances

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -277,7 +277,7 @@ def _precache_zipimporters(path=None):
     For each path that has not been already cached 
     in the sys.path_importer_cache, create a new zipimporter
     instance and add it into the cache.
-    Return a dict associating all paths, stored into the cache, to corresponding
+    Return a dict associating all paths, stored in the cache, to corresponding
     zipimporter instances
 
     :param path: paths that has to be added into the cache


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR is a variant from #811 . Instead of having different types of objects inside the `pic.items()` collection returned by the `_precache_zipimporters` function, the return value of this last one is filled only with `zipimporter` instances.
Thus the warning dealing with `find_spec/find_module` is no more present because `zipimporter` object have only `find_module` method.
For more details please read the conversation of #811.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related issue

Closes #703
