### PR TITLE
Consolidate test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,7 @@ language: python
 jobs:
   include:
     - python: 3.6
-      env: TOXENV=py36,py36-six
-    - python: 3.7
-      env: TOXENV=py37-six
-    - python: 3.8
-      env: TOXENV=py38-six
-    - python: 3.9
-      env: TOXENV=py39-six
+      env: TOXENV=py36
 before_install:
   - python --version
   - uname -a

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -1,3 +1,5 @@
+attrs
 nose
 numpy
-attrs
+python-dateutil
+six

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -33,7 +33,6 @@
 
 """Tests for basic functionality in astroid.brain."""
 import io
-import os
 import queue
 import re
 import sys
@@ -401,12 +400,6 @@ class NoseBrainTest(unittest.TestCase):
 
 @unittest.skipUnless(HAS_SIX, "These tests require the six library")
 class SixBrainTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        tox_env = os.environ.get("TOX_ENV_NAME")
-        if tox_env and not tox_env.endswith("-six") and HAS_SIX:
-            raise Exception("six was installed in a non-six testing environment.")
-
     def test_attribute_access(self):
         ast_nodes = builder.extract_node(
             """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -54,6 +54,13 @@ from astroid.objects import ExceptionInstance
 
 from . import resources
 
+try:
+    import six  # pylint: disable=unused-import
+
+    HAS_SIX = True
+except ImportError:
+    HAS_SIX = False
+
 
 def get_node_of_class(start_from, klass):
     return next(start_from.nodes_of_class(klass))
@@ -2975,6 +2982,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 24)
 
+    @unittest.skipUnless(HAS_SIX, "These tests require the six library")
     def test_with_metaclass__getitem__(self):
         ast_node = extract_node(
             """
@@ -3008,6 +3016,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 24)
 
+    @unittest.skipUnless(HAS_SIX, "These tests require the six library")
     def test_bin_op_classes_with_metaclass(self):
         ast_node = extract_node(
             """
@@ -3362,6 +3371,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 42)
 
+    @unittest.skipUnless(HAS_SIX, "These tests require the six library")
     def test_unary_op_classes_with_metaclass(self):
         ast_node = extract_node(
             """
@@ -3768,6 +3778,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertEqual(inferred.name, "B")
 
+    @unittest.skipUnless(HAS_SIX, "These tests require the six library")
     def test_With_metaclass_subclasses_arguments_are_classes_not_instances(self):
         ast_node = extract_node(
             """
@@ -3785,6 +3796,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertEqual(inferred.name, "B")
 
+    @unittest.skipUnless(HAS_SIX, "These tests require the six library")
     def test_With_metaclass_with_partial_imported_name(self):
         ast_node = extract_node(
             """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}, py{36,37,38,39}-six
+envlist = py{36,37,38,39}
 skip_missing_interpreters = true
 
 [testenv:pylint]
@@ -11,9 +11,7 @@ commands = pre-commit run pylint --all-files
 [testenv]
 deps =
   -r requirements_test_min.txt
-  py{36,37,38,39}: -r requirements_test_brain.txt
-  !py{36,37,38,39}-six: python-dateutil
-  six: six
+  -r requirements_test_brain.txt
   coverage<5
 
 setenv =


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
`six` is only used to test `brain_six.py`. Besides that, it isn't used anywhere. There is no reason why we can't include it with the other third party brain dependencies. Similar story for `python-dateutil`.

The tests have guards to check if `six` is installed, so there is no need for further action besides this MR.
https://github.com/PyCQA/astroid/blob/54e6efeb3989bbb1c1127a73e8e0cbc2aef78912/tests/unittest_brain.py#L63-L82

/CC: @Pierre-Sassoulas, @hippo91 

Preparation for #947


## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |