### PR TITLE
``is_generator`` correctly considers `Yield` nodes in `AugAssign` nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -98,6 +98,12 @@ Release Date: TBA
 
   Close PyCQA/pylint#3686
 
+* ``is_generator`` correctly considers `Yield` nodes in `AugAssign` nodes
+
+  This fixes a false positive with the `assignment-from-no-return` pylint check.
+
+  Close PyCQA/pylint#3904
+
 
 What's New in astroid 2.4.2?
 ============================

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -2125,6 +2125,11 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         yield self.target
         yield self.value
 
+    def _get_yield_nodes_skip_lambdas(self):
+        """An AugAssign node can contain a Yield node in the value"""
+        yield from self.value._get_yield_nodes_skip_lambdas()
+        yield from super()._get_yield_nodes_skip_lambdas()
+
 
 class Repr(NodeNG):
     """Class representing an :class:`ast.Repr` node.

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1360,5 +1360,16 @@ def test_is_generator_for_yield_in_if():
     assert bool(node.is_generator())
 
 
+def test_is_generator_for_yield_in_aug_assign():
+    code = """
+    def test():
+        buf = ''
+        while True:
+            buf += yield
+    """
+    node = astroid.extract_node(code)
+    assert bool(node.is_generator())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This fixes a false positive with the `assignment-from-no-return` pylint check, which skips generators when checking from assignments from functions that don't return anything.


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
Close PyCQA/pylint#3904
