### PR TITLE
Fix crash on random.sample brain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,10 @@ Release Date: TBA
   Closes PyCQA/pylint#3535
   Closes PyCQA/pylint#4358
 
+* Update random brain to fix a crash with inference of some sequence elements
+
+  Closes #922
+
 
 What's New in astroid 2.5.6?
 ============================

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -9,6 +9,8 @@ ACCEPTED_ITERABLES_FOR_SAMPLE = (astroid.List, astroid.Set, astroid.Tuple)
 
 
 def _clone_node_with_lineno(node, parent, lineno):
+    if isinstance(node, astroid.EvaluatedObject):
+        node = node.original
     cls = node.__class__
     other_fields = node._other_fields
     _astroid_fields = node._astroid_fields

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1858,6 +1858,18 @@ class RandomSampleTest(unittest.TestCase):
         elems = sorted(elem.value for elem in inferred.elts)
         self.assertEqual(elems, [1, 2])
 
+    def test_no_crash_on_evaluatedobject(self):
+        node = astroid.extract_node(
+            """
+        from random import sample
+        class A: pass
+        sample(list({1: A()}.values()), 1)"""
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, astroid.List)
+        assert len(inferred.elts) == 1
+        assert isinstance(inferred.elts[0], nodes.Call)
+
 
 class SubprocessTest(unittest.TestCase):
     """Test subprocess brain"""


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Some sequence nodes can result in an `EvaluatedObject` after inference, which cannot be cloned by the `_clone_node_with_lineno` helper in `brain_random`. This change updates `_clone_node_with_lineno` to use the original node when cloning.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes #922 
