### PR TITLE
Introduce speedups implemented in cython

### DIFF
--- a/astroid/arguments.pxd
+++ b/astroid/arguments.pxd
@@ -1,0 +1,21 @@
+import cython
+from .context cimport InferenceContext, CallContext
+
+@cython.final
+cdef class CallSite:
+    cdef public dict argument_context_map
+    cdef public set duplicated_keywords
+    cdef list _unpacked_args
+    cdef dict _unpacked_kwargs
+    cdef public list positional_arguments
+    cdef public dict keyword_arguments
+
+
+    cpdef int has_invalid_arguments(self) except -1
+    cpdef has_invalid_keywords(self)
+
+
+    cdef dict _unpack_keywords(self, list keywords, InferenceContext context=*)
+    cdef list _unpack_args(self, list args, InferenceContext context=*)
+
+    cpdef infer_argument(self, funcnode, name, InferenceContext context)

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -8,12 +8,13 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/COPYING.LESSER
 
+import cython
 
 from astroid import bases
-from astroid import context as contextmod
 from astroid import exceptions
 from astroid import nodes
 from astroid import util
+from .context import InferenceContext, CallContext
 
 
 class CallSite:
@@ -33,6 +34,7 @@ class CallSite:
         An instance of :class:`astroid.context.Context`.
     """
 
+    @cython.locals(callcontext=CallContext, context=InferenceContext)
     def __init__(self, callcontext, argument_context_map=None, context=None):
         if argument_context_map is None:
             argument_context_map = {}
@@ -62,8 +64,8 @@ class CallSite:
         """
 
         # Determine the callcontext from the given `context` object if any.
-        context = context or contextmod.InferenceContext()
-        callcontext = contextmod.CallContext(call_node.args, call_node.keywords)
+        context = context or InferenceContext()
+        callcontext = CallContext(call_node.args, call_node.keywords)
         return cls(callcontext, context=context)
 
     def has_invalid_arguments(self):
@@ -88,7 +90,7 @@ class CallSite:
 
     def _unpack_keywords(self, keywords, context=None):
         values = {}
-        context = context or contextmod.InferenceContext()
+        context = context or InferenceContext()
         context.extra_context = self.argument_context_map
         for name, value in keywords:
             if name is None:
@@ -128,7 +130,7 @@ class CallSite:
 
     def _unpack_args(self, args, context=None):
         values = []
-        context = context or contextmod.InferenceContext()
+        context = context or InferenceContext()
         context.extra_context = self.argument_context_map
         for arg in args:
             if isinstance(arg, nodes.Starred):

--- a/astroid/bases.pxd
+++ b/astroid/bases.pxd
@@ -1,0 +1,5 @@
+from .context cimport InferenceContext, bind_context_to_node, CallContext
+
+cdef set PROPERTIES
+cdef set POSSIBLE_PROPERTIES
+cdef object MANAGER

--- a/astroid/context.pxd
+++ b/astroid/context.pxd
@@ -1,0 +1,23 @@
+import cython
+
+@cython.final
+cdef class InferenceContext:
+    cdef public set path
+    cdef public str lookupname
+    cdef public CallContext callcontext
+    cdef public object boundnode
+    cdef public dict inferred
+    cdef public dict extra_context
+
+    cpdef int push(self, node) except -1
+    cpdef InferenceContext clone(self)
+
+
+@cython.final
+cdef class CallContext:
+    cdef public list args
+    cdef public list keywords
+
+cpdef InferenceContext copy_context(InferenceContext context)
+
+cpdef InferenceContext bind_context_to_node(InferenceContext context, node)

--- a/astroid/decorators.pxd
+++ b/astroid/decorators.pxd
@@ -1,0 +1,1 @@
+from .context cimport InferenceContext

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -19,10 +19,11 @@
 import functools
 
 import wrapt
+import cython
 
-from astroid import context as contextmod
 from astroid import exceptions
 from astroid import util
+from .context import InferenceContext
 
 
 @wrapt.decorator
