### PR TITLE
Bug pylint 4001

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@ astroid's ChangeLog
 What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
+* Adds a brain for type object so that it is possible to write `type[int]` in annotation.
+
+  Fixes PyCQA/pylint#4001
 
 * Adds `degrees`, `radians`, which are `numpy ufunc` functions, in the `numpy` brain. Adds `random` function in the `numpy.random` brain.
 

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -29,7 +29,7 @@ def _looks_like_type_subscript(node):
     Try to figure out if a Name node is used inside a type related subscript
 
     :param node: node to check
-    :type node: nodes.Name
+    :type node: astroid.node_classes.NodeNG
     :return: true if the node is a Name node inside a type related subscript
     :rtype: bool
     """

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -18,12 +18,7 @@ Thanks to Lukasz Langa for fruitful discussion.
 """
 import sys
 
-from astroid import (
-    MANAGER,
-    extract_node,
-    inference_tip,
-    nodes,
-)
+from astroid import MANAGER, extract_node, inference_tip, nodes
 
 
 def _looks_like_type_subscript(node):
@@ -58,7 +53,6 @@ def infer_type_sub(node, context=None):
      """
     node = extract_node(class_src)
     return node.infer(context=context)
-
 
 
 if sys.version_info[:2] == (3, 9):

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -1,4 +1,21 @@
 # -*- coding: utf-8 -*-
+"""
+Astroid hooks for type support.
+
+Starting from python3.9, type object behaves as it had __class_getitem__ method.
+However it was not possible to simply add this method inside type's body, otherwise
+all types would also have this method. In this case it would have been possible
+to write str[int].
+Guido Van Rossum proposed a hack to handle this in the interpreter:
+https://github.com/python/cpython/blob/master/Objects/abstract.c#L186-L189
+
+This brain follows the same logic. It is no wise to add permanently the __class_getitem__ method 
+to the type object. Instead we choose to add it only in the case of a subscript node
+which inside name node is type. 
+Doing this type[int] is allowed whereas str[int] is not.
+
+Thanks to Lukasz Langa for fruitful discussion.
+"""
 import sys
 
 from astroid import (
@@ -10,20 +27,30 @@ from astroid import (
 
 
 def _looks_like_type_subscript(node):
-    """Try to figure out if a Subscript node *might* be a typing-related subscript"""
-    if isinstance(node, nodes.Name):
+    """
+    Try to figure out if a Name node is used inside a type related subscript
+
+    :param node: node to check
+    :type node: nodes.Name
+    :return: true if the node is a Name node inside a type related subscript
+    :rtype: bool
+    """
+    if isinstance(node, nodes.Name) and isinstance(node.parent, nodes.Subscript):
         return node.name == "type"
-    if isinstance(node, nodes.Subscript):
-        if isinstance(node.value, Name) and node.value.name == "type":
-            return True
     return False
 
 
 def infer_type_sub(node, context=None):
-    """Infer a typing.X[...] subscript"""
-    sub_node = node.parent
-    if not isinstance(sub_node, nodes.Subscript):
-        raise UseInferenceDefault
+    """
+    Infer a type[...] subscript
+
+    :param node: node to infer
+    :type node: astroid.node_classes.NodeNG
+    :param context: inference context
+    :type context: astroid.context.InferenceContext
+    :return: the inferred node
+    :rtype: nodes.NodeNG
+    """
     class_src = """
     class type:
         def __class_getitem__(cls, key):

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -3,12 +3,9 @@ import sys
 
 from astroid import (
     MANAGER,
-    UseInferenceDefault,
     extract_node,
     inference_tip,
     nodes,
-    InferenceError,
-    Name,
 )
 
 

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import sys
+
+from astroid import (
+    MANAGER,
+    UseInferenceDefault,
+    extract_node,
+    inference_tip,
+    nodes,
+    InferenceError,
+    Name,
+)
+
+
+def _looks_like_type_subscript(node):
+    """Try to figure out if a Subscript node *might* be a typing-related subscript"""
+    if isinstance(node, nodes.Name):
+        return node.name == "type"
+    if isinstance(node, nodes.Subscript):
+        if isinstance(node.value, Name) and node.value.name == "type":
+            return True
+    return False
+
+
+def infer_type_sub(node, context=None):
+    """Infer a typing.X[...] subscript"""
+    sub_node = node.parent
+    if not isinstance(sub_node, nodes.Subscript):
+        raise UseInferenceDefault
+    class_src = """
+    class type:
+        def __class_getitem__(cls, key):
+            return cls
+     """
+    node = extract_node(class_src)
+    return node.infer(context=context)
+
+
+
+if sys.version_info[:2] == (3, 9):
+    MANAGER.register_transform(
+        nodes.Name, inference_tip(infer_type_sub), _looks_like_type_subscript
+    )

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -21,6 +21,9 @@ import sys
 from astroid import MANAGER, extract_node, inference_tip, nodes
 
 
