### PR TITLE
Update pylint to 2.8.2

### DIFF
--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -2,5 +2,5 @@ autoflake==1.4
 black==20.8b1
 pyupgrade==2.13.0
 black-disable-checker==1.0.1
-pylint==2.7.4
+pylint==2.8.2
 isort==5.8.0


### PR DESCRIPTION
## Description
Update `pylint` version used for pre-commit checks to `2.8.2`.