### PR TITLE
brain: Add `__class_getitem__` to `subprocess.Popen` starting from Python 3.9

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
 
+* Add ``__class_getitem__`` method to ``subprocess.Popen`` brain under Python 3.9 so that it is seen as subscriptable by pylint.
+
+  Fixes PyCQA/pylint#4034
+
 * Adds `degrees`, `radians`, which are `numpy ufunc` functions, in the `numpy` brain. Adds `random` function in the `numpy.random` brain.
 
   Fixes PyCQA/pylint#3856

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -14,6 +14,7 @@ import textwrap
 import astroid
 
 
+PY39 = sys.version_info >= (3, 9)
 PY37 = sys.version_info >= (3, 7)
 PY36 = sys.version_info >= (3, 6)
 
@@ -147,6 +148,12 @@ def _subprocess_transform():
             "py3_args": py3_args,
         }
     )
+    if PY39:
+        code += """
+    @classmethod
+    def __class_getitem__(cls, item):
+        pass
+        """
 
     init_lines = textwrap.dedent(init).splitlines()
     indented_init = "\n".join(" " * 4 + line for line in init_lines)

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1292,6 +1292,13 @@ class SubprocessTest(unittest.TestCase):
         assert isinstance(inferred, astroid.Const)
         assert isinstance(inferred.value, (str, bytes))
 
+    @test_utils.require_version("3.9")
+    def test_popen_does_not_have_class_getitem(self):
+        code = """import subprocess; subprocess.Popen"""
+        node = astroid.extract_node(code)
+        inferred = next(node.infer())
+        assert "__class_getitem__" in inferred
+
 
 class TestIsinstanceInference:
     """Test isinstance builtin inference"""


### PR DESCRIPTION

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes PyCQA/pylint#4034

## Description

This fix is necessary for pylint to detect that `subprocess.Popen` is subscriptable, starting from Python 3.9 (see PyCQA/pylint#4034).

pylint relies on the presence of `__class_getitem__()` to determine if a class is subcriptable. Starting from Python 3.9, `subprocess.Popen` implements this method (and is thus subscriptable):

    $ python3.9
    >>> import subprocess
    >>> subprocess.Popen.__class_getitem__
    <bound method GenericAlias of <class 'subprocess.Popen'>>