### PR TITLE
Fix a bug for dunder methods inference of function objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ Release Date: TBA
 
   Fixes PyCQA/pylint#3640
 
+* Fix a bug for dunder methods inference of function objects
+
+  Fixes #819
+
 * Fixes a bug in the signature of the ``ndarray.__or__`` method,
   in the ``brain_numpy_ndarray.py`` module.
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -324,6 +324,7 @@ class FunctionModel(ObjectModel):
                     doc=func.doc,
                     lineno=func.lineno,
                     col_offset=func.col_offset,
+                    parent=func.parent,
                 )
                 # pylint: disable=no-member
                 new_func.postinit(func.args, func.body, func.decorators, func.returns)

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -343,5 +343,16 @@ def test_ancestor_looking_up_redefined_function():
     assert isinstance(found[0], nodes.FunctionDef)
 
 
+def test_crash_in_dunder_inference_prevented():
+    code = """
+    class MyClass():
+        def fu(self, objects):
+            delitem = dict.__delitem__.__get__(self, dict)
+            delitem #@
+    """
+    inferred = next(extract_node(code).infer())
+    assert "builtins.dict.__delitem__" == inferred.qname()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

The inferred dunder methods of functions (`__delitem__` et al.) did not have a parent set on the inferred object, which results in all sorts of issues on `pylint` side.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
Fixes #819