### PR TITLE
Corrected the parent of function type comment nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -119,6 +119,13 @@ Release Date: TBA
 
   Close PyCQA/pylint#3904
 
+* Corrected the parent of function type comment nodes.
+
+  These nodes used to be parented to their original ast.FunctionDef parent
+  but are now correctly parented to their astroid.FunctionDef parent.
+
+  Close PyCQA/astroid#851
+
 
 What's New in astroid 2.4.2?
 ============================

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -238,7 +238,7 @@ class TreeRebuilder:
 
         return type_object.value
 
-    def check_function_type_comment(self, node):
+    def check_function_type_comment(self, node, parent):
         type_comment = getattr(node, "type_comment", None)
         if not type_comment:
             return None
@@ -251,10 +251,10 @@ class TreeRebuilder:
 
         returns = None
         argtypes = [
-            self.visit(elem, node) for elem in (type_comment_ast.argtypes or [])
+            self.visit(elem, parent) for elem in (type_comment_ast.argtypes or [])
         ]
         if type_comment_ast.returns:
-            returns = self.visit(type_comment_ast.returns, node)
+            returns = self.visit(type_comment_ast.returns, parent)
 
         return returns, argtypes
 
@@ -615,7 +615,7 @@ class TreeRebuilder:
             returns = None
 
         type_comment_args = type_comment_returns = None
-        type_comment_annotation = self.check_function_type_comment(node)
+        type_comment_annotation = self.check_function_type_comment(node, newnode)
         if type_comment_annotation:
             type_comment_returns, type_comment_args = type_comment_annotation
         newnode.postinit(

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1181,6 +1181,19 @@ def test_type_comments_posonly_arguments():
                 assert actual_arg.as_string() == expected_arg
 
 
+@pytest.mark.skipif(not HAS_TYPED_AST, reason="requires typed_ast")
+def test_correct_function_type_comment_parent():
+    data = """
+        def f(a):
+            # type: (A) -> A
+            pass
+    """
+    astroid = builder.parse(data)
+    f = astroid.body[0]
+    assert f.type_comment_args[0].parent is f
+    assert f.type_comment_returns.parent is f
+
+
 def test_is_generator_for_yield_assignments():
     node = astroid.extract_node(
         """


### PR DESCRIPTION
## Description

Nodes that represent type comments for a function are currently parented to their original ast.FunctionDef parent
but are now correctly parented to their astroid.FunctionDef parent.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|    | :sparkles: New feature |
|    | :hammer: Refactoring  |
|    | :scroll: Docs |

## Related Issue

Closes #851 
