### PR TITLE
Improve Sphinx config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -231,7 +231,13 @@ man_pages = [
      ['Logilab, PyCQA and contributors'], 1)
 ]
 
-autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance']
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+}
+autodoc_member_order = "groupwise"
+autodoc_typehints = 'description'
 intersphinx_mapping = {
     'green_tree_snakes':
         ('http://greentreesnakes.readthedocs.io/en/latest/', 'ast_objects.inv'),

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
 -e .
-sphinx
+sphinx~=4.0

--- a/tox.ini
+++ b/tox.ini
@@ -68,4 +68,4 @@ changedir = doc/
 deps =
     -r doc/requirements.txt
 commands =
-    sphinx-build -b html . build
+    sphinx-build -E -b html . build


### PR DESCRIPTION
## Description

Update Sphinx config to better handle type hints. This change will allow us to remove `:type:` from the docstrings if the variable has a type annotation.

#### Comparison
Current: http://pylint.pycqa.org/projects/astroid/en/latest/api/astroid.nodes.html#astroid.nodes.Match
New: https://pylint--1001.org.readthedocs.build/projects/astroid/en/1001/api/astroid.nodes.html#astroid.nodes.Match

#### Changes
* Update and pin Sphinx version
* Update conf
* Group class members
* Display typehints in description

#### Links
https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |