### PR TITLE
Modify infernce tip for typing.Generic and typing.Annotated with ``__class_getitem__``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,10 @@ Release Date: TBA
 
 * Use ``inference_tip`` for ``typing.TypedDict`` brain.
 
+* Add inference tip for typing.Generic and typing.Annotated with ``__class_getitem__``
+
+  Closes PyCQA/pylint#2822
+
 
 What's New in astroid 2.5.2?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ Release Date: TBA
 
 * Use ``inference_tip`` for ``typing.TypedDict`` brain.
 
+* Fix mro for classes that inherit from typing.Generic
+
 * Add inference tip for typing.Generic and typing.Annotated with ``__class_getitem__``
 
   Closes PyCQA/pylint#2822

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -160,6 +160,16 @@ def infer_typing_attr(
         # infer the native methods, replace them for an easy inference tip
         func_to_add = astroid.extract_node(CLASS_GETITEM_TEMPLATE)
         value.locals["__class_getitem__"] = [func_to_add]
+        if (
+            isinstance(node.parent, nodes.ClassDef)
+            and node in node.parent.bases
+            and getattr(node.parent, "__cache", None)
+        ):
+            # node.parent.slots is evaluated and cached before the inference tip
+            # is first applied. Remove the last result to allow a recalculation of slots
+            cache = getattr(node.parent, "__cache")
+            if cache and cache.get(node.parent.slots) is not None:
+                del cache[node.parent.slots]
         return iter([value])
 
     node = extract_node(TYPING_TYPE_TEMPLATE.format(value.qname().split(".")[-1]))

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -88,6 +88,12 @@ TYPING_ALIAS = frozenset(
     )
 )
 
+CLASS_GETITEM_TEMPLATE = """
+@classmethod
+def __class_getitem__(cls, item):
+    return cls
+"""
+
 
 def looks_like_typing_typevar_or_newtype(node):
     func = node.func
@@ -126,7 +132,9 @@ def _looks_like_typing_subscript(node):
     return False
 
 
-def infer_typing_attr(node, context=None):
+def infer_typing_attr(
+    node: nodes.Subscript, ctx: context.InferenceContext = None
+) -> typing.Iterator[nodes.ClassDef]:
     """Infer a typing.X[...] subscript"""
     try:
         value = next(node.value.infer())
@@ -142,8 +150,20 @@ def infer_typing_attr(node, context=None):
         # (PY37+) handle it separately.
         raise UseInferenceDefault
 
+    if (
+        PY37
+        and isinstance(value, nodes.ClassDef)
+        and value.qname() in ("typing.Generic", "typing.Annotated")
+    ):
+        # With PY37+ typing.Generic and typing.Annotated (PY39) are subscriptable
+        # through __class_getitem__. Since astroid can't easily
+        # infer the native methods, replace them for an easy inference tip
+        func_to_add = astroid.extract_node(CLASS_GETITEM_TEMPLATE)
+        value.locals["__class_getitem__"] = [func_to_add]
+        return iter([value])
+
     node = extract_node(TYPING_TYPE_TEMPLATE.format(value.qname().split(".")[-1]))
-    return node.infer(context=context)
+    return node.infer(context=ctx)
 
 
 def _looks_like_typedDict(  # pylint: disable=invalid-name
@@ -164,13 +184,6 @@ def infer_typedDict(  # pylint: disable=invalid-name
         parent=node.parent,
     )
     return iter([class_def])
-
-
-CLASS_GETITEM_TEMPLATE = """
-@classmethod
-def __class_getitem__(cls, item):
-    return cls
-"""
 
 
 def _looks_like_typing_alias(node: nodes.Call) -> bool:

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -153,7 +153,8 @@ def infer_typing_attr(
     if (
         PY37
         and isinstance(value, nodes.ClassDef)
-        and value.qname() in ("typing.Generic", "typing.Annotated")
+        and value.qname()
+        in ("typing.Generic", "typing.Annotated", "typing_extensions.Annotated")
     ):
         # With PY37+ typing.Generic and typing.Annotated (PY39) are subscriptable
         # through __class_getitem__. Since astroid can't easily

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -169,7 +169,7 @@ def infer_typing_attr(
             # node.parent.slots is evaluated and cached before the inference tip
             # is first applied. Remove the last result to allow a recalculation of slots
             cache = getattr(node.parent, "__cache")
-            if cache and cache.get(node.parent.slots) is not None:
+            if cache.get(node.parent.slots) is not None:
                 del cache[node.parent.slots]
         return iter([value])
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1361,6 +1361,33 @@ class TypingBrain(unittest.TestCase):
             inferred = next(node.infer())
             self.assertIsInstance(inferred, nodes.ClassDef, node.as_string())
 
+    @test_utils.require_version(minver="3.7")
+    def test_typing_generic_subscriptable(self):
+        """Test typing.Generic is subscriptable with __class_getitem__ (added in PY37)"""
+        node = builder.extract_node(
+            """
+        from typing import Generic, TypeVar
+        T = TypeVar('T')
+        Generic[T]
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)
+        assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
+
+    @test_utils.require_version(minver="3.9")
+    def test_typing_annotated_subscriptable(self):
+        """Test typing.Annotated is subscriptable with __class_getitem__"""
+        node = builder.extract_node(
+            """
+        import typing
+        typing.Annotated[str, "data"]
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)
+        assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
+
     def test_has_dunder_args(self):
         ast_node = builder.extract_node(
             """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
With Python 3.7, `typing.Generic` is now subscriptable through `__class_getitem__`. Same for `typing.Annotated` which was added in 3.9. As with the `__class_getitem__` methods for the `collections.abc` classes, astroid needs a bit of help inferring them correctly.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
This will address: https://github.com/PyCQA/pylint/issues/2822
I would like to add a test case to `pylint` before closing it, though.