### PR TITLE
Add flake8 in pre-commit configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+extend-ignore = E203, E266, E501, C901, F401
+max-complexity = 20
+select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-extend-ignore = E203, E266, E501, C901, F401
+extend-ignore = E203,E266,E501,C901,F401
 max-complexity = 20
 select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,11 @@ repos:
       - id: isort
         exclude: tests/testdata|astroid/__init__.py
   - repo: https://github.com/Pierre-Sassoulas/black-disable-checker/
-    rev: 1.0.0
+    rev: 1.0.1
     hooks:
       - id: black-disable-checker
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.12.0
+    rev: v2.13.0
     hooks:
       - id: pyupgrade
         exclude: tests/testdata
@@ -45,6 +45,12 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear]
+        exclude: tests/testdata|doc/conf.py|astroid/__init__.py|setup.py
   - repo: local
     hooks:
       - id: pylint

--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -6,11 +6,10 @@ from typing import Optional
 
 import astroid
 
-_ast_py3 = None
 try:
     import typed_ast.ast3 as _ast_py3
 except ImportError:
-    pass
+    _ast_py3 = None
 
 
 PY38 = sys.version_info[:2] >= (3, 8)

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -106,7 +106,7 @@ class Proxy:
 
     def __getattr__(self, name):
         if name == "_proxied":
-            return getattr(self.__class__, "_proxied")
+            return self.__class__._proxied
         if name in self.__dict__:
             return self.__dict__[name]
         return getattr(self._proxied, name)

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -220,7 +220,7 @@ class BaseInstance(Proxy):
             yield from _infer_stmts(
                 self._wrap_attr(get_attr, context), context, frame=self
             )