+PY39 = sys.version_info >= (3, 9)
+
+
 def _looks_like_type_subscript(node):
     """
     Try to figure out if a Name node is used inside a type related subscript
@@ -55,7 +58,7 @@ def infer_type_sub(node, context=None):
     return node.infer(context=context)
 
 
-if sys.version_info[:2] == (3, 9):
+if PY39:
     MANAGER.register_transform(
         nodes.Name, inference_tip(infer_type_sub), _looks_like_type_subscript
     )

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -952,7 +952,7 @@ class TypeBrain(unittest.TestCase):
         val_inf = src.annotation.value.inferred()[0]
         self.assertIsInstance(val_inf, astroid.ClassDef)
         self.assertEqual(val_inf.name, "type")
-        meth_inf = val_inf.getattr('__class_getitem__')[0]
+        meth_inf = val_inf.getattr("__class_getitem__")[0]
         self.assertIsInstance(meth_inf, astroid.FunctionDef)
 
     def test_invalid_type_subscript(self):
@@ -970,7 +970,7 @@ class TypeBrain(unittest.TestCase):
         self.assertIsInstance(val_inf, astroid.ClassDef)
         self.assertEqual(val_inf.name, "str")
         with self.assertRaises(astroid.exceptions.AttributeInferenceError):
-            meth_inf = val_inf.getattr('__class_getitem__')[0]
+            meth_inf = val_inf.getattr("__class_getitem__")[0]
 
 
 @test_utils.require_version("3.6")

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -940,6 +940,10 @@ class IOBrainTest(unittest.TestCase):
 @test_utils.require_version("3.9")
 class TypeBrain(unittest.TestCase):
     def test_type_subscript(self):
+        """
+        Check that type object has the __class_getitem__ method
+        when it is used as a subscript
+        """
         src = builder.extract_node(
             """
             a: type[int] = int
@@ -952,6 +956,11 @@ class TypeBrain(unittest.TestCase):
         self.assertIsInstance(meth_inf, astroid.FunctionDef)
 
     def test_invalid_type_subscript(self):
+        """
+        Check that a type (str for example) that inherits
+        from type does not have __class_getitem__ method even
+        when it is used as a subscript
+        """
         src = builder.extract_node(
             """
             a: str[int] = "abc"

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -937,6 +937,33 @@ class IOBrainTest(unittest.TestCase):
             self.assertEqual(raw.name, "FileIO")
 
 
+@test_utils.require_version("3.9")
+class TypeBrain(unittest.TestCase):
+    def test_type_subscript(self):
+        src = builder.extract_node(
+            """
+            a: type[int] = int
+            """
+        )
+        val_inf = src.annotation.value.inferred()[0]
+        self.assertIsInstance(val_inf, astroid.ClassDef)
+        self.assertEqual(val_inf.name, "type")
+        meth_inf = val_inf.getattr('__class_getitem__')[0]
+        self.assertIsInstance(meth_inf, astroid.FunctionDef)
+
+    def test_invalid_type_subscript(self):
+        src = builder.extract_node(
+            """
+            a: str[int] = "abc"
+            """
+        )
+        val_inf = src.annotation.value.inferred()[0]
+        self.assertIsInstance(val_inf, astroid.ClassDef)
+        self.assertEqual(val_inf.name, "str")
+        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+            meth_inf = val_inf.getattr('__class_getitem__')[0]
+
+
 @test_utils.require_version("3.6")
 class TypingBrain(unittest.TestCase):
     def test_namedtuple_base(self):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR adds a brain to mock the fact that, starting with `python3.9`, `type` object should behave as it had a `__class_getitem__` method so that it is possible to use such annotation: `type[int]`.
Note that `python` types, that inherit from `type` object, do not have such method, otherwise it would be possible to use `str[int]` in annotation. 

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
