### PR TITLE
Fix regression property no member 2641

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.5.0?
 ============================
 Release Date: TBA
 
+* Adds `attr_fset` in the `PropertyModel` class.
+
+  Fixes PyCQA/pylint#3480
+
 * Remove support for Python 3.5.
 * Remove the runtime dependency on ``six``. The ``six`` brain remains in
   astroid.

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -775,7 +775,6 @@ class PropertyModel(ObjectModel):
     @property
     def attr_fget(self):
         from astroid.scoped_nodes import FunctionDef
-        from astroid.node_classes import Arguments, AssignName
 
         func = self._instance
 
@@ -791,19 +790,8 @@ class PropertyModel(ObjectModel):
                     caller=caller, context=context
                 )
 
-        l_args = Arguments()
-        l_args.postinit(
-            args=[AssignName(name="self")],
-            defaults=[],
-            kwonlyargs=[],
-            kw_defaults=[],
-            annotations=[],
-            posonlyargs=[],
-            posonlyargs_annotations=[],
-            kwonlyargs_annotations=[],
-        )
         property_accessor = PropertyFuncAccessor(name="fget", parent=self._instance)
-        property_accessor.postinit(args=l_args, body=func.body)
+        property_accessor.postinit(args=func.args, body=func.body)
         return property_accessor
 
     @property

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -797,9 +797,9 @@ class PropertyModel(ObjectModel):
     @property
     def attr_fset(self):
         from astroid.scoped_nodes import FunctionDef
+        from astroid.node_classes import Arguments, AssignName
 
         func = self._instance
-
         class PropertyFuncAccessor(FunctionDef):
             def infer_call_result(self, caller=None, context=None):
                 nonlocal func
@@ -813,7 +813,18 @@ class PropertyModel(ObjectModel):
                 )
 
         property_accessor = PropertyFuncAccessor(name="fset", parent=self._instance)
-        property_accessor.postinit(args=func.args, body=func.body)
+        l_args = Arguments()
+        l_args.postinit(
+            args=[AssignName(name="self"), AssignName(name="value")],
+            defaults=[],
+            kwonlyargs=[],
+            kw_defaults=[],
+            annotations=[],
+            posonlyargs=[],
+            posonlyargs_annotations=[],
+            kwonlyargs_annotations=[],
+        )
+        property_accessor.postinit(args=l_args, body=func.body)
         return property_accessor
 
     @property

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -775,6 +775,7 @@ class PropertyModel(ObjectModel):
     @property
     def attr_fget(self):
         from astroid.scoped_nodes import FunctionDef
+        from astroid.node_classes import Arguments, AssignName
 
         func = self._instance
 
@@ -790,8 +791,19 @@ class PropertyModel(ObjectModel):
                     caller=caller, context=context
                 )
 
+        l_args = Arguments()
+        l_args.postinit(
+            args=[AssignName(name="self")],
+            defaults=[],
+            kwonlyargs=[],
+            kw_defaults=[],
+            annotations=[],
+            posonlyargs=[],
+            posonlyargs_annotations=[],
+            kwonlyargs_annotations=[],
+        )
         property_accessor = PropertyFuncAccessor(name="fget", parent=self._instance)
-        property_accessor.postinit(args=func.args, body=func.body)
+        property_accessor.postinit(args=l_args, body=func.body)
         return property_accessor
 
     @property

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5440,14 +5440,19 @@ def test_property_inference():
         def test(self):
             return 42
 
+        @test.setter
+        def test(self, value):
+            return "banco"
+
     A.test #@
     A().test #@
     A.test.fget(A) #@
+    A.test.fset(A, "a_value") #@
     A.test.setter #@
     A.test.getter #@
     A.test.deleter #@
     """
-    prop, prop_result, prop_fget_result, prop_setter, prop_getter, prop_deleter = extract_node(
+    prop, prop_result, prop_fget_result, prop_fset_result, prop_setter, prop_getter, prop_deleter = extract_node(
         code
     )
 
@@ -5464,6 +5469,10 @@ def test_property_inference():
     inferred = next(prop_fget_result.infer())
     assert isinstance(inferred, nodes.Const)
     assert inferred.value == 42
+
+    inferred = next(prop_fset_result.infer())
+    assert isinstance(inferred, nodes.Const)
+    assert inferred.value == "banco"
 
     for prop_func in prop_setter, prop_getter, prop_deleter:
         inferred = next(prop_func.infer())


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR adds the `attr_fset` method to the `PropertModel` class, so that `pylint` is able to deal with property setter.
The need for such a fix has been highlighted with #740 and is confirmed by the bug report PyCQA/pylint#3480.


## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes PyCQA/pylint#3480
