### PR TITLE
Add lineno and col_offset for `Keyword` nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ What's New in astroid 2.5.8?
 ============================
 Release Date: TBA
 
+* Add lineno and col_offset for ``Keyword`` nodes and Python 3.9+
 
 
 What's New in astroid 2.5.7?

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -53,6 +53,7 @@ REDIRECT = {
 }
 PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
+PY39 = sys.version_info >= (3, 9)
 
 
 def _visit_or_none(node, attr, visitor, parent, visit="visit", **kws):
@@ -742,9 +743,14 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
-    def visit_keyword(self, node, parent):
+    def visit_keyword(self, node: "ast.keyword", parent: NodeNG) -> nodes.Keyword:
         """visit a Keyword node by returning a fresh instance of it"""
-        newnode = nodes.Keyword(node.arg, parent=parent)
+        if PY39:
+            newnode = nodes.Keyword(
+                node.arg, node.lineno, node.col_offset, parent=parent
+            )
+        else:
+            newnode = nodes.Keyword(node.arg, parent=parent)
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 


### PR DESCRIPTION
## Description
Python 3.9 added line and column information to the `ast.keyword` node. Besides `lineno` and `col_offset`, `end_lineno` and `end_col_offset` have been added as well. I'm not sure if it would be valuable to us if I add them as well, since astroid uses `tolineno` only with regards to blocks, i.e. `body`.

https://bugs.python.org/issue40141

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |