### PR TITLE
Update license metadata

### DIFF
--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -35,7 +35,7 @@ install_requires = [
 ]
 
 # pylint: disable=redefined-builtin; why license is a builtin anyway?
-license = "LGPL"
+license = "LGPL-2.1-or-later"
 
 author = "Python Code Quality Authority"
 author_email = "code-quality@python.org"


### PR DESCRIPTION
## Description
Updated metadata license information to the correct SPDX license tag: `LGPL-2.1-or-later`.

https://spdx.org/licenses/


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

--

This should be safe to cherry-pick for `2.5.1`.