### PR TITLE
Fix name type inference when used as in a subscript

### DIFF
--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -17,7 +17,7 @@ Thanks to Lukasz Langa for fruitful discussion.
 """
 import sys
 
-from astroid import MANAGER, extract_node, inference_tip, nodes
+from astroid import MANAGER, UseInferenceDefault, extract_node, inference_tip, nodes
 
 PY39 = sys.version_info >= (3, 9)
 
@@ -47,6 +47,8 @@ def infer_type_sub(node, context=None):
     :return: the inferred node
     :rtype: nodes.NodeNG
     """
+    if "type" in node.scope().locals:
+        raise UseInferenceDefault()
     class_src = """
     class type:
         def __class_getitem__(cls, key):

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -47,7 +47,8 @@ def infer_type_sub(node, context=None):
     :return: the inferred node
     :rtype: nodes.NodeNG
     """
-    if "type" in node.scope().locals:
+    node_scope, _ = node.scope().lookup("type")
+    if node_scope.qname() != "builtins":
         raise UseInferenceDefault()
     class_src = """
     class type:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4036,6 +4036,20 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         assert not isinstance(inferred, nodes.ClassDef)  # was inferred as builtins.type
         assert inferred is util.Uninferable
 
+    @test_utils.require_version(minver="3.9")
+    def test_infer_arg_called_type_defined_in_outer_scope_is_uninferable(self):
+        # https://github.com/PyCQA/astroid/pull/958
+        node = extract_node(
+            """
+        def outer(type):
+            def inner():
+                type[0] #@
+        """
+        )
+        inferred = next(node.infer())
+        assert not isinstance(inferred, nodes.ClassDef)  # was inferred as builtins.type
+        assert inferred is util.Uninferable
+
 
 class GetattrTest(unittest.TestCase):
     def test_yes_when_unknown(self):


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

When used in a `nodes.Subscript`, an existing `inference_tip` was set for `Name` nodes matching called type. However, when this name was redefined this led to false-positive typecheck errors in pylint such as invalid-sequence-index (see PyCQA/pylint#4083 and PyCQA/pylint#4387)

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

See above
