### PR TITLE
Fix unhandled AstroidSyntaxError raised by infer_named_tuple brain 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,11 @@ Release Date: TBA
 
   Closes #932
 
+* Update `infer_named_tuple` brain to reject namedtuple definitions
+  that would raise ValueError
+
+  Closes #920
+
 * Do not set instance attributes on builtin object()
 
  Closes #945

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -214,6 +214,10 @@ class AstroidTypeError(AstroidError):
     """Raised when a TypeError would be expected in Python code."""
 
 
+class AstroidValueError(AstroidError):
+    """Raised when a ValueError would be expected in Python code."""
+
+
 class InferenceOverwriteError(AstroidError):
     """Raised when an inference tip is overwritten
 


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This adds a test suite and updates the infer_named_tuple brain with
some additional behaviours expected by `collections.namedtuple`, specifically
about rejecting invalid type and field names. Some of these cases inferred as
namedtuples/`ClassDef` when they would have raised `ValueError` and some of
these raise unhandled `AstroidSyntaxError`s due to attempts to parse class
fakes with type names that would have raised `ValueError`. For example:

```python
from collections import namedtuple
Tuple = namedtuple('X', 'abc abc')
# Traceback (most recent call last):
#     ...
# ValueError: Encountered duplicate field name: 'abc'

import astroid
node = astroid.extract_node("""
    from collections import namedtuple
    Tuple = namedtuple('X', 'abc abc')
    Tuple
""")
next(node.infer())
# <ClassDef.X l.3 at 0x...>


from collections import namedtuple
Tuple = namedtuple('123', 'abc')
# Traceback (most recent call last):
#     ...
# ValueError: Type names and field names must be valid identifiers: '123'

import astroid
node = astroid.extract_node("""
    from collections import namedtuple
    Tuple = namedtuple('123', 'abc')
    Tuple
""")
next(node.infer())
# Traceback (most recent call last):
#     ...
# KeyError: (<function infer_named_tuple at 0x...>, <Call l.3 at 0x...>)
# 
# During handling of the above exception, another exception occurred:
# 
# Traceback (most recent call last):
#     ...
#   File "<unknown>", line 2
#     class 123(tuple):
#             ^
# SyntaxError: invalid syntax
# 
# The above exception was the direct cause of the following exception:
# 
# Traceback (most recent call last):
#     ...
# astroid.exceptions.AstroidSyntaxError: Parsing Python code failed:
# invalid syntax (<unknown>, line 2)
```

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #920 
