### PR TITLE
Use absolute URIs in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Astroid
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
-.. |tideliftlogo| image:: doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png
+.. |tideliftlogo| image:: https://github.com/PyCQA/astroid/blob/master/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
    :width: 75
    :height: 60
    :alt: Tidelift


### PR DESCRIPTION
## Description
Replace relative URIs with absolute ones. The relative ones don't work for pypi: https://pypi.org/project/astroid/
MR for `pylint`: https://github.com/PyCQA/pylint/pull/4397

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |