### PR TITLE
Improve typing.TypedDict inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ Release Date: TBA
 
   Closes #895 #899
 
+* Improve typing.TypedDict inference
+
+
 What's New in astroid 2.5?
 ============================
 Release Date: 2021-02-15

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -91,9 +91,7 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
     node: nodes.FunctionDef,
 ) -> bool:
     """Check if node is TypedDict FunctionDef."""
-    if isinstance(node, nodes.FunctionDef) and node.name == "TypedDict":
-        return True
-    return False
+    return isinstance(node, nodes.FunctionDef) and node.name == "TypedDict"
 
 
 def infer_typedDict(  # pylint: disable=invalid-name

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -17,6 +17,7 @@ from astroid import (
     InferenceError,
 )
 
+PY39 = sys.version_info[:2] >= (3, 9)
 
 TYPING_NAMEDTUPLE_BASENAMES = {"NamedTuple", "typing.NamedTuple"}
 TYPING_TYPEVARS = {"TypeVar", "NewType"}
@@ -98,8 +99,6 @@ def infer_typedDict(  # pylint: disable=invalid-name
     node: nodes.FunctionDef, ctx: context.InferenceContext = None
 ) -> None:
     """Replace TypedDict FunctionDef with ClassDef."""
-    if sys.version_info < (3, 9):
-        return
     class_def = nodes.ClassDef(
         name="TypedDict",
         doc=node.doc,
@@ -120,4 +119,7 @@ MANAGER.register_transform(
     nodes.Subscript, inference_tip(infer_typing_attr), _looks_like_typing_subscript
 )
 
-MANAGER.register_transform(nodes.FunctionDef, infer_typedDict, _looks_like_typedDict)
+if PY39:
+    MANAGER.register_transform(
+        nodes.FunctionDef, infer_typedDict, _looks_like_typedDict
+    )

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2018 Bryce Guinta <bryce.paul.guinta@gmail.com>
 
 """Astroid hooks for typing.py support."""
+import sys
 import typing
 
 from astroid import (
@@ -96,9 +97,11 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
 
 
 def infer_typedDict(  # pylint: disable=invalid-name
-    node: nodes.FunctionDef, context: context.InferenceContext = None
+    node: nodes.FunctionDef, ctx: context.InferenceContext = None
 ) -> None:
     """Replace TypedDict FunctionDef with ClassDef."""
+    if sys.version_info < (3, 9):
+        return
     class_def = nodes.ClassDef(
         name="TypedDict",
         doc=node.doc,
@@ -108,7 +111,6 @@ def infer_typedDict(  # pylint: disable=invalid-name
     )
     class_def.postinit(bases=[], body=[], decorators=None)
     node.root().locals["TypedDict"] = [class_def]
-    return None
 
 
 MANAGER.register_transform(

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1188,6 +1188,9 @@ class TypingBrain(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, astroid.Instance)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="TypedDict changed from version 3.8 to 3.9"
+    )
     def test_typedDict(self):
         node = builder.extract_node(
             """

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1188,6 +1188,21 @@ class TypingBrain(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, astroid.Instance)
 
+    def test_typedDict(self):
+        node = builder.extract_node(
+            """
+        from typing import TypedDict
+        class CustomTD(TypedDict):
+            var: int
+        """
+        )
+        assert len(node.bases) == 1
+        inferred_base = next(node.bases[0].infer())
+        self.assertIsInstance(inferred_base, nodes.ClassDef, node.as_string())
+        typing_module = inferred_base.root()
+        assert len(typing_module.locals["TypedDict"]) == 1
+        assert inferred_base == typing_module.locals["TypedDict"][0]
+
 
 class ReBrainTest(unittest.TestCase):
     def test_regex_flags(self):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1188,9 +1188,7 @@ class TypingBrain(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, astroid.Instance)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="TypedDict changed from version 3.8 to 3.9"
-    )
+    @test_utils.require_version("3.8")
     def test_typedDict(self):
         node = builder.extract_node(
             """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Beginning with Python **3.9** `typing.TypedDict`s are defined as functions instead of classes. That causes `inherit-non-class` errors in pylint. https://github.com/PyCQA/pylint/pull/4072 addressed it, but only by hiding the error message.

This change rewrites the `TypedDict` base from `astroid.FunctionDef` to `astroid.ClassDef`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue
https://github.com/PyCQA/pylint/pull/4072
