### PR TITLE
Inferring property fields in a class context when metaclass is present

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ Release Date: TBA
   that can now be inferred
 
   Closes #926
- 
+
 * Add ``kind`` field to ``Const`` nodes, matching the structure of the built-in ast Const.
   The kind field is "u" if the literal is a u-prefixed string, and ``None`` otherwise.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,15 @@ Release Date: TBA
 
   Closes #926
 
+* Fix property inference in class contexts for properties defined on the metaclass
+
+  Closes #940
+
+* Update enum brain to fix definition of __members__ for subclass-defined Enums
+
+  Closes PyCQA/pylint#3535
+  Closes PyCQA/pylint#4358
+
 
 What's New in astroid 2.5.6?
 ============================

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -2554,7 +2554,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         context = contextmod.copy_context(context)
         context.lookupname = name
 
-        metaclass = self.declared_metaclass(context=context)
+        metaclass = self.metaclass(context=context)
         try:
             attributes = self.getattr(name, context, class_context=class_context)
             # If we have more than one attribute, make sure that those starting from
@@ -2587,9 +2587,12 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
                         yield from function.infer_call_result(
                             caller=self, context=context
                         )
-                    # If we have a metaclass, we're accessing this attribute through
-                    # the class itself, which means we can solve the property
-                    elif metaclass:
+                    # If we're in a class context, we need to determine if the property
+                    # was defined in the metaclass (a derived class must be a subclass of
+                    # the metaclass of all its bases), in which case we can resolve the
+                    # property. If not, i.e. the property is defined in some base class
+                    # instead, then we return the property object
+                    elif metaclass and function.parent.scope() is metaclass:
                         # Resolve a property as long as it is not accessed through
                         # the class itself.
                         yield from function.infer_call_result(

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2031,7 +2031,6 @@ def test_issue940_metaclass_derived_funcdef():
     assert [c.value for c in inferred_result.elts] == ["a", "func"]
 
 
-@pytest.mark.xfail(reason="attribute is Uninferable")
 def test_issue940_metaclass_funcdef_is_not_datadescriptor():
     node = builder.extract_node(
         """
@@ -2039,7 +2038,9 @@ def test_issue940_metaclass_funcdef_is_not_datadescriptor():
         def __members__(cls):
             return ['a', 'property']
     class Parent(metaclass=BaseMeta):
-        __members__ = property(BaseMeta.__members__)
+        @property
+        def __members__(cls):
+            return BaseMeta.__members__()
     class Derived(Parent):
         pass
     Derived.__members__

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2054,6 +2054,22 @@ def test_issue940_metaclass_funcdef_is_not_datadescriptor():
     assert isinstance(inferred, objects.Property)
 
 
+def test_issue940_enums_as_a_real_world_usecase():
+    node = builder.extract_node(
+        """
+    from enum import Enum
+    class Sounds(Enum):
+        bee = "buzz"
+        cat = "meow"
+    Sounds.__members__
+    """
+    )
+    inferred_result = next(node.infer())
+    assert isinstance(inferred_result, nodes.Dict)
+    actual = [k.value for k, _ in inferred_result.items]
+    assert sorted(actual) == ["bee", "cat"]
+
+
 def test_metaclass_cannot_infer_call_yields_an_instance():
     node = builder.extract_node(
         """

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1923,6 +1923,136 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         builder.parse(data)
 
 
+def test_issue940_metaclass_subclass_property():
+    node = builder.extract_node(
+        """
+    class BaseMeta(type):
+        @property
+        def __members__(cls):
+            return ['a', 'property']
+    class Parent(metaclass=BaseMeta):
+        pass
+    class Derived(Parent):
+        pass
+    Derived.__members__
+    """
+    )
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.List)
+    assert [c.value for c in inferred.elts] == ["a", "property"]
+
+
+def test_issue940_property_grandchild():
+    node = builder.extract_node(
+        """
+    class Grandparent:
+        @property
+        def __members__(self):
+            return ['a', 'property']
+    class Parent(Grandparent):
+        pass
+    class Child(Parent):
+        pass
+    Child().__members__
+    """
+    )
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.List)
+    assert [c.value for c in inferred.elts] == ["a", "property"]
+
+
+def test_issue940_metaclass_property():
+    node = builder.extract_node(
+        """
+    class BaseMeta(type):
+        @property
+        def __members__(cls):
+            return ['a', 'property']
+    class Parent(metaclass=BaseMeta):
+        pass
+    Parent.__members__
+    """
+    )
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.List)
+    assert [c.value for c in inferred.elts] == ["a", "property"]
+
+
+def test_issue940_with_metaclass_class_context_property():
+    node = builder.extract_node(
+        """
+    class BaseMeta(type):
+        pass
+    class Parent(metaclass=BaseMeta):
+        @property
+        def __members__(self):
+            return ['a', 'property']
+    class Derived(Parent):
+        pass
+    Derived.__members__
+    """
+    )
+    inferred = next(node.infer())
+    assert not isinstance(inferred, nodes.List)
+    assert isinstance(inferred, objects.Property)
+
+
+def test_issue940_metaclass_values_funcdef():
+    node = builder.extract_node(
+        """
+    class BaseMeta(type):
+        def __members__(cls):
+            return ['a', 'func']
+    class Parent(metaclass=BaseMeta):
+        pass
+    Parent.__members__()
+    """
+    )
+    inferred = next(node.infer())
+    assert isinstance(inferred, nodes.List)
+    assert [c.value for c in inferred.elts] == ["a", "func"]
+
+
+def test_issue940_metaclass_derived_funcdef():
+    node = builder.extract_node(
+        """
+    class BaseMeta(type):
+        def __members__(cls):
+            return ['a', 'func']
+    class Parent(metaclass=BaseMeta):
+        pass
+    class Derived(Parent):
+        pass
+    Derived.__members__()
+    """
+    )
+    inferred_result = next(node.infer())
+    assert isinstance(inferred_result, nodes.List)
+    assert [c.value for c in inferred_result.elts] == ["a", "func"]
+
+
+@pytest.mark.xfail(reason="attribute is Uninferable")
+def test_issue940_metaclass_funcdef_is_not_datadescriptor():
+    node = builder.extract_node(
+        """
+    class BaseMeta(type):
+        def __members__(cls):
+            return ['a', 'property']
+    class Parent(metaclass=BaseMeta):
+        __members__ = property(BaseMeta.__members__)
+    class Derived(Parent):
+        pass
+    Derived.__members__
+    """
+    )
+    # Here the function is defined on the metaclass, but the property
+    # is defined on the base class. When loading the attribute in a
+    # class context, this should return the property object instead of
+    # resolving the data descriptor
+    inferred = next(node.infer())
+    assert isinstance(inferred, objects.Property)
+
+
 def test_metaclass_cannot_infer_call_yields_an_instance():
     node = builder.extract_node(
         """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

If we are accessing an attribute and it is found on
`type(A).__dict__` *and* it is a data descriptor, then we resolve that
descriptor. For the case of inferring a property which is accessed as a
class attribute, this equates to the property being defined on the
metaclass (which may be anywhere in the class hierarchy).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes #940 
