### PR TITLE
Infer return value of None for correctly inferred functions with no returns

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -45,6 +45,11 @@ Release Date: TBA
 
   Closes #904
 
+* Allow inferring a return value of None for non-abstract empty functions and
+  functions with no return statements (implicitly returning None)
+
+  Closes #485
+
 
 What's New in astroid 2.5.6?
 ============================

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -329,6 +329,12 @@ class Instance(BaseInstance):
             raise exceptions.InferenceError(
                 "Could not find __getitem__ for {node!r}.", node=self, context=context
             )
+        if len(method.args.arguments) != 2:  # (self, index)
+            raise exceptions.AstroidTypeError(
+                "__getitem__ for {node!r} does not have correct signature",
+                node=self,
+                context=context,
+            )
         return next(method.infer_call_result(self, new_context))
 
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -1744,7 +1744,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
 
         first_return = next(returns, None)
         if not first_return:
-            if self.body and isinstance(self.body[-1], node_classes.Assert):
+            if self.body:
                 yield node_classes.Const(None)
                 return
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -706,14 +706,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         NoGetitem()[4] #@
         InvalidGetitem()[5] #@
         InvalidGetitem2()[10] #@
-        """
-        )
-        for node in ast_nodes[:3]:
-            self.assertRaises(InferenceError, next, node.infer())
-        for node in ast_nodes[3:]:
-            self.assertEqual(next(node.infer()), util.Uninferable)
-        ast_nodes = extract_node(
-            """
         [1, 2, 3][None] #@
         'lala'['bala'] #@
         """

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -466,6 +466,18 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         self.assertIsInstance(func_vals[0], nodes.Const)
         self.assertIsNone(func_vals[0].value)
 
+    def test_no_returns_is_implicitly_none(self):
+        code = """
+            def f():
+                print('non-empty, non-pass, no return statements')
+            value = f()
+            value
+        """
+        node = builder.extract_node(code)
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value is None
+
     def test_func_instance_attr(self):
         """test instance attributes for functions"""
         data = """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

Functions with empty bodies or no return statements e.g. `def f(): pass` were returned as `Uninferable` from `infer_call_result`

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes #485 
Ref #663 

Pylint PR: https://github.com/PyCQA/pylint/pull/4428