### PR TITLE
Fix 930 pyreverse regression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -54,6 +54,7 @@ Release Date: TBA
 
   Closes #485
 
+
 What's New in astroid 2.5.6?
 ============================
 Release Date: 2021-04-25

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.6.0?
 ============================
 Release Date: TBA
 
+* Fix detection of relative imports.
+  Closes #930
+  Closes PyCQA/pylint#4186
+
 What's New in astroid 2.5.6?
 ============================
 Release Date: 2021-04-25

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -292,15 +292,13 @@ def _precache_zipimporters(path=None):
     new_paths = _cached_set_diff(req_paths, cached_paths)
     for entry_path in new_paths:
         try:
-            pic[entry_path] = zipimport.zipimporter(  # pylint: disable=no-member
-                entry_path
-            )
-        except zipimport.ZipImportError:  # pylint: disable=no-member
+            pic[entry_path] = zipimport.zipimporter(entry_path)
+        except zipimport.ZipImportError:
             continue
     return {
         key: value
         for key, value in pic.items()
-        if isinstance(value, zipimport.zipimporter)  # pylint: disable=no-member
+        if isinstance(value, zipimport.zipimporter)
     }
 
 

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -213,9 +213,7 @@ class AstroidManager:
             except ValueError:
                 continue
             try:
-                importer = zipimport.zipimporter(  # pylint: disable=no-member
-                    eggpath + ext
-                )
+                importer = zipimport.zipimporter(eggpath + ext)
                 zmodname = resource.replace(os.path.sep, ".")
                 if importer.is_package(resource):
                     zmodname = zmodname + ".__init__"

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -18,6 +18,7 @@
 # Copyright (c) 2020 hippo91 <guillaume.peillex@gmail.com>
 # Copyright (c) 2020 Peter Kolbus <peter.kolbus@gmail.com>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
+# Copyright (c) 2021 Andreas Finkler <andi.finkler@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
@@ -37,6 +38,8 @@
 # We disable the import-error so pylint can work without distutils installed.
 # pylint: disable=no-name-in-module,useless-suppression
 
+import importlib
+import importlib.machinery
 import importlib.util
 import itertools
 import os
@@ -574,12 +577,9 @@ def is_relative(modname, from_file):
         from_file = os.path.dirname(from_file)
     if from_file in sys.path:
         return False
-    modspec = importlib.machinery.PathFinder().find_spec(
-        modname.split(".")[0], [from_file]
+    return bool(
+        importlib.machinery.PathFinder.find_spec(modname.split(".")[0], [from_file])
     )
-    if modspec:
-        return True
-    return False
 
 
 # internal only functions #####################################################

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -578,7 +578,9 @@ def is_relative(modname, from_file):
     if from_file in sys.path:
         return False
     return bool(
-        importlib.machinery.PathFinder.find_spec(modname.partition(".")[0], [from_file])
+        importlib.machinery.PathFinder.find_spec(
+            modname.split(".", maxsplit=1)[0], [from_file]
+        )
     )
 
 

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -578,7 +578,7 @@ def is_relative(modname, from_file):
     if from_file in sys.path:
         return False
     return bool(
-        importlib.machinery.PathFinder.find_spec(modname.split(".")[0], [from_file])
+        importlib.machinery.PathFinder.find_spec(modname.partition(".")[0], [from_file])
     )
 
 

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -574,10 +574,10 @@ def is_relative(modname, from_file):
         from_file = os.path.dirname(from_file)
     if from_file in sys.path:
         return False
-    spec = importlib.machinery.PathFinder().find_spec(
+    modspec = importlib.machinery.PathFinder().find_spec(
         modname.split(".")[0], [from_file]
     )
-    if spec:
+    if modspec:
         return True
     return False
 

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -574,21 +574,12 @@ def is_relative(modname, from_file):
         from_file = os.path.dirname(from_file)
     if from_file in sys.path:
         return False
-    name = os.path.basename(from_file)
-    file_path = os.path.dirname(from_file)
-    parent_spec = importlib.util.find_spec(name, from_file)
-    while parent_spec is None and len(file_path) > 0:
-        name = os.path.basename(file_path) + "." + name
-        file_path = os.path.dirname(file_path)
-        parent_spec = importlib.util.find_spec(name, from_file)
-
-    if parent_spec is None:
-        return False
-
-    submodule_spec = importlib.util.find_spec(
-        name + "." + modname.split(".")[0], parent_spec.submodule_search_locations
+    spec = importlib.machinery.PathFinder().find_spec(
+        modname.split(".")[0], [from_file]
     )
-    return submodule_spec is not None
+    if spec:
+        return True
+    return False
 
 
 # internal only functions #####################################################

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -301,6 +301,18 @@ class IsRelativeTest(unittest.TestCase):
     def test_knownValues_is_relative_3(self):
         self.assertFalse(modutils.is_relative("astroid", astroid.__path__[0]))
 
+    def test_knownValues_is_relative_4(self):
+        self.assertTrue(
+            modutils.is_relative("util", astroid.interpreter._import.spec.__file__)
+        )
+
+    def test_knownValues_is_relative_5(self):
+        self.assertFalse(
+            modutils.is_relative(
+                "objectmodel", astroid.interpreter._import.spec.__file__
+            )
+        )
+
     def test_deep_relative(self):
         self.assertTrue(modutils.is_relative("ElementTree", xml.etree.__path__[0]))
 


### PR DESCRIPTION

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
PR #857 introduced a regression for ``modutils.is_relative()``.
Calling this function failed if the inspected import statement was inside a module of a package at least two levels deep (e.g. ``astroid.interpreter._import.spec``, see the added unit tests).

Inspecting the old implementation of ``is_relative`` which relied on ``imp`` and the implementation of ``imp.find_module``, this only checked of the given ``modname`` (or better to say the first part after splitting it on ".") was a module or package inside the same package as the ``from_file`` itself. 

The new implementation seemed to do a lot more, and I could not really understand what exactly.

Anyways, ``importlib.machinery.PathFinder().find_spec`` [seems to be a better replacement for ``imp.find_module``](https://stackoverflow.com/a/50028745/4030694), makes the implementation simpler, passes all the tests and ``pyreverse`` is working again.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #930 
Closes PyCQA/pylint#4186
