### PR TITLE
Improve support for Pattern Matching

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ What's New in astroid 2.5.8?
 ============================
 Release Date: TBA
 
+* Improve support for Pattern Matching
 
 
 What's New in astroid 2.5.7?

--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -27,6 +27,21 @@
 * :func:`dump` function return an internal representation of nodes found
   in the tree, useful for debugging or understanding the tree structure
 """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .node_classes import (
+        Match,
+        MatchAs,
+        MatchCase,
+        MatchClass,
+        MatchMapping,
+        MatchOr,
+        MatchSequence,
+        MatchSingleton,
+        MatchStar,
+        MatchValue,
+    )
 
 # pylint: disable=unused-argument
 
@@ -590,6 +605,80 @@ class AsStringVisitor:
     def visit_starred(self, node):
         """return Starred node as string"""
         return "*" + node.value.accept(self)
+
+    def visit_match(self, node: "Match") -> str:
+        """Return an astroid.Match node as string."""
+        return f"match {node.subject.accept(self)}:\n{self._stmt_list(node.cases)}"
+
+    def visit_matchcase(self, node: "MatchCase") -> str:
+        """Return an astroid.MatchCase node as string."""
+        guard_str = f" if {node.guard.accept(self)}" if node.guard else ""
+        return (
+            f"case {node.pattern.accept(self)}{guard_str}:\n"
+            f"{self._stmt_list(node.body)}"
+        )
+
+    def visit_matchvalue(self, node: "MatchValue") -> str:
+        """Return an astroid.MatchValue node as string."""
+        return node.value.accept(self)
+
+    @staticmethod
+    def visit_matchsingleton(node: "MatchSingleton") -> str:
+        """Return an astroid.MatchSingleton node as string."""
+        return str(node.value)
+
+    def visit_matchsequence(self, node: "MatchSequence") -> str:
+        """Return an astroid.MatchSequence node as string."""
+        if node.patterns is None:
+            return "[]"
+        return f"[{', '.join(p.accept(self) for p in node.patterns)}]"
+
+    def visit_matchmapping(self, node: "MatchMapping") -> str:
+        """Return an astroid.MatchMapping node as string."""
+        mapping_strings = []
+        if node.keys and node.patterns:
+            mapping_strings.extend(
+                f"{key.accept(self)}: {p.accept(self)}"
+                for key, p in zip(node.keys, node.patterns)
+            )
+        if node.rest:
+            mapping_strings.append(f"**{node.rest.accept(self)}")
+        return f"{'{'}{', '.join(mapping_strings)}{'}'}"
+
+    def visit_matchclass(self, node: "MatchClass") -> str:
+        """Return an astroid.MatchClass node as string."""
+        if node.cls is None:
+            raise Exception(f"{node} does not have a 'cls' node")
+        class_strings = []
+        if node.patterns:
+            class_strings.extend(p.accept(self) for p in node.patterns)
+        if node.kwd_attrs and node.kwd_patterns:
+            for attr, pattern in zip(node.kwd_attrs, node.kwd_patterns):
+                class_strings.append(f"{attr}={pattern.accept(self)}")
+        return f"{node.cls.accept(self)}({', '.join(class_strings)})"
+
+    def visit_matchstar(self, node: "MatchStar") -> str:
+        """Return an astroid.MatchStar node as string."""
+        return f"*{node.name.accept(self) if node.name else '_'}"
+
+    def visit_matchas(self, node: "MatchAs") -> str:
+        """Return an astroid.MatchAs node as string."""
+        # pylint: disable=import-outside-toplevel
+        # Prevent circular dependency
+        from astroid.node_classes import MatchClass, MatchMapping, MatchSequence
+
+        if isinstance(node.parent, (MatchSequence, MatchMapping, MatchClass)):
+            return node.name.accept(self) if node.name else "_"
+        return (
+            f"{node.pattern.accept(self) if node.pattern else '_'}"
+            f"{f' as {node.name.accept(self)}' if node.name else ''}"
+        )
+
+    def visit_matchor(self, node: "MatchOr") -> str:
+        """Return an astroid.MatchOr node as string."""
+        if node.patterns is None:
+            raise Exception(f"{node} does not have pattern nodes")
+        return " | ".join(p.accept(self) for p in node.patterns)
 
     # These aren't for real AST nodes, but for inference objects.
 

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4813,7 +4813,18 @@ class EvaluatedObject(NodeNG):
 
 
 class Match(Statement):
-    """Class representing a :class:`ast.Match` node."""
+    """Class representing a :class:`ast.Match` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case 200:
+            ...
+        case _:
+            ...
+    ''')
+    >>> node
+    <Match l.2 at 0x10c24e170>
+    """
 
     _astroid_fields = ("subject", "cases")
     subject: typing.Optional[NodeNG] = None
@@ -4836,7 +4847,16 @@ class Match(Statement):
 
 
 class MatchCase(NodeNG):
-    """Class representing a :class:`ast.match_case` node."""
+    """Class representing a :class:`ast.match_case` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case 200:
+            ...
+    ''')
+    >>> node.cases[0]
+    <MatchCase l.3 at 0x10c24e590>
+    """
 
     _astroid_fields = ("pattern", "guard", "body")
     pattern: typing.Optional["PatternTypes"] = None
@@ -4864,7 +4884,16 @@ class MatchCase(NodeNG):
 
 
 class MatchValue(NodeNG):
-    """Class representing a :class:`ast.MatchValue` node."""
+    """Class representing a :class:`ast.MatchValue` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case 200:
+            ...
+    ''')
+    >>> node.cases[0].pattern
+    <MatchValue l.3 at 0x10c24e200>
+    """
 
     _astroid_fields = ("value",)
     value: typing.Optional[NodeNG] = None
@@ -4878,7 +4907,24 @@ class MatchValue(NodeNG):
 
 
 class MatchSingleton(mixins.NoChildrenMixin, NodeNG):
-    """Class representing a :class:`ast.MatchSingleton` node."""
+    """Class representing a :class:`ast.MatchSingleton` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case True:
+            ...
+        case False:
+            ...
+        case None:
+            ...
+    ''')
+    >>> node.cases[0].pattern
+    <MatchSingleton l.3 at 0x10c2282e0>
+    >>> node.cases[1].pattern
+    <MatchSingleton l.5 at 0x10c228af0>
+    >>> node.cases[2].pattern
+    <MatchSingleton l.7 at 0x10c229f90>
+    """
 
     _other_fields = ("value",)
 
@@ -4895,7 +4941,20 @@ class MatchSingleton(mixins.NoChildrenMixin, NodeNG):
 
 
 class MatchSequence(NodeNG):
-    """Class representing a :class:`ast.MatchSequence` node."""
+    """Class representing a :class:`ast.MatchSequence` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case [1, 2]:
+            ...
+        case (1, 2, *_):
+            ...
+    ''')
+    >>> node.cases[0].pattern
+    <MatchSequence l.3 at 0x10ca80d00>
+    >>> node.cases[1].pattern
+    <MatchSequence l.5 at 0x10ca80b20>
+    """
 
     _astroid_fields = ("patterns",)
     patterns: typing.Optional[typing.List["PatternTypes"]] = None
@@ -4911,7 +4970,16 @@ class MatchSequence(NodeNG):
 
 
 class MatchMapping(mixins.AssignTypeMixin, NodeNG):
-    """Class representing a :class:`ast.MatchMapping` node."""
+    """Class representing a :class:`ast.MatchMapping` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case {1: "Hello", 2: "World", 3: _, **rest}:
+            ...
+    ''')
+    >>> node.cases[0].pattern
+    <MatchMapping l.3 at 0x10c8a8850>
+    """
 
     _astroid_fields = ("keys", "patterns", "rest")
     keys: typing.Optional[typing.List[NodeNG]] = None
@@ -4939,7 +5007,20 @@ class MatchMapping(mixins.AssignTypeMixin, NodeNG):
 
 
 class MatchClass(NodeNG):
-    """Class representing a :class:`ast.MatchClass` node."""
+    """Class representing a :class:`ast.MatchClass` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case Point2D(0, 0):
+            ...
+        case Point3D(x=0, y=0, z=0):
+            ...
+    ''')
+    >>> node.cases[0].pattern
+    <MatchClass l.3 at 0x10ca83940>
+    >>> node.cases[1].pattern
+    <MatchClass l.5 at 0x10ca80880>
+    """
 
     _astroid_fields = ("cls", "patterns", "kwd_attrs", "kwd_patterns")
     cls: typing.Optional[NodeNG] = None
@@ -4970,7 +5051,16 @@ class MatchClass(NodeNG):
 
 
 class MatchStar(mixins.AssignTypeMixin, NodeNG):
-    """Class representing a :class:`ast.MatchStar` node."""
+    """Class representing a :class:`ast.MatchStar` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case [1, *_]:
+            ...
+    ''')
+    >>> node.cases[0].pattern.patterns[1]
+    <MatchStar l.3 at 0x10ca809a0>
+    """
 
     _astroid_fields = ("name",)
     name: typing.Optional[AssignName] = None
@@ -4984,7 +5074,28 @@ class MatchStar(mixins.AssignTypeMixin, NodeNG):
 
 
 class MatchAs(mixins.AssignTypeMixin, NodeNG):
-    """Class representing a :class:`ast.MatchAs` node."""
+    """Class representing a :class:`ast.MatchAs` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case [1, a]:
+            ...
+        case {'key': b}:
+            ...
+        case Point2D(0, 0) as c:
+            ...
+        case d:
+            ...
+    ''')
+    >>> node.cases[0].pattern.patterns[1]
+    <MatchAs l.3 at 0x10d0b2da0>
+    >>> node.cases[1].pattern.patterns[0]
+    <MatchAs l.5 at 0x10d0b2920>
+    >>> node.cases[2].pattern
+    <MatchAs l.7 at 0x10d0b06a0>
+    >>> node.cases[3].pattern
+    <MatchAs l.9 at 0x10d09b880>
+    """
 
     _astroid_fields = ("pattern", "name")
     pattern: typing.Optional["PatternTypes"] = None
@@ -5009,7 +5120,16 @@ class MatchAs(mixins.AssignTypeMixin, NodeNG):
 
 
 class MatchOr(NodeNG):
-    """Class representing a :class:`ast.MatchOr` node."""
+    """Class representing a :class:`ast.MatchOr` node.
+
+    >>> node = astroid.extract_node('''
+    match x:
+        case 400 | 401 | 402:
+            ...
+    ''')
+    >>> node.cases[0].pattern
+    <MatchOr l.3 at 0x10d0b0b50>
+    """
 
     _astroid_fields = ("patterns",)
     patterns: typing.Optional[typing.List["PatternTypes"]] = None

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4877,7 +4877,7 @@ class MatchValue(NodeNG):
             yield self.value
 
 
-class MatchSingleton(NodeNG):
+class MatchSingleton(mixins.NoChildrenMixin, NodeNG):
     """Class representing a :class:`ast.MatchSingleton` node."""
 
     _other_fields = ("value",)

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1064,10 +1064,18 @@ class TreeRebuilder:
         self, node: "ast.MatchMapping", parent: NodeNG
     ) -> nodes.MatchMapping:
         newnode = nodes.MatchMapping(node.lineno, node.col_offset, parent)
+        name_node: Optional[nodes.AssignName] = None
+        if node.rest is not None:
+            # Add AssignName node for 'node.rest'
+            # https://bugs.python.org/issue43994
+            name_node = nodes.AssignName(
+                node.rest, node.lineno, node.col_offset, newnode
+            )
+            self._save_assignment(name_node)
         newnode.postinit(
             keys=[self.visit(child, newnode) for child in node.keys],
             patterns=[self.visit(pattern, newnode) for pattern in node.patterns],
-            rest=node.rest,
+            rest=name_node,
         )
         return newnode
 
@@ -1086,13 +1094,31 @@ class TreeRebuilder:
         return newnode
 
     def visit_matchstar(self, node: "ast.MatchStar", parent: NodeNG) -> nodes.MatchStar:
-        return nodes.MatchStar(node.lineno, node.col_offset, parent, name=node.name)
+        newnode = nodes.MatchStar(node.lineno, node.col_offset, parent)
+        name_node: Optional[nodes.AssignName] = None
+        if node.name is not None:
+            # Add AssignName node for 'node.name'
+            # https://bugs.python.org/issue43994
+            name_node = nodes.AssignName(
+                node.name, node.lineno, node.col_offset, newnode
+            )
+            self._save_assignment(name_node)
+        newnode.postinit(name=name_node)
+        return newnode
 
     def visit_matchas(self, node: "ast.MatchAs", parent: NodeNG) -> nodes.MatchAs:
         newnode = nodes.MatchAs(None, None, parent)
+        name_node: Optional[nodes.AssignName] = None
+        if node.name is not None:
+            # Add AssignName node for 'node.name'
+            # https://bugs.python.org/issue43994
+            name_node = nodes.AssignName(
+                node.name, node.lineno, node.col_offset, newnode
+            )
+            self._save_assignment(name_node)
         newnode.postinit(
             pattern=_visit_or_none(node, "pattern", self, newnode),
-            name=node.name,
+            name=name_node,
         )
         return newnode
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1107,7 +1107,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_matchas(self, node: "ast.MatchAs", parent: NodeNG) -> nodes.MatchAs:
-        newnode = nodes.MatchAs(None, None, parent)
+        newnode = nodes.MatchAs(node.lineno, node.col_offset, parent)
         name_node: Optional[nodes.AssignName] = None
         if node.name is not None:
             # Add AssignName node for 'node.name'
@@ -1123,7 +1123,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_matchor(self, node: "ast.MatchOr", parent: NodeNG) -> nodes.MatchOr:
-        newnode = nodes.MatchOr(None, None, parent)
+        newnode = nodes.MatchOr(node.lineno, node.col_offset, parent)
         newnode.postinit(
             patterns=[self.visit(pattern, newnode) for pattern in node.patterns]
         )


### PR DESCRIPTION
## Description
1. Fix pylint `undefined-variable` and `unused-variable` errors for Pattern Matching (Python 3.10).
At the moment, the following nodes use strings for new variable names instead of the `ast.Name` node: `MatchAs` (for `name`), `MatchStar` (also for `name`), and `MatchMapping` (for `rest`). https://bugs.python.org/issue43994

```py
var = 42
match var:
    case _ as new_var:
        print(new_var)

var2 = [1, 2, 3]
match var2:
    case [*rest1]:
        print(rest1)

var3 = {1: "Hallo", 2: "World"}
match var3:
    case {**rest2}:
        print(rest2)
```

2. Fix `lineno` and `col_offset` for `MatchAs` and `MatchOr` nodes.
3. Add string representations for match nodes
4. Add example nodes in docstrings

--
**Useful links**
https://docs.python.org/3.10/whatsnew/3.10.html#pep-634-structural-pattern-matching
https://docs.python.org/3.10/library/ast.html#pattern-matching


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |