### PR TITLE
Remove backports.functools_lru_cache dependency

### DIFF
--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -21,11 +21,7 @@ import importlib.machinery
 import os
 import sys
 import zipimport
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
+from functools import lru_cache
 
 from . import util
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ commands = pylint -rn --rcfile={toxinidir}/pylintrc {toxinidir}/astroid
 [testenv]
 deps =
   -r requirements_test_min.txt
-  pypy: backports.functools_lru_cache
   py{36,37,38,39}: -r requirements_test_brain.txt
   !py{36,37,38,39}-six: python-dateutil
   six: six


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description
`functools.lru_cache` should be included with pypy. It's used in other places without the import guard.

https://docs.python.org/3/library/functools.html#functools.lru_cache
https://github.com/PyCQA/astroid/blob/a1fa9e32edc71d32bfe5e87d05c29b230a626244/astroid/node_classes.py#L38-L40

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
#947