@@ -84,11 +85,12 @@ def path_wrapper(func):
     at for a given `InferenceContext` to prevent infinite recursion
     """
 
+    @cython.locals(context=InferenceContext)
     @functools.wraps(func)
     def wrapped(node, context=None, _func=func, **kwargs):
         """wrapper function handling context"""
         if context is None:
-            context = contextmod.InferenceContext()
+            context = InferenceContext()
         if context.push(node):
             return None
 

--- a/astroid/helpers.pxd
+++ b/astroid/helpers.pxd
@@ -1,0 +1,8 @@
+from .context cimport InferenceContext, CallContext
+
+cpdef int is_subtype(type1, type2) except -1
+cpdef int is_supertype(type1, type2) except -1
+cpdef bint _type_check(type1, type2) except -1
+cpdef safe_infer(node, InferenceContext context=*)
+cpdef object_type(node, InferenceContext context=*)
+cpdef class_instance_as_index(node)

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -18,13 +18,13 @@ Various helper utilities.
 import builtins as builtins_mod
 
 from astroid import bases
-from astroid import context as contextmod
 from astroid import exceptions
 from astroid import manager
 from astroid import nodes
 from astroid import raw_building
 from astroid import scoped_nodes
 from astroid import util
+from .context import InferenceContext, CallContext
 
 
 BUILTINS = builtins_mod.__name__
@@ -52,7 +52,7 @@ def _function_type(function, builtins):
 def _object_type(node, context=None):
     astroid_manager = manager.AstroidManager()
     builtins = astroid_manager.builtins_module
-    context = context or contextmod.InferenceContext()
+    context = context or InferenceContext()
 
     for inferred in node.infer(context=context):
         if isinstance(inferred, scoped_nodes.ClassDef):
@@ -217,8 +217,8 @@ def class_instance_as_index(node):
     be used in some scenarios where an integer is expected,
     for instance when multiplying or subscripting a list.
     """
-    context = contextmod.InferenceContext()
-    context.callcontext = contextmod.CallContext(args=[node])
+    context = InferenceContext()
+    context.callcontext = CallContext(args=[node])
 
     try:
         for inferred in node.igetattr("__index__", context=context):

--- a/astroid/inference.pxd
+++ b/astroid/inference.pxd
@@ -1,0 +1,22 @@
+from .context cimport InferenceContext, copy_context, CallContext, bind_context_to_node
+from .helpers cimport is_subtype, is_supertype, safe_infer, object_type, class_instance_as_index
+
+cdef object MANAGER
+
+cdef list _infer_sequence_helper(node, InferenceContext context=*)
+cdef dict _update_with_replacement(dict lhs_dict, dict rhs_dict)
+cdef _higher_function_scope(node)
+# cdef int _is_not_implemented(const) except -1
+cdef _invoke_binop_inference(instance, opnode, op, other, InferenceContext context, method_name)
+cdef _aug_op(instance, opnode, op, other, InferenceContext context, bint reverse=*)
+cdef _bin_op(instance, opnode, op, other, InferenceContext context, reverse=*)
+cdef int _same_type(type1, type2) except -1
+cdef list _get_binop_flow(
+    left, left_type, binary_opnode, right, right_type, InferenceContext context, reverse_context
+)
+
+cdef dict _populate_context_lookup(call, InferenceContext context)
+
+cdef object _SUBSCRIPT_SENTINEL
+
+

--- a/astroid/node_classes.pxd
+++ b/astroid/node_classes.pxd
@@ -1,0 +1,36 @@
+import cython
+from .context cimport InferenceContext
+
+cdef dict OP_PRECEDENCE
+cdef object MANAGER
+
+cdef bint _is_const(object value)
+
+cpdef int are_exclusive(
+    stmt1, stmt2, exceptions=*
+) except -1
+
+cdef object _slice_value(object index, object context=*)
+
+cdef tuple _find_arg(argname, args, rec=*)
+cdef str _format_args(args, defaults=*, annotations=*)
+cdef _container_getitem(instance, elts, index, context=*)
+
+cdef class NodeNG:
+    cdef _fixed_source_line(self)
+    cpdef accept(self, visitor)
+    cpdef last_child(self)
+    cpdef bint parent_of(self, NodeNG node)
+    cpdef NodeNG statement(self)
+    cpdef frame(self)
+    cpdef scope(self)
+    cpdef root(self)
+    cpdef child_sequence(self, child)
+    cpdef locate_child(self, child)
+    cpdef next_sibling(self)
+    cpdef previous_sibling(self)
+
+cdef class Statement(NodeNG):
+    @cython.locals(parent=NodeNG)
+    cpdef next_sibling(self)
+    cpdef previous_sibling(self)

--- a/astroid/protocols.pxd
+++ b/astroid/protocols.pxd
@@ -1,0 +1,5 @@
+from .context cimport InferenceContext, copy_context, CallContext, bind_context_to_node
+from .cimport arguments
+
+cdef str _CONTEXTLIB_MGR
+cdef dict _UNARY_OPERATORS

