### PR TITLE
Bug astroid 895 899

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
 astroid's ChangeLog
 ===================
 
+What's New in astroid 2.5.1?
+============================
+Release Date: TBA
+
+* The ``context.path`` is reverted to a set because otherwise it leds to false positives 
+  for non `numpy` functions.
+
+  Closes #895 #899
+
 What's New in astroid 2.5?
 ============================
 Release Date: 2021-02-15

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -30,10 +30,8 @@ class InferenceContext:
         "extra_context",
     )
 
-    maximum_path_visit = 3
-
     def __init__(self, path=None, inferred=None):
-        self.path = path or dict()
+        self.path = path or set()
         """
         :type: set(tuple(NodeNG, optional(str)))
 
@@ -90,10 +88,10 @@ class InferenceContext:
         Allows one to see if the given node has already
         been looked at for this inference context"""
         name = self.lookupname
-        if self.path.get((node, name), 0) >= self.maximum_path_visit:
+        if (node, name) in self.path:
             return True
 
-        self.path[(node, name)] = self.path.setdefault((node, name), 0) + 1
+        self.path.add((node, name))
         return False
 
     def clone(self):
@@ -111,7 +109,7 @@ class InferenceContext:
 
     @contextlib.contextmanager
     def restore_path(self):
-        path = dict(self.path)
+        path = set(self.path)
         yield
         self.path = path
 

--- a/tests/unittest_brain_numpy_core_umath.py
+++ b/tests/unittest_brain_numpy_core_umath.py
@@ -226,9 +226,11 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
             with self.subTest(typ=func_):
                 inferred_values = list(self._inferred_numpy_func_call(func_))
                 self.assertTrue(
-                    len(inferred_values) == 1,
+                    len(inferred_values) == 1
+                    or len(inferred_values) == 2
+                    and inferred_values[-1].pytype() is util.Uninferable,
                     msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values, func_
+                        inferred_values[-1].pytype(), func_
                     ),
                 )
                 self.assertTrue(

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1301,7 +1301,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         result = node.inferred()
         assert len(result) == 2
         assert isinstance(result[0], nodes.Dict)
-        assert isinstance(result[1], nodes.Dict)
+        assert result[1] is util.Uninferable
 
     def test_python25_no_relative_import(self):
         ast = resources.build_file("data/package/absimport.py")
@@ -3686,8 +3686,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         flow = AttributeDict()
         flow['app'] = AttributeDict()
         flow['app']['config'] = AttributeDict()
-        flow['app']['config']['doffing'] = AttributeDict()
-        flow['app']['config']['doffing']['thinkto'] = AttributeDict() #@
+        flow['app']['config']['doffing'] = AttributeDict() #@
         """
         )
         self.assertIsNone(helpers.safe_infer(ast_node.targets[0]))

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -99,7 +99,7 @@ multiply([1, 2], [3, 4])
         astroid = builder.string_build(data, __name__, __file__)
         callfunc = astroid.body[1].value.func
         inferred = callfunc.inferred()
-        self.assertEqual(len(inferred), 1)
+        self.assertEqual(len(inferred), 2)
 
     def test_nameconstant(self):
         # used to fail for Python 3.4


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR reverts #884. The goal of this PR was to ensure that `numpy` ufunc functions where inferred unconditionally as ufunc objects (i.e Uninferable was not part of the inferred values).
However doing this led to false positives such as #895 and #899. The modules used in those bug reports do not have anything to do with `astroid` brain. They use the classical astroid engine (when i say classical it means no use of brains).
IMHO it is not acceptable that trying to improve `numpy` inference (which already uses astroid brains) leds to downgrading inference of other modules. That's why i propose this PR.

In case `numpy` inference really has to be improved, i'll try to find another solution.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Related Issue
Closes #895 #899
<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
