### PR TITLE
Remove enum34 from dependencies

### DIFF
--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -47,18 +47,6 @@ import sys
 import unittest
 
 try:
-    import enum  # pylint: disable=unused-import
-
-    HAS_ENUM = True
-except ImportError:
-    try:
-        import enum34 as enum  # pylint: disable=unused-import
-
-        HAS_ENUM = True
-    except ImportError:
-        HAS_ENUM = False
-
-try:
     import nose  # pylint: disable=unused-import
 
     HAS_NOSE = True
@@ -654,12 +642,6 @@ class ThreadingBrainTest(unittest.TestCase):
             self.assertIsInstance(next(inferred.igetattr(method)), astroid.BoundMethod)
 
 
-@unittest.skipUnless(
-    HAS_ENUM,
-    "The enum module was only added in Python 3.4. Support for "
-    "older Python versions may be available through the enum34 "
-    "compatibility module.",
-)
 class EnumBrainTest(unittest.TestCase):
     def test_simple_enum(self):
         module = builder.parse(

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -62,8 +62,6 @@ except ImportError:
 
 import pytest
 
-HAS_PYTEST = True
-
 try:
     import attr as attr_module  # pylint: disable=unused-import
 
@@ -904,7 +902,6 @@ class DateutilBrainTest(unittest.TestCase):
         self.assertEqual(d_type.qname(), "datetime.datetime")
 
 
-@unittest.skipUnless(HAS_PYTEST, "This test requires the pytest library.")
 class PytestBrainTest(unittest.TestCase):
     def test_pytest(self):
         ast_node = builder.extract_node(

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ pylint: git+https://github.com/pycqa/pylint@master
 [testenv]
 deps =
   pypy: backports.functools_lru_cache
-  pypy: enum34
   lazy-object-proxy==1.4.*
   ; we have a brain for nose
   ; we use pytest for tests


### PR DESCRIPTION
## Description

Since we don't support python 3.3 we can remove enum34 from the depencencies.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

#937 
