### PR TITLE
Add kind field to Const nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,11 @@ Release Date: TBA
 
   Closes #926
 
+* Add ``kind`` field to ``Const`` nodes, matching the structure of the built-in ast Const.
+  The kind field is "u" if the literal is a u-prefixed string, and ``None`` otherwise.
+
+  Closes #898
+
 
 What's New in astroid 2.5.6?
 ============================

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -2557,7 +2557,7 @@ class Const(mixins.NoChildrenMixin, NodeNG, bases.Instance):
 
     _other_fields = ("value",)
 
-    def __init__(self, value, lineno=None, col_offset=None, parent=None):
+    def __init__(self, value, lineno=None, col_offset=None, parent=None, kind=None):
         """
         :param value: The value that the constant represents.
         :type value: object
@@ -2571,12 +2571,12 @@ class Const(mixins.NoChildrenMixin, NodeNG, bases.Instance):
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param kind: The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only.
+        :type kind: str or None
         """
         self.value = value
-        """The value that the constant represents.
-
-        :type: object
-        """
+        self.kind = kind
 
         super().__init__(lineno, col_offset, parent)
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -425,6 +425,7 @@ class TreeRebuilder:
             getattr(node, "lineno", None),
             getattr(node, "col_offset", None),
             parent,
+            getattr(node, "kind", None),
         )
 
     def visit_continue(self, node, parent):
@@ -814,6 +815,7 @@ class TreeRebuilder:
             getattr(node, "lineno", None),
             getattr(node, "col_offset", None),
             parent,
+            getattr(node, "kind", None),
         )
 
     # Not used in Python 3.8+.

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -542,6 +542,19 @@ class ConstNodeTest(unittest.TestCase):
     def test_unicode(self):
         self._test("a")
 
+    @pytest.mark.skipif(
+        not PY38, reason="kind attribute for ast.Constant was added in 3.8"
+    )
+    def test_str_kind(self):
+        node = builder.extract_node(
+            """
+            const = u"foo"
+        """
+        )
+        assert isinstance(node.value, nodes.Const)
+        assert node.value.value == "foo"
+        assert node.value.kind, "u"
+
     def test_copy(self):
         """
         Make sure copying a Const object doesn't result in infinite recursion


### PR DESCRIPTION
## Description

Adds a kind field to Const nodes.

Note: this field is only available in Python's 3.8+ AST. Should `astroid` backport this for older supported versions of Python or are we fine as is?

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

Closes https://github.com/PyCQA/astroid/issues/898
