### PR TITLE
Fix crash when evaluating ``typing.NamedTuple``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release Date: TBA
 
 * Added inference tip for ``typing.Tuple`` alias
 
+* Fix crash when evaluating ``typing.NamedTuple``
+
+  Closes PyCQA/pylint#4383
+
 
 What's New in astroid 2.5.3?
 ============================

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -473,7 +473,8 @@ MANAGER.register_transform(
 MANAGER.register_transform(
     nodes.FunctionDef,
     inference_tip(infer_typing_namedtuple_function),
-    lambda node: node.name == "NamedTuple" and node.parent.name == "typing",
+    lambda node: node.name == "NamedTuple"
+    and getattr(node.root(), "name", None) == "typing",
 )
 MANAGER.register_transform(
     nodes.Call, inference_tip(infer_typing_namedtuple), _looks_like_typing_namedtuple

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1321,6 +1321,32 @@ class TypingBrain(unittest.TestCase):
         const = next(class_attr.infer())
         self.assertEqual(const.value, "class_attr")
 
+    def test_namedtuple_inferred_as_class(self):
+        node = builder.extract_node(
+            """
+        from typing import NamedTuple
+        NamedTuple
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)
+        assert inferred.name == "NamedTuple"
+
+    def test_namedtuple_bug_pylint_4383(self):
+        """Inference of 'NamedTuple' function shouldn't cause InferenceError.
+
+        https://github.com/PyCQA/pylint/issues/4383
+        """
+        node = builder.extract_node(
+            """
+        if True:
+            def NamedTuple():
+                pass
+        NamedTuple
+        """
+        )
+        next(node.infer())
+
     def test_typing_types(self):
         ast_nodes = builder.extract_node(
             """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Small MR to fix a crash when evaluating ``typing.NamedTuple``

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes https://github.com/PyCQA/pylint/issues/4383
