### PR TITLE
Fix a crash in functools.partial inference when the arguments cannot be determined

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -75,6 +75,11 @@ Release Date: TBA
 
   Close #835
 
+* Fix a crash in functools.partial inference when the arguments cannot be determined
+
+  Close PyCQA/pylint#3776
+
+
 What's New in astroid 2.4.3?
 ============================
 Release Date: TBA

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -86,11 +86,14 @@ def _functools_partial_inference(node, context=None):
 
     # Determine if the passed keywords into the callsite are supported
     # by the wrapped function.
-    function_parameters = chain(
-        inferred_wrapped_function.args.args or (),
-        inferred_wrapped_function.args.posonlyargs or (),
-        inferred_wrapped_function.args.kwonlyargs or (),
-    )
+    if not inferred_wrapped_function.args:
+        function_parameters = []
+    else:
+        function_parameters = chain(
+            inferred_wrapped_function.args.args or (),
+            inferred_wrapped_function.args.posonlyargs or (),
+            inferred_wrapped_function.args.kwonlyargs or (),
+        )
     parameter_names = set(
         param.name
         for param in function_parameters


### PR DESCRIPTION
## Description

Close PyCQA/pylint#3776

Unfortunately I could not find an example on how to reproduce this without the original reproduction example.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