-        except exceptions.AttributeInferenceError as error:
+        except exceptions.AttributeInferenceError:
             try:
                 # fallback to class.igetattr since it has some logic to handle
                 # descriptors

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -322,7 +322,9 @@ infer_frozenset = partial(
 
 
 def _get_elts(arg, context):
-    is_iterable = lambda n: isinstance(n, (nodes.List, nodes.Tuple, nodes.Set))
+    def is_iterable(n):
+        return isinstance(n, (nodes.List, nodes.Tuple, nodes.Set))
+
     try:
         inferred = next(arg.infer(context))
     except (InferenceError, NameInferenceError) as exc:

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -18,7 +18,10 @@ import astroid.builder
 _BUILDER = astroid.builder.AstroidBuilder(astroid.MANAGER)
 
 
-def _pep8(name, caps=re.compile("([A-Z])")):
+CAPITALS = re.compile("([A-Z])")
+
+
+def _pep8(name, caps=CAPITALS):
     return caps.sub(lambda m: "_" + m.groups()[0].lower(), name)
 
 

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -26,7 +26,11 @@ SIX_ADD_METACLASS = "six.add_metaclass"
 SIX_WITH_METACLASS = "six.with_metaclass"
 
 
-def _indent(text, prefix, predicate=None):
+def default_predicate(line):
+    return line.strip()
+
+
+def _indent(text, prefix, predicate=default_predicate):
     """Adds 'prefix' to the beginning of selected lines in 'text'.
 
     If 'predicate' is provided, 'prefix' will only be added to the lines
@@ -34,8 +38,6 @@ def _indent(text, prefix, predicate=None):
     it will default to adding 'prefix' to all non-empty lines that do not
     consist solely of whitespace characters.
     """
-    if predicate is None:
-        predicate = lambda line: line.strip()
 
     def prefixed_lines():
         for line in text.splitlines(True):

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -169,7 +169,7 @@ def infer_typing_attr(
         ):
             # node.parent.slots is evaluated and cached before the inference tip
             # is first applied. Remove the last result to allow a recalculation of slots
-            cache = getattr(node.parent, "__cache")
+            cache = node.parent.__cache
             if cache.get(node.parent.slots) is not None:
                 del cache[node.parent.slots]
         return iter([value])

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -203,7 +203,9 @@ class AstroidBuilder(raw_building.InspectBuilder):
 
         Resort the locals if coming from a delayed node
         """
-        _key_func = lambda node: node.fromlineno
+
+        def _key_func(node):
+            return node.fromlineno
 
         def sort_locals(my_list):
             my_list.sort(key=_key_func)

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -928,7 +928,7 @@ nodes.IfExp._infer = infer_ifexp
 
 # pylint: disable=dangerous-default-value
 @wrapt.decorator
-def _cached_generator(func, instance, args, kwargs, _cache={}):
+def _cached_generator(func, instance, args, kwargs, _cache={}):  # noqa: B006
     node = args[0]
     try:
         return iter(_cache[func, id(node)])

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -276,7 +276,7 @@ def infer_import_from(self, context=None, asname=True):
         return bases._infer_stmts(stmts, context)
     except exceptions.AttributeInferenceError as error:
         raise exceptions.InferenceError(
-            error.message, target=self, attribute=name, context=context
+            str(error), target=self, attribute=name, context=context
         ) from error
 
 
@@ -339,7 +339,7 @@ def infer_global(self, context=None):
         return bases._infer_stmts(self.root().getattr(context.lookupname), context)
     except exceptions.AttributeInferenceError as error:
         raise exceptions.InferenceError(
-            error.message, target=self, attribute=context.lookupname, context=context
+            str(error), target=self, attribute=context.lookupname, context=context
         ) from error
 
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -558,7 +558,9 @@ class GeneratorModel(FunctionModel):
         generator = astroid.MANAGER.builtins_module["generator"]
         for name, values in generator.locals.items():
             method = values[0]
-            patched = lambda cls, meth=method: meth
+
+            def patched(cls, meth=method):
+                return meth
 
             setattr(type(ret), IMPL_PREFIX + name, property(patched))
 
@@ -589,7 +591,9 @@ class AsyncGeneratorModel(GeneratorModel):
 
         for name, values in generator.locals.items():
             method = values[0]
-            patched = lambda cls, meth=method: meth
+
+            def patched(cls, meth=method):
+                return meth
 
             setattr(type(ret), IMPL_PREFIX + name, property(patched))
 

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -414,8 +414,9 @@ class InspectBuilder:
 
 _CONST_PROXY = {}
 
-# TODO : find a nicer way to handle this situation;
+
 def _set_proxied(const):
+    # TODO : find a nicer way to handle this situation;
     return _CONST_PROXY[const.value.__class__]
 
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -611,7 +611,7 @@ class Module(LocalsDictNodeNG):
             return bases._infer_stmts(self.getattr(name, context), context, frame=self)
         except exceptions.AttributeInferenceError as error:
             raise exceptions.InferenceError(
-                error.message, target=self, attribute=name, context=context
+                str(error), target=self, attribute=name, context=context
             ) from error
 
     def fully_defined(self):
@@ -1617,7 +1617,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
             return bases._infer_stmts(self.getattr(name, context), context, frame=self)
         except exceptions.AttributeInferenceError as error:
             raise exceptions.InferenceError(
-                error.message, target=self, attribute=name, context=context
+                str(error), target=self, attribute=name, context=context
             ) from error
 
     def is_method(self):
@@ -2605,7 +2605,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
                 yield util.Uninferable
             else:
                 raise exceptions.InferenceError(
-                    error.message, target=self, attribute=name, context=context
+                    str(error), target=self, attribute=name, context=context
                 ) from error
 
     def has_dynamic_getattr(self, context=None):

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -760,9 +760,9 @@ class Module(LocalsDictNodeNG):
         if not isinstance(explicit, (node_classes.Tuple, node_classes.List)):
             return default
 
-        str_const = lambda node: (
-            isinstance(node, node_classes.Const) and isinstance(node.value, str)
-        )
+        def str_const(node):
+            return isinstance(node, node_classes.Const) and isinstance(node.value, str)
+
         for node in explicit.elts:
             if str_const(node):
                 inferred.append(node.value)

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -56,8 +56,7 @@ class Uninferable:
     __nonzero__ = __bool__
 
     def accept(self, visitor):
-        func = getattr(visitor, "visit_uninferable")
-        return func(self)
+        return visitor.visit_uninferable(self)
 
 
 class BadOperationMessage:

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,6 +1,6 @@
 autoflake==1.4
 black==20.8b1
-pyupgrade==2.11.0
-black-disable-checker==1.0.0
+pyupgrade==2.13.0
+black-disable-checker==1.0.1
 pylint==2.7.4
 isort==5.8.0

--- a/tests/unittest_transforms.py
+++ b/tests/unittest_transforms.py
@@ -187,7 +187,10 @@ class TestTransforms(unittest.TestCase):
             return node
 
         manager = builder.MANAGER
-        predicate = lambda node: node.root().name == "time"
+
+        def predicate(node):
+            return node.root().name == "time"
+
         with add_transform(manager, nodes.FunctionDef, transform_function, predicate):
             builder_instance = builder.AstroidBuilder()
             module = builder_instance.module_build(time)


### PR DESCRIPTION
## Description

Fix the legacy problem with flake8, some of them quite ancient (python 2.6 deprecation!) and add an automated checker in pre-commit configuration.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |
