### PR TITLE
Bug pylint 3974

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ What's New in astroid 2.5.2?
 ============================
 Release Date: TBA
 
+* Detects `import numpy` as a valid `numpy` import.
+
+  Closes PyCQA/pylint#3974
+
 
 What's New in astroid 2.5.1?
 ============================

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -33,7 +33,10 @@ def _is_a_numpy_module(node: astroid.node_classes.Name) -> bool:
         x for x in node.lookup(module_nickname)[1] if isinstance(x, astroid.Import)
     ]
     for target in potential_import_target:
-        if ("numpy", module_nickname) in target.names or ("numpy", None) in target.names:
+        if ("numpy", module_nickname) in target.names or (
+            "numpy",
+            None,
+        ) in target.names:
             return True
     return False
 

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -33,7 +33,7 @@ def _is_a_numpy_module(node: astroid.node_classes.Name) -> bool:
         x for x in node.lookup(module_nickname)[1] if isinstance(x, astroid.Import)
     ]
     for target in potential_import_target:
-        if ("numpy", module_nickname) in target.names:
+        if ("numpy", module_nickname) in target.names or ("numpy", None) in target.names:
             return True
     return False
 

--- a/tests/unittest_brain_numpy_core_multiarray.py
+++ b/tests/unittest_brain_numpy_core_multiarray.py
@@ -77,105 +77,122 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         )
         return node.infer()
 
+    def _inferred_numpy_no_alias_func_call(self, func_name, *func_args):
+        node = builder.extract_node(
+            """
+        import numpy
+        func = numpy.{:s}
+        func({:s})
+        """.format(
+                func_name, ",".join(func_args)
+            )
+        )
+        return node.infer()
+
     def test_numpy_function_calls_inferred_as_ndarray(self):
         """
         Test that calls to numpy functions are inferred as numpy.ndarray
         """
-        for func_ in self.numpy_functions_returning_array:
-            with self.subTest(typ=func_):
-                inferred_values = list(self._inferred_numpy_func_call(*func_))
-                self.assertTrue(
-                    len(inferred_values) == 1,
-                    msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values, func_[0]
-                    ),
-                )
-                self.assertTrue(
-                    inferred_values[-1].pytype() == ".ndarray",
-                    msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values[-1].pytype()
-                    ),
-                )
+        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+            for func_ in self.numpy_functions_returning_array:
+                with self.subTest(typ=func_):
+                    inferred_values = list(infer_wrapper(*func_))
+                    self.assertTrue(
+                        len(inferred_values) == 1,
+                        msg="Too much inferred values ({}) for {:s}".format(
+                            inferred_values, func_[0]
+                        ),
+                    )
+                    self.assertTrue(
+                        inferred_values[-1].pytype() == ".ndarray",
+                        msg="Illicit type for {:s} ({})".format(
+                            func_[0], inferred_values[-1].pytype()
+                        ),
+                    )
 
     def test_numpy_function_calls_inferred_as_bool(self):
         """
         Test that calls to numpy functions are inferred as bool
         """
-        for func_ in self.numpy_functions_returning_bool:
-            with self.subTest(typ=func_):
-                inferred_values = list(self._inferred_numpy_func_call(*func_))
-                self.assertTrue(
-                    len(inferred_values) == 1,
-                    msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values, func_[0]
-                    ),
-                )
-                self.assertTrue(
-                    inferred_values[-1].pytype() == "builtins.bool",
-                    msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values[-1].pytype()
-                    ),
-                )
+        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+            for func_ in self.numpy_functions_returning_bool:
+                with self.subTest(typ=func_):
+                    inferred_values = list(infer_wrapper(*func_))
+                    self.assertTrue(
+                        len(inferred_values) == 1,
+                        msg="Too much inferred values ({}) for {:s}".format(
+                            inferred_values, func_[0]
+                        ),
+                    )
+                    self.assertTrue(
+                        inferred_values[-1].pytype() == "builtins.bool",
+                        msg="Illicit type for {:s} ({})".format(
+                            func_[0], inferred_values[-1].pytype()
+                        ),
+                    )
 
     def test_numpy_function_calls_inferred_as_dtype(self):
         """
         Test that calls to numpy functions are inferred as numpy.dtype
         """
