### PR TITLE
Fix duplicate bases error (MROs) with GenericAlias

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ Release Date: TBA
 
   Closes #895 #899
 
+* Fixed duplicate bases error for "typing._GenericAlias" (false-positive)
+
+  Closes #905
+
 What's New in astroid 2.5?
 ============================
 Release Date: 2021-02-15

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,7 @@ Release Date: TBA
 
   Closes #895 #899
 
-* Fixed duplicate bases error for "typing._GenericAlias" (false-positive)
+* Use flag to guard DuplicateBasesError
 
   Closes #905
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -105,7 +105,12 @@ def clean_duplicates_mro(sequences, cls, context):
             (node.lineno, node.qname()) if node.name else None for node in sequence
         ]
         last_index = dict(map(reversed, enumerate(names)))
-        if names and names[0] is not None and last_index[names[0]] != 0:
+        if (
+            names
+            and names[0] is not None
+            and last_index[names[0]] != 0
+            and names[0][1] != "typing._GenericAlias"
+        ):
             raise exceptions.DuplicateBasesError(
                 message="Duplicates found in MROs {mros} for {cls!r}.",
                 mros=sequences,

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1436,6 +1436,62 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         )
         self.assertEqualMro(cls, ["C", "A", "B", "object"])
 
+    @test_utils.require_version("3.7", "3.9")
+    def test_mro_with_duplicate_generic_alias(self):
+        """Catch false positive. Assert no error is thrown."""
+        cls = builder.extract_node(
+            """
+        import abc
+        from typing import Sized, Iterable
+        class AbstractRoute(abc.ABC):
+            pass
+        class AbstractResource(Sized, Iterable["AbstractRoute"]):
+            pass
+        class IndexView(AbstractResource):
+            def __init__(self):
+                self.var = 1
+        """
+        )
+        self.assertEqualMro(
+            cls,
+            [
+                "IndexView",
+                "AbstractResource",
+                "_GenericAlias",
+                "_Final",
+                "_GenericAlias",
+                "object",
+            ],
+        )
+
+    @test_utils.require_version("3.9")
+    def test_mro_with_duplicate_generic_alias_2(self):
+        cls = builder.extract_node(
+            """
+        import abc
+        from typing import Sized, Iterable
+        class AbstractRoute(abc.ABC):
+            pass
+        class AbstractResource(Sized, Iterable["AbstractRoute"]):
+            pass
+        class IndexView(AbstractResource):
+            def __init__(self):
+                self.var = 1
+        """
+        )
+        self.assertEqualMro(
+            cls,
+            [
+                "IndexView",
+                "AbstractResource",
+                "_SpecialGenericAlias",
+                "_BaseGenericAlias",
+                "_Final",
+                "_SpecialGenericAlias",
+                "object",
+            ],
+        )
+
     def test_generator_from_infer_call_result_parent(self):
         func = builder.extract_node(
             """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Fix duplicate bases error that occurred for Python `<3.9` when using multiple inheritance from `_GenericAlias`. Starting with `3.9` this is parsed differently as `_SpecialGenericAlias` and `_BaseGenericAlias`.

--

As this is a bug fix, it would be great if it could be included in the next release `2.5.1`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
Closes #905 