### PR TITLE
Fix six.with_metaclass transformation so it doesn't break user defined transformations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ What's New in astroid 2.5.7?
 ============================
 Release Date: TBA
 
+* Fix six.with_metaclass transformation so it doesn't break user defined transformations.
+
 * Fix detection of relative imports.
   Closes #930
   Closes PyCQA/pylint#4186

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -225,6 +225,7 @@ def transform_six_with_metaclass(node):
     """
     call = node.bases[0]
     node._metaclass = call.args[0]
+    return node
 
 
 register_module_extender(MANAGER, "six", six_moves_transform)

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -498,7 +498,7 @@ class SixBrainTest(unittest.TestCase):
     def test_six_with_metaclass_with_additional_transform(self):
         def transform_class(cls):
             if cls.name == "A":
-                setattr(cls, "_test_transform", 314)
+                cls._test_transform = 314
             return cls
 
         MANAGER.register_transform(nodes.ClassDef, transform_class)

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -495,7 +495,7 @@ class SixBrainTest(unittest.TestCase):
         self.assertIsInstance(ancestors[1], nodes.ClassDef)
         self.assertEqual(ancestors[1].name, "object")
 
-    def test_six_add_metaclass_with_additional_transform(self):
+    def test_six_with_metaclass_with_additional_transform(self):
         def transform_class(cls):
             if cls.name == "A":
                 setattr(cls, "_test_transform", 314)

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -495,6 +495,28 @@ class SixBrainTest(unittest.TestCase):
         self.assertIsInstance(ancestors[1], nodes.ClassDef)
         self.assertEqual(ancestors[1].name, "object")
 
+    def test_six_add_metaclass_with_additional_transform(self):
+        def transform_class(cls):
+            if cls.name == "A":
+                setattr(cls, "_test_transform", 314)
+            return cls
+
+        MANAGER.register_transform(nodes.ClassDef, transform_class)
+        try:
+            ast_node = builder.extract_node(
+                """
+                import six
+                class A(six.with_metaclass(type, object)):
+                    pass
+
+                A #@
+            """
+            )
+            inferred = next(ast_node.infer())
+            assert getattr(inferred, "_test_transform", None) == 314
+        finally:
+            MANAGER.unregister_transform(nodes.ClassDef, transform_class)
+
 
 @unittest.skipUnless(
     HAS_MULTIPROCESSING,


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

`astroid.brain.brain_six.transform_six_with_metaclass`  transformation doesn't return a node after fixing `_metaclass` attribute on a node (code https://github.com/PyCQA/astroid/blob/master/astroid/brain/brain_six.py#L225). It lead to an issue when user defined transformations for classes defined with `six.with_metaclass` are skipped.

`astroid.brain.brain_six.transform_six_add_metaclass`  doesn't have this issue (code https://github.com/PyCQA/astroid/blob/master/astroid/brain/brain_six.py#L192). However, it looks like both should behave in the same way.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