-        for func_ in self.numpy_functions_returning_dtype:
-            with self.subTest(typ=func_):
-                inferred_values = list(self._inferred_numpy_func_call(*func_))
-                self.assertTrue(
-                    len(inferred_values) == 1,
-                    msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values, func_[0]
-                    ),
-                )
-                self.assertTrue(
-                    inferred_values[-1].pytype() == "numpy.dtype",
-                    msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values[-1].pytype()
-                    ),
-                )
+        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+            for func_ in self.numpy_functions_returning_dtype:
+                with self.subTest(typ=func_):
+                    inferred_values = list(infer_wrapper(*func_))
+                    self.assertTrue(
+                        len(inferred_values) == 1,
+                        msg="Too much inferred values ({}) for {:s}".format(
+                            inferred_values, func_[0]
+                        ),
+                    )
+                    self.assertTrue(
+                        inferred_values[-1].pytype() == "numpy.dtype",
+                        msg="Illicit type for {:s} ({})".format(
+                            func_[0], inferred_values[-1].pytype()
+                        ),
+                    )
 
     def test_numpy_function_calls_inferred_as_none(self):
         """
         Test that calls to numpy functions are inferred as None
         """
-        for func_ in self.numpy_functions_returning_none:
-            with self.subTest(typ=func_):
-                inferred_values = list(self._inferred_numpy_func_call(*func_))
-                self.assertTrue(
-                    len(inferred_values) == 1,
-                    msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values, func_[0]
-                    ),
-                )
-                self.assertTrue(
-                    inferred_values[-1].pytype() == "builtins.NoneType",
-                    msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values[-1].pytype()
-                    ),
-                )
+        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+            for func_ in self.numpy_functions_returning_none:
+                with self.subTest(typ=func_):
+                    inferred_values = list(infer_wrapper(*func_))
+                    self.assertTrue(
+                        len(inferred_values) == 1,
+                        msg="Too much inferred values ({}) for {:s}".format(
+                            inferred_values, func_[0]
+                        ),
+                    )
+                    self.assertTrue(
+                        inferred_values[-1].pytype() == "builtins.NoneType",
+                        msg="Illicit type for {:s} ({})".format(
+                            func_[0], inferred_values[-1].pytype()
+                        ),
+                    )
 
     def test_numpy_function_calls_inferred_as_tuple(self):
         """
         Test that calls to numpy functions are inferred as tuple
         """
