### PR TITLE
Iterate over Keywords when using ClassDef.get_children

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ Release Date: TBA
 
   Closes PyCQA/pylint#3974
 
+* Iterate over ``Keywords`` when using ``ClassDef.get_children``
+
+  Closes PyCQA/pylint#3202
+
 
 What's New in astroid 2.5.1?
 ============================

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1895,7 +1895,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     # by a raw factories
 
     # a dictionary of class instances attributes
-    _astroid_fields = ("decorators", "bases", "body")  # name
+    _astroid_fields = ("decorators", "bases", "keywords", "body")  # name
 
     decorators = None
     """The decorators that are applied to this class.
@@ -2920,6 +2920,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             yield self.decorators
 
         yield from self.bases
+        yield from self.keywords
         yield from self.body
 
     @decorators_mod.cached

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -2920,7 +2920,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             yield self.decorators
 
         yield from self.bases
-        yield from self.keywords
+        if self.keywords is not None:
+            yield from self.keywords
         yield from self.body
 
     @decorators_mod.cached

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1758,6 +1758,12 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         cls = astroid["TestKlass"]
         self.assertEqual(len(cls.keywords), 2)
         self.assertEqual([x.arg for x in cls.keywords], ["foo", "bar"])
+        children = list(cls.get_children())
+        assert len(children) == 4
+        assert isinstance(children[1], nodes.Keyword)
+        assert isinstance(children[2], nodes.Keyword)
+        assert children[1].arg == "foo"
+        assert children[2].arg == "bar"
 
     def test_kite_graph(self):
         data = """


### PR DESCRIPTION
## Description
This MR adds `Keywords` as a field to iterate over when getting the children of a `ClassDef`.

@hippo91 Would you mind taking a look at this? I'm a bit unsure how to best test this or if at all. In the end, it will be checked by pylint. The tests are passing with the current master.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

## Related Issue
Closes https://github.com/PyCQA/pylint/issues/3202