### PR TITLE
Sum and multiply clean

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@
 astroid's ChangeLog
 ===================
 
+* The ``context.path`` is now a ``dict`` and the ``context.push`` method
+  returns ``True`` if the node has been visited a certain amount of times.
+
+  Close #669
 
 What's New in astroid 2.5.0?
 ============================

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -106,6 +106,7 @@ def numpy_core_umath_transform():
     trunc = FakeUfuncOneArg()
 
     # Two args functions with optional kwargs
+    add = FakeUfuncTwoArgs()
     bitwise_and = FakeUfuncTwoArgs()
     bitwise_or = FakeUfuncTwoArgs()
     bitwise_xor = FakeUfuncTwoArgs()
@@ -133,6 +134,7 @@ def numpy_core_umath_transform():
     logical_xor = FakeUfuncTwoArgs()
     maximum = FakeUfuncTwoArgs()
     minimum = FakeUfuncTwoArgs()
+    multiply = FakeUfuncTwoArgs()
     nextafter = FakeUfuncTwoArgs()
     not_equal = FakeUfuncTwoArgs()
     power = FakeUfuncTwoArgs()

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -29,8 +29,10 @@ class InferenceContext:
         "extra_context",
     )
 
+    maximum_path_visit = 3
+
     def __init__(self, path=None, inferred=None):
-        self.path = path or set()
+        self.path = path or dict()
         """
         :type: set(tuple(NodeNG, optional(str)))
 
@@ -87,10 +89,10 @@ class InferenceContext:
         Allows one to see if the given node has already
         been looked at for this inference context"""
         name = self.lookupname
-        if (node, name) in self.path:
+        if self.path.get((node, name), 0) >= self.maximum_path_visit:
             return True
 
-        self.path.add((node, name))
+        self.path[(node, name)] = self.path.setdefault((node, name), 0) + 1
         return False
 
     def clone(self):
@@ -108,7 +110,7 @@ class InferenceContext:
 
     @contextlib.contextmanager
     def restore_path(self):
-        path = set(self.path)
+        path = dict(self.path)
         yield
         self.path = path
 

--- a/tests/unittest_brain_numpy_core_umath.py
+++ b/tests/unittest_brain_numpy_core_umath.py
@@ -65,6 +65,7 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
     )
 
     two_args_ufunc = (
+        "add",
         "bitwise_and",
         "bitwise_or",
         "bitwise_xor",
@@ -92,6 +93,7 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
         "logical_xor",
         "maximum",
         "minimum",
+        "multiply",
         "nextafter",
         "not_equal",
         "power",
@@ -224,11 +226,9 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
             with self.subTest(typ=func_):
                 inferred_values = list(self._inferred_numpy_func_call(func_))
                 self.assertTrue(
-                    len(inferred_values) == 1
-                    or len(inferred_values) == 2
-                    and inferred_values[-1].pytype() is util.Uninferable,
+                    len(inferred_values) == 1,
                     msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values[-1].pytype(), func_
+                        inferred_values, func_
                     ),
                 )
                 self.assertTrue(

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1301,7 +1301,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         result = node.inferred()
         assert len(result) == 2
         assert isinstance(result[0], nodes.Dict)
-        assert result[1] is util.Uninferable
+        assert isinstance(result[1], nodes.Dict)
 
     def test_python25_no_relative_import(self):
         ast = resources.build_file("data/package/absimport.py")
@@ -3656,7 +3656,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         flow = AttributeDict()
         flow['app'] = AttributeDict()
         flow['app']['config'] = AttributeDict()
-        flow['app']['config']['doffing'] = AttributeDict() #@
+        flow['app']['config']['doffing'] = AttributeDict()
+        flow['app']['config']['doffing']['thinkto'] = AttributeDict() #@
         """
         )
         self.assertIsNone(helpers.safe_infer(ast_node.targets[0]))

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -93,7 +93,7 @@ class NonRegressionTests(resources.AstroidCacheSetupMixin, unittest.TestCase):
         data = """
 from numpy import multiply
 
-multiply(1, 2, 3)
+multiply([1, 2], [3, 4])
 """
         astroid = builder.string_build(data, __name__, __file__)
         callfunc = astroid.body[1].value.func


### PR DESCRIPTION
Just the same PR as `sum_and_multiply` with a cleaner log history.
No need to review