--- a/astroid/scoped_nodes.pxd
+++ b/astroid/scoped_nodes.pxd
@@ -1,0 +1,12 @@
+from .context cimport InferenceContext, copy_context, CallContext, bind_context_to_node
+from . cimport node_classes
+cdef object MANAGER
+cdef object BUILTINS
+cdef tuple ITER_METHODS
+cdef object EXCEPTION_BASE_CLASSES
+cdef object objects
+cdef object BUILTIN_DESCRIPTORS
+
+cdef list _c3_merge(list sequences, cls, InferenceContext context)
+cpdef function_to_method(n, klass)
+cpdef tuple builtin_lookup(str name)

--- a/astroid/transforms.pxd
+++ b/astroid/transforms.pxd
@@ -1,0 +1,7 @@
+import cython
+
+@cython.final
+cdef class TransformVisitor:
+    cdef public object transforms
+
+    cdef _visit(self, node)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

This PR introduces PoC of implementing speed ups in Cython. This PR is increasing speed of pylint by 10-15% (based on my measurements). 

The optimization in cython is achieved annotation of code using 3 ways:
1. introducing `.pxd` header providing details about types and C structures
2. introducing `@cython` decorators to annotate the code (when executed via python this decorators are empty)
3. annotating the code via PEP 3107 and PEP 526 annotations.

### Motivation
Cython is well established compiler compiling python code to C where programmer can partially optimize code to avoid slow python API calls. Cython is wide used in multiple projects including Numpy [1], aiohttp [2] and also cython itself [3] (cython uses pure python mode),  Speedups written in this PR are written using *pure python mode* of Cython [4]. This ensures that

* the python code is kept almost untouched (the python code contains refactor changes only to write in an a way to be easily cythonized)
* running code does not require compling to binary

The main benefit of cython is that
* there is no need of rewriting huge code bases to different language
* speed ups can be implemented by small steps, introducing only simple changes in the beginning and after more invasive changes can be written.

Current PoC shows around **10-15%** speed increase comparing to python version.

### Drawbacks

* To improve performance via cython, the programmer needs to understand C language and basics of python API. 
* Using Cython requires learning Cython language. Cython language can challenging to understand can in some places - e.g. exception propagation in c methods/functions [5] (`except -1` vs. `except? -1` vs. `except *`).
* Cython contains 3 major issues which complicates optimization of astroid code base:
  -  generators using `yield` keyword cannot be cythonized to C method/function [6]
  - There is a bug which causes creas of cython for syntax of providing generator as parameter - e.g.: `any(... for ... in ...)` [7]
  - Cython C classes does not play well with Multiple Inheritance [8]

### Possible improvements
This PR servers as PoC showing that Cython can be viable platform to improve pylint/astroid performance. But there are more additional improvements which varies in complexity:
1. PR cythonize only portion of code. Whole astroid/pylint code base can be cythonized which is simple brute force approach which can saves some small  execution time for free.
2. based on my measurements the most expensive part of astroid is `scoped_nodes.py` module. This module can be rewritten to enable compiling more code in C mode (avoiding python API calls)
3. `AstroidManager` class should be easily compiled to cdef class.
4. shared global variables can be migrated to C variables after some small changes in python code.
5. `InferenceContext` class should be further optimized when some changes in python code are changed - see [9]
6. pylint codebase can be cythonized and C declarations from astroid can be imported in pylint to access directly C symbols of astroid

### Compilation and building binaries

Cython directly integrates to setup.py [10], but the goal of this PR is just to show how cython can improve performance in astroid. For building extention the following command needs to be executed in `astroid/astroid` directory:
```
cythonize -3ib arguments.py  bases.py  context.py  decorators.py  helpers.py  inference.py  node_classes.py  protocols.py  scoped_nodes.py  transforms.py
```

This command produces .so files (on linux platform which are used during import instead of .py files). For investigating the optimization the following command:
```
cython -3 -a <FILE>.py
```
produces a html page showing the optimizations of cython - see [11] and 

[1] https://github.com/numpy/numpy/tree/main/numpy/random
[2] https://github.com/aio-libs/aiohttp/tree/master/aiohttp
[3] https://github.com/cython/cython/blob/master/Cython/Compiler/FlowControl.pxd
[4] https://cython.readthedocs.io/en/latest/src/tutorial/pure.html
[5] https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#error-return-values
[6] https://github.com/cython/cython/issues/2597
[7] https://github.com/cython/cython/issues/3477
[8] https://cython.readthedocs.io/en/latest/src/tutorial/cdef_classes.html#extension-types-aka-cdef-classes
[9] https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#fast-instantiation
[10] https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#basic-setup-py
[11] https://cython.readthedocs.io/en/latest/src/tutorial/cython_tutorial.html#primes

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |
