### PR TITLE
Add __init__ to astroid.brain package

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -41,7 +41,8 @@ Main modules are:
 import enum
 import itertools
 import os
-import sys
+from importlib import import_module
+from pathlib import Path
 
 import wrapt
 
@@ -156,11 +157,7 @@ def register_module_extender(manager, module_name, get_extension_mod):
 
 
 # load brain plugins
-BRAIN_MODULES_DIR = os.path.join(os.path.dirname(__file__), "brain")
-if BRAIN_MODULES_DIR not in sys.path:
-    # add it to the end of the list so user path take precedence
-    sys.path.append(BRAIN_MODULES_DIR)
-# load modules in this directory
+BRAIN_MODULES_DIR = Path(__file__).with_name("brain")
 for module in os.listdir(BRAIN_MODULES_DIR):
     if module.endswith(".py"):
-        __import__(module[:-3])
+        import_module(f"astroid.brain.{module[:-3]}")

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -10,9 +10,9 @@
 
 import functools
 
-from brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
-
 import astroid
+
+from .brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 
 METHODS_TO_BE_INFERRED = {
     "linspace": """def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -9,9 +9,9 @@
 
 import functools
 
-from brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
-
 import astroid
+
+from .brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 
 
 def numpy_core_multiarray_transform():

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -10,9 +10,9 @@
 
 import functools
 
-from brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
-
 import astroid
+
+from .brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 
 
 def numpy_core_numeric_transform():


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
For #937 to work, `astroid.brain` needs to be a package, i.e. have an `__init__.py` file.
With this change, `astroid.brain` is no longer added to `sys.path`, instead I use `importlib.import_module` and the full path `astroid.brain.brain_xxx.py`. A good side effect is that we can now use relative imports inside the brain modules.

/CC: @Pierre-Sassoulas @hippo91 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |