### PR TITLE
CI - Add python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -159,7 +159,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2.3.4
@@ -240,7 +240,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -282,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -1,5 +1,8 @@
 attrs
 nose
-numpy
+# Don't test numpy with py310
+# Until a wheel is uploaded to pypi, this would require
+# additional dependencies to build it from source
+numpy; python_version < "3.10"
 python-dateutil
 six


### PR DESCRIPTION
## Description
Just add `3.10-dev` to Github actions for now. `numpy` wheels aren't yet published for `310`, so only test it with `< 3.10`.

## Related
#966