### PR TITLE
Fix a crash in inference caused by `Uninferable` container elements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ Release Date: TBA
 
   Closes #703
 
+* Fix a crash in inference caused by `Uninferable` container elements
+
+  Close #866
+
 * Add `python 3.9` support.
 
 * The flat attribute of ``numpy.ndarray`` is now inferred as an ``numpy.ndarray`` itself.

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -224,6 +224,8 @@ def _container_generic_transform(arg, context, klass, iterables, build_elts):
             # TODO: Does not handle deduplication for sets.
             elts = []
             for element in arg.elts:
+                if not element:
+                    continue
                 inferred = helpers.safe_infer(element, context=context)
                 if inferred:
                     evaluated_object = nodes.EvaluatedObject(

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5884,5 +5884,19 @@ def test_infer_generated_setter():
     assert list(inferred.nodes_of_class(nodes.Const)) == []
 
 
+def test_infer_list_of_uninferables_does_not_crash():
+    code = """
+    x = [A] * 1
+    f = [x, [A] * 2]
+    x = list(f) + [] # List[Uninferable]
+    tuple(x[0])
+    """
+    node = extract_node(code)
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.Tuple)
+    # Would not be able to infer the first element.
+    assert not inferred.elts
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description
I managed to reproduce the original issue with this test, which shows that lists having elements as `Uninferable` would lead to a potential crash when we try to infer the `Uninferable` element.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue

Close #866
