### PR TITLE
Use inference_tip for typing.TypedDict brain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@ Release Date: TBA
 
   Closes PyCQA/pylint#4206
 
+* Use ``inference_tip`` for ``typing.TypedDict`` brain.
+
+
 What's New in astroid 2.5.2?
 ============================
 Release Date: 2021-03-28

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -104,17 +104,15 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
 
 def infer_typedDict(  # pylint: disable=invalid-name
     node: nodes.FunctionDef, ctx: context.InferenceContext = None
-) -> None:
+) -> typing.Iterator[nodes.ClassDef]:
     """Replace TypedDict FunctionDef with ClassDef."""
     class_def = nodes.ClassDef(
         name="TypedDict",
-        doc=node.doc,
         lineno=node.lineno,
         col_offset=node.col_offset,
         parent=node.parent,
     )
-    class_def.postinit(bases=[], body=[], decorators=None)
-    node.root().locals["TypedDict"] = [class_def]
+    return iter([class_def])
 
 
 CLASS_GETITEM_TEMPLATE = """
@@ -238,7 +236,7 @@ MANAGER.register_transform(
 
 if PY39:
     MANAGER.register_transform(
-        nodes.FunctionDef, infer_typedDict, _looks_like_typedDict
+        nodes.FunctionDef, inference_tip(infer_typedDict), _looks_like_typedDict
     )
 
 if PY37:

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1372,12 +1372,9 @@ class TypingBrain(unittest.TestCase):
             var: int
         """
         )
-        assert len(node.bases) == 1
         inferred_base = next(node.bases[0].infer())
-        self.assertIsInstance(inferred_base, nodes.ClassDef, node.as_string())
-        typing_module = inferred_base.root()
-        assert len(typing_module.locals["TypedDict"]) == 1
-        assert inferred_base == typing_module.locals["TypedDict"][0]
+        assert isinstance(inferred_base, nodes.ClassDef)
+        assert inferred_base.qname() == "typing.TypedDict"
 
     @test_utils.require_version(minver="3.7")
     def test_typing_alias_type(self):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
The typing brain should use `inference_tip` for `TypedDict` instead of a normal transform.
The pylint tests continue to pass with this change.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
