### PR TITLE
Fix six with metaclass

### DIFF
--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -221,7 +221,6 @@ def transform_six_with_metaclass(node):
     """
     call = node.bases[0]
     node._metaclass = call.args[0]
-    node.bases = call.args[1:]
 
 
 register_module_extender(MANAGER, "six", six_moves_transform)

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3793,34 +3793,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertEqual(inferred.name, "B")
 
-    def test_With_metaclass_subclasses_inheritance(self):
-        ast_node = extract_node(
-            """
-        class A(type):
-            def test(cls):
-                return cls
-
-        class C:
-            pass
-
-        import six
-        class B(six.with_metaclass(A, C)):
-            pass
-
-        B #@
-        """
-        )
-        inferred = next(ast_node.infer())
-        self.assertIsInstance(inferred, nodes.ClassDef)
-        self.assertEqual(inferred.name, "B")
-        bases = inferred.bases
-        self.assertIsInstance(bases[0], nodes.Call)
-        ancestors = tuple(inferred.ancestors())
-        self.assertIsInstance(ancestors[0], nodes.ClassDef)
-        self.assertEqual(ancestors[0].name, "C")
-        self.assertIsInstance(ancestors[1], nodes.ClassDef)
-        self.assertEqual(ancestors[1].name, "object")
-
     def test_With_metaclass_with_partial_imported_name(self):
         ast_node = extract_node(
             """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3793,6 +3793,34 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertEqual(inferred.name, "B")
 
+    def test_With_metaclass_subclasses_inheritance(self):
+        ast_node = extract_node(
+            """
+        class A(type):
+            def test(cls):
+                return cls
+
+        class C:
+            pass
+
+        import six
+        class B(six.with_metaclass(A, C)):
+            pass
+
+        B #@
+        """
+        )
+        inferred = next(ast_node.infer())
+        self.assertIsInstance(inferred, nodes.ClassDef)
+        self.assertEqual(inferred.name, "B")
+        bases = inferred.bases
+        self.assertIsInstance(bases[0], nodes.Call)
+        ancestors = tuple(inferred.ancestors())
+        self.assertIsInstance(ancestors[0], nodes.ClassDef)
+        self.assertEqual(ancestors[0].name, "C")
+        self.assertIsInstance(ancestors[1], nodes.ClassDef)
+        self.assertEqual(ancestors[1].name, "object")
+
     def test_With_metaclass_with_partial_imported_name(self):
         ast_node = extract_node(
             """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR corrects the brain dealing with `six.with_metaclass`.
The error came from the tweaking of the node bases. It has not to be done. 
For example, following code:
```
from astroid import extract_node
src = """
class A:
    pass

def get_parent():
    return A

class B(get_parent()):
    pass

B
"""
node=extract_node(src)
cls_node = node.inferred()[0]
print(list(cls_node.bases))
print(list(cls_node.ancestors()))
```
gives:
```
[<Call l.8 at 0x7f0ad5ecc250>]
[<ClassDef.A l.2 at 0x7f0ad5faf350>, <ClassDef.object l.0 at 0x7f0ad6ea45d0>]
```
The base is a CallNode, whereas the ancestors are ClassDef from the class hierarchy.
Thus in the `six.with_metaclass` case, the base has to be a call node.
Doing this, the `six` module is seen as really used and this avoids the emission of `unused-import` message.

This PR should correct the failing CI on `pylint` side.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
Failing CI on `pylint`.
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
