### PR TITLE
Julien palard mdk/class getitem

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,11 +6,14 @@ What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
 
+* Enrich the ``brain_collection`` module so that ``__class_getitem__`` method is added to `deque` for
+  ``python`` version above 3.9.
+
 * The ``context.path`` is now a ``dict`` and the ``context.push`` method
   returns ``True`` if the node has been visited a certain amount of times.
 
   Close #669
-  
+
 * Adds a brain for type object so that it is possible to write `type[int]` in annotation.
 
   Fixes PyCQA/pylint#4001

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,14 +2,15 @@
 astroid's ChangeLog
 ===================
 
+What's New in astroid 2.5.0?
+============================
+Release Date: TBA
+
 * The ``context.path`` is now a ``dict`` and the ``context.push`` method
   returns ``True`` if the node has been visited a certain amount of times.
 
   Close #669
-
-What's New in astroid 2.5.0?
-============================
-Release Date: TBA
+  
 * Adds a brain for type object so that it is possible to write `type[int]` in annotation.
 
   Fixes PyCQA/pylint#4001

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -12,6 +12,9 @@ import sys
 import astroid
 
 
+PY39 = sys.version_info >= (3, 9)
+
+
 def _collections_transform():
     return astroid.parse(
         """
@@ -60,7 +63,9 @@ def _deque_mock():
         def __iadd__(self, other): pass
         def __mul__(self, other): pass
         def __imul__(self, other): pass
-        def __rmul__(self, other): pass
+        def __rmul__(self, other): pass"""
+    if PY39:
+        base_deque_class += """
         @classmethod
         def __class_getitem__(self, item): pass"""
     return base_deque_class

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2017 Derek Gustafson <degustaf@gmail.com>
 # Copyright (c) 2018 Ioana Tagirta <ioana.tagirta@gmail.com>
 # Copyright (c) 2019 Hugo van Kemenade <hugovk@users.noreply.github.com>
+# Copyright (c) 2021 Julien Palard <julien@palard.fr>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -141,6 +141,17 @@ class CollectionsDequeTests(unittest.TestCase):
         self.assertIn("insert", inferred.locals)
         self.assertIn("index", inferred.locals)
 
+    @test_utils.require_version(maxver="3.8")
+    def test_deque_not_py39methods(self):
+        inferred = self._inferred_queue_instance()
+        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+            inferred.getattr("__class_getitem__")
+
+    @test_utils.require_version(minver="3.9")
+    def test_deque_py39methods(self):
+        inferred = self._inferred_queue_instance()
+        self.assertTrue(inferred.getattr("__class_getitem__"))
+
 
 class OrderedDictTest(unittest.TestCase):
     def _inferred_ordered_dict_instance(self):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR completes #856 of @JulienPalard with unittests and the ability to distinguish between python versions to add the method `__class_getitem__` only for python versions above 3.9.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #855

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