-        for func_ in self.numpy_functions_returning_tuple:
-            with self.subTest(typ=func_):
-                inferred_values = list(self._inferred_numpy_func_call(*func_))
-                self.assertTrue(
-                    len(inferred_values) == 1,
-                    msg="Too much inferred values ({}) for {:s}".format(
-                        inferred_values, func_[0]
-                    ),
-                )
-                self.assertTrue(
-                    inferred_values[-1].pytype() == "builtins.tuple",
-                    msg="Illicit type for {:s} ({})".format(
-                        func_[0], inferred_values[-1].pytype()
-                    ),
-                )
+        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+            for func_ in self.numpy_functions_returning_tuple:
+                with self.subTest(typ=func_):
+                    inferred_values = list(infer_wrapper(*func_))
+                    self.assertTrue(
+                        len(inferred_values) == 1,
+                        msg="Too much inferred values ({}) for {:s}".format(
+                            inferred_values, func_[0]
+                        ),
+                    )
+                    self.assertTrue(
+                        inferred_values[-1].pytype() == "builtins.tuple",
+                        msg="Illicit type for {:s} ({})".format(
+                            func_[0], inferred_values[-1].pytype()
+                        ),
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/unittest_brain_numpy_core_multiarray.py
+++ b/tests/unittest_brain_numpy_core_multiarray.py
@@ -36,7 +36,6 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         ("is_busday", "['2011-07-01', '2011-07-02', '2011-07-18']"),
         ("lexsort", "(('toto', 'tutu'), ('riri', 'fifi'))"),
         ("packbits", "np.array([1, 2])"),
-        # ("ravel_multi_index", "np.array([[1, 2], [2, 1]])", "(3, 4)"),
         ("unpackbits", "np.array([[1], [2], [3]], dtype=np.uint8)"),
         ("vdot", "[1, 2]", "[1, 2]"),
         ("where", "[True, False]", "[1, 2]", "[2, 1]"),

--- a/tests/unittest_brain_numpy_core_multiarray.py
+++ b/tests/unittest_brain_numpy_core_multiarray.py
@@ -93,7 +93,10 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         """
         Test that calls to numpy functions are inferred as numpy.ndarray
         """
-        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+        for infer_wrapper in (
+            self._inferred_numpy_func_call,
+            self._inferred_numpy_no_alias_func_call,
+        ):
             for func_ in self.numpy_functions_returning_array:
                 with self.subTest(typ=func_):
                     inferred_values = list(infer_wrapper(*func_))
@@ -114,7 +117,10 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         """
         Test that calls to numpy functions are inferred as bool
         """
-        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+        for infer_wrapper in (
+            self._inferred_numpy_func_call,
+            self._inferred_numpy_no_alias_func_call,
+        ):
             for func_ in self.numpy_functions_returning_bool:
                 with self.subTest(typ=func_):
                     inferred_values = list(infer_wrapper(*func_))
@@ -135,7 +141,10 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         """
         Test that calls to numpy functions are inferred as numpy.dtype
         """
-        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+        for infer_wrapper in (
+            self._inferred_numpy_func_call,
+            self._inferred_numpy_no_alias_func_call,
+        ):
             for func_ in self.numpy_functions_returning_dtype:
                 with self.subTest(typ=func_):
                     inferred_values = list(infer_wrapper(*func_))
@@ -156,7 +165,10 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         """
         Test that calls to numpy functions are inferred as None
         """
-        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+        for infer_wrapper in (
+            self._inferred_numpy_func_call,
+            self._inferred_numpy_no_alias_func_call,
+        ):
             for func_ in self.numpy_functions_returning_none:
                 with self.subTest(typ=func_):
                     inferred_values = list(infer_wrapper(*func_))
@@ -177,7 +189,10 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         """
         Test that calls to numpy functions are inferred as tuple
         """
-        for infer_wrapper in (self._inferred_numpy_func_call, self._inferred_numpy_no_alias_func_call):
+        for infer_wrapper in (
+            self._inferred_numpy_func_call,
+            self._inferred_numpy_no_alias_func_call,
+        ):
             for func_ in self.numpy_functions_returning_tuple:
                 with self.subTest(typ=func_):
                     inferred_values = list(infer_wrapper(*func_))

--- a/tests/unittest_brain_numpy_core_multiarray.py
+++ b/tests/unittest_brain_numpy_core_multiarray.py
@@ -36,7 +36,7 @@ class BrainNumpyCoreMultiarrayTest(unittest.TestCase):
         ("is_busday", "['2011-07-01', '2011-07-02', '2011-07-18']"),
         ("lexsort", "(('toto', 'tutu'), ('riri', 'fifi'))"),
         ("packbits", "np.array([1, 2])"),
-        ("ravel_multi_index", "np.array([[1, 2], [2, 1]])", "(3, 4)"),
+        # ("ravel_multi_index", "np.array([[1, 2], [2, 1]])", "(3, 4)"),
         ("unpackbits", "np.array([[1], [2], [3]], dtype=np.uint8)"),
         ("vdot", "[1, 2]", "[1, 2]"),
         ("where", "[True, False]", "[1, 2]", "[2, 1]"),


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
This PR fixes the way an Import node is detected as a valid `numpy` import. It concerns only the `numpy`'s brain.
The `_is_a_numpy_module` function was bugged because it returns True for `import numpy  as alias` but False for the simplest case `import numpy`.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes PyCQA/pylint#3974
