### PR TITLE
Fix inference of instance attributes defined in base class

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.6.0?
 ============================
 Release Date: TBA
 
+* Fix inference of instance attributes defined in base classes
+
+  Closes #932
+
 * Do not set instance attributes on builtin object()
 
  Closes #945

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -207,8 +207,9 @@ class BaseInstance(Proxy):
         if not context:
             context = contextmod.InferenceContext()
         try:
+            context.lookupname = name
             # avoid recursively inferring the same attr on the same class
-            if context.push((self._proxied, name)):
+            if context.push(self._proxied):
                 raise exceptions.InferenceError(
                     message="Cannot infer the same attribute again",
                     node=self,

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4050,6 +4050,42 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         assert not isinstance(inferred, nodes.ClassDef)  # was inferred as builtins.type
         assert inferred is util.Uninferable
 
+    def test_infer_subclass_attr_instance_attr_indirect(self):
+        node = extract_node(
+            """
+        class Parent:
+            def __init__(self):
+                self.data = 123
+
+        class Test(Parent):
+            pass
+        t = Test()
+        t
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, Instance)
+        const = next(inferred.igetattr("data"))
+        assert isinstance(const, nodes.Const)
+        assert const.value == 123
+
+    def test_infer_subclass_attr_instance_attr(self):
+        node = extract_node(
+            """
+        class Parent:
+            def __init__(self):
+                self.data = 123
+
+        class Test(Parent):
+            pass
+        t = Test()
+        t.data
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 123
+
 
 class GetattrTest(unittest.TestCase):
     def test_yes_when_unknown(self):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Ref #932. The cause of this appears to be failing to specify the
`lookupname` on the inference context in `BaseInstance.igetattr`.
Additionally, the context path key was not set in a manner that matched
other usages. This appears to date back to at least 2015 when context
path keys were changed. The usage as a tuple instead of a node with
implict `lookupname` was changed last in 3d342e85 but the lookup key was
preserved throughout various changes since then.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes #932 