### PR TITLE
Fix strong references to mutable objects in context.clone

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,11 @@ Release Date: TBA
  Closes PyCQA/pylint#3970
  Closes PyCQA/pylint#3595
 
+* Fix some spurious cycles detected in ``context.path`` leading to more cases
+  that can now be inferred
+
+  Closes #926
+
 
 What's New in astroid 2.5.6?
 ============================

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -102,7 +102,7 @@ class InferenceContext:
         starts with the same context but diverge as each side is inferred
         so the InferenceContext will need be cloned"""
         # XXX copy lookupname/callcontext ?
-        clone = InferenceContext(self.path, inferred=self.inferred)
+        clone = InferenceContext(self.path.copy(), inferred=self.inferred.copy())
         clone.callcontext = self.callcontext
         clone.boundnode = self.boundnode
         clone.extra_context = self.extra_context

--- a/tests/unittest_brain_numpy_core_umath.py
+++ b/tests/unittest_brain_numpy_core_umath.py
@@ -220,9 +220,7 @@ class NumpyBrainCoreUmathTest(unittest.TestCase):
             with self.subTest(typ=func_):
                 inferred_values = list(self._inferred_numpy_func_call(func_))
                 self.assertTrue(
-                    len(inferred_values) == 1
-                    or len(inferred_values) == 2
-                    and inferred_values[-1].pytype() is util.Uninferable,
+                    len(inferred_values) == 1,
                     msg="Too much inferred values ({}) for {:s}".format(
                         inferred_values[-1].pytype(), func_
                     ),

--- a/tests/unittest_brain_numpy_core_umath.py
+++ b/tests/unittest_brain_numpy_core_umath.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     HAS_NUMPY = False
 
-from astroid import bases, builder, nodes, util
+from astroid import bases, builder, nodes
 
 
 @unittest.skipUnless(HAS_NUMPY, "This test requires the numpy library.")

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1704,7 +1704,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         ast = extract_node(code, __name__)
         expr = ast.func.expr
-        self.assertIs(next(expr.infer()), util.Uninferable)
+        with pytest.raises(exceptions.InferenceError):
+            next(expr.infer())
 
     def test_tuple_builtin_inference(self):
         code = """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6032,5 +6032,37 @@ def test_infer_list_of_uninferables_does_not_crash():
     assert not inferred.elts
 
 
+# https://github.com/PyCQA/astroid/issues/926
+def test_issue926_infer_stmts_referencing_same_name_is_not_uninferable():
+    code = """
+    pair = [1, 2]
+    ex = pair[0]
+    if 1 + 1 == 2:
+        ex = pair[1]
+    ex
+    """
+    node = extract_node(code)
+    inferred = list(node.infer())
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+    assert isinstance(inferred[1], nodes.Const)
+    assert inferred[1].value == 2
+
+
+# https://github.com/PyCQA/astroid/issues/926
+def test_issue926_binop_referencing_same_name_is_not_uninferable():
+    code = """
+    pair = [1, 2]
+    ex = pair[0] + pair[1]
+    ex
+    """
+    node = extract_node(code)
+    inferred = list(node.infer())
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -99,7 +99,7 @@ multiply([1, 2], [3, 4])
         astroid = builder.string_build(data, __name__, __file__)
         callfunc = astroid.body[1].value.func
         inferred = callfunc.inferred()
-        self.assertEqual(len(inferred), 2)
+        self.assertEqual(len(inferred), 1)
 
     def test_nameconstant(self):
         # used to fail for Python 3.4


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Since `InferenceContext.clone` passes `self.path` when
constructing a new instance, these two objects will hold references to
the same underlying set object. This caused modifications to
`context.path` further down in the stack to be reflected in "earlier"
objects and this would incorrectly detect a loop if the same node was
used twice in the inference of a some node (instead of only if an
inference result was used in inferring itself).

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related Issue

Closes #926 
