### PR TITLE
Performance improvements to counter context.clone slowdown

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.5.8?
 ============================
 Release Date: TBA
 
+* Add global inference cache to speed up inference of long statement blocks
+
+* Add a limit to the total number of nodes inferred indirectly as a result
+  of inferring some node
 
 
 What's New in astroid 2.5.7?

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -30,9 +30,16 @@ class InferenceContext:
         "boundnode",
         "inferred",
         "extra_context",
+        "_nodes_inferred",
     )
 
-    def __init__(self, path=None, inferred=None):
+    max_inferred = 100
+
+    def __init__(self, path=None, inferred=None, nodes_inferred=None):
+        if nodes_inferred is None:
+            self._nodes_inferred = [0]
+        else:
+            self._nodes_inferred = nodes_inferred
         self.path = path or set()
         """
         :type: set(tuple(NodeNG, optional(str)))
@@ -81,6 +88,20 @@ class InferenceContext:
         for call arguments
         """
 
+    @property
+    def nodes_inferred(self):
+        """
+        Number of nodes inferred in this context and all its clones/decendents
+
+        Wrap inner value in a mutable cell to allow for mutating a class
+        variable in the presence of __slots__
+        """
+        return self._nodes_inferred[0]
+
+    @nodes_inferred.setter
+    def nodes_inferred(self, value):
+        self._nodes_inferred[0] = value
+
     def push(self, node):
         """Push node into inference path
 
@@ -103,7 +124,11 @@ class InferenceContext:
         starts with the same context but diverge as each side is inferred
         so the InferenceContext will need be cloned"""
         # XXX copy lookupname/callcontext ?
-        clone = InferenceContext(self.path.copy(), inferred=self.inferred.copy())
+        clone = InferenceContext(
+            self.path.copy(),
+            inferred=self.inferred.copy(),
+            nodes_inferred=self._nodes_inferred,
+        )
         clone.callcontext = self.callcontext
         clone.boundnode = self.boundnode
         clone.extra_context = self.extra_context

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -150,7 +150,7 @@ def safe_infer(node, context=None):
     try:
         inferit = node.infer(context=context)
         value = next(inferit)
-    except exceptions.InferenceError:
+    except (exceptions.InferenceError, StopIteration):
         return None
     try:
         next(inferit)

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -10,6 +10,8 @@
 import collections
 from functools import lru_cache
 
+from astroid import context as contextmod
+
 
 class TransformVisitor:
     """A visitor for handling transforms.
@@ -42,6 +44,7 @@ class TransformVisitor:
                 # if the transformation function returns something, it's
                 # expected to be a replacement for the node
                 if ret is not None:
+                    contextmod._invalidate_cache()
                     node = ret
                 if ret.__class__ != cls:
                     # Can no longer apply the rest of the transforms.


### PR DESCRIPTION
## Steps

- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

This adds a couple of changes to `InferenceContext` to eliminate copies of the `inferred` nodes cache and limit the total number of inferred nodes in a context and all of its clones (preventing deep inference chains).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Related Issue

Ref #1003
