### PR TITLE
Deprecate Ellipsis node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,8 +10,8 @@ Release Date: TBA
   they represented have been removed with the change to Python 3
 
 * Deprecate ``Ellipsis`` node. It will be removed with the next minor release.
-  Checker that already support Python 3.8+ work without issues. It's only
-  necessary to remove all references to the astroid ``Ellipsis`` node.
+  Checkers that already support Python 3.8+ work without issues. It's only
+  necessary to remove all references to the ``astroid.Ellipsis`` node.
   This changes will make development of checkers easier as the resulting tree for Ellipsis
   will no longer depend on the python version. **Background**: With Python 3.8 the
   ``ast.Ellipsis`` node, along with ``ast.Str``, ``ast.Bytes``, ``ast.Num``,

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,14 @@ Release Date: TBA
 * Removed ``Repr``, ``Exec``, and ``Print`` nodes as the ``ast`` nodes
   they represented have been removed with the change to Python 3
 
+* Deprecate ``Ellipsis`` node. It will be removed with the next minor release.
+  Checker that already support Python 3.8+ work without issues. It's only
+  necessary to remove all references to the astroid ``Ellipsis`` node.
+  This changes will make development of checkers easier as the resulting tree for Ellipsis
+  will no longer depend on the python version. **Background**: With Python 3.8 the
+  ``ast.Ellipsis`` node, along with ``ast.Str``, ``ast.Bytes``, ``ast.Num``,
+  and ``ast.NamedConstant`` were merged into ``ast.Constant``.
+
 
 What's New in astroid 2.5.8?
 ============================

--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -284,10 +284,6 @@ class AsStringVisitor:
             excs = "except"
         return f"{excs}:\n{self._stmt_list(node.body)}"
 
-    def visit_ellipsis(self, node):
-        """return an astroid.Ellipsis node as string"""
-        return "..."
-
     def visit_empty(self, node):
         """return an Empty node as string"""
         return ""

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -37,7 +37,6 @@ import abc
 import builtins as builtins_mod
 import itertools
 import pprint
-import sys
 import typing
 from functools import lru_cache
 from functools import singledispatch as _singledispatch
@@ -54,7 +53,6 @@ except ImportError:
 
 BUILTINS = builtins_mod.__name__
 MANAGER = manager.AstroidManager()
-PY38 = sys.version_info[:2] >= (3, 8)
 
 
 def _is_const(value):
@@ -2967,19 +2965,9 @@ class Ellipsis(mixins.NoChildrenMixin, NodeNG):  # pylint: disable=redefined-bui
 
     An :class:`Ellipsis` is the ``...`` syntax.
 
-    >>> node = astroid.extract_node('...')
-    >>> node
-    <Ellipsis l.1 at 0x7f23b2e35160>
+    Deprecated since v2.6.0 - Use :class:`Const` instead.
+    Will be removed with the release v2.7.0
     """
-
-    def bool_value(self, context=None):
-        """Determine the boolean value of this node.
-
-        :returns: The boolean value of this node.
-            For an :class:`Ellipsis` this is always ``True``.
-        :rtype: bool
-        """
-        return True
 
 
 class EmptyNode(mixins.NoChildrenMixin, NodeNG):
@@ -5045,9 +5033,8 @@ CONST_CLS = {
     set: Set,
     type(None): Const,
     type(NotImplemented): Const,
+    type(...): Const,
 }
-if PY38:
-    CONST_CLS[type(...)] = Const
 
 
 def _update_const_classes():

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -249,7 +249,7 @@ class TreeRebuilder:
 
     # Not used in Python 3.8+
     @overload
-    def visit(self, node: "ast.Ellipsis", parent: NodeNG) -> nodes.Ellipsis:
+    def visit(self, node: "ast.Ellipsis", parent: NodeNG) -> nodes.Const:
         ...
 
     @overload
@@ -883,9 +883,14 @@ class TreeRebuilder:
         return newnode
 
     # Not used in Python 3.8+.
-    def visit_ellipsis(self, node: "ast.Ellipsis", parent: NodeNG) -> nodes.Ellipsis:
-        """visit an Ellipsis node by returning a fresh instance of it"""
-        return nodes.Ellipsis(node.lineno, node.col_offset, parent)
+    def visit_ellipsis(self, node: "ast.Ellipsis", parent: NodeNG) -> nodes.Const:
+        """visit an Ellipsis node by returning a fresh instance of Const"""
+        return nodes.Const(
+            value=Ellipsis,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            parent=parent,
+        )
 
     def visit_emptynode(self, node: "ast.AST", parent: NodeNG) -> nodes.EmptyNode:
         """visit an EmptyNode node by returning a fresh instance of it"""

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1120,11 +1120,8 @@ def test_type_comments_arguments():
     ]
     for node, expected_args in zip(module.body, expected_annotations):
         assert len(node.type_comment_args) == 1
-        if PY38:
-            assert isinstance(node.type_comment_args[0], astroid.Const)
-            assert node.type_comment_args[0].value == Ellipsis
-        else:
-            assert isinstance(node.type_comment_args[0], astroid.Ellipsis)
+        assert isinstance(node.type_comment_args[0], astroid.Const)
+        assert node.type_comment_args[0].value == Ellipsis
         assert len(node.args.type_comment_args) == len(expected_args)
         for expected_arg, actual_arg in zip(expected_args, node.args.type_comment_args):
             assert actual_arg.as_string() == expected_arg
@@ -1155,11 +1152,8 @@ def test_type_comments_posonly_arguments():
     ]
     for node, expected_types in zip(module.body, expected_annotations):
         assert len(node.type_comment_args) == 1
-        if PY38:
-            assert isinstance(node.type_comment_args[0], astroid.Const)
-            assert node.type_comment_args[0].value == Ellipsis
-        else:
-            assert isinstance(node.type_comment_args[0], astroid.Ellipsis)
+        assert isinstance(node.type_comment_args[0], astroid.Const)
+        assert node.type_comment_args[0].value == Ellipsis
         type_comments = [
             node.args.type_comment_posonlyargs,
             node.args.type_comment_args,


### PR DESCRIPTION
## Description
The `ast.Ellipsis` node was deprecated in Python 3.8 and fully replaced by `ast.Constant`. Similar to `ast.Str`, which was also replaced in Python 3.8, the `visit_ellipsis` method will now return a `nodes.Const` node. That will simplify development as the node for `Ellipsis` will no longer depend on the Python version.


#### Breaking Change
Although technically a breaking change, this only effects checkers that haven't been updated for Python 3.8. Thus I imagine the impact will be fairly limited. `pylint` tests pass without any changes. End user code will not be impacted. It will still be possible to check Python 3.6 only code.

#### Required Changes
After the next release of `astroid`, all references to the astroid `Ellipsis` node need to be removed from `pylint`. That's quite easy to do: https://github.com/PyCQA/pylint/pull/4567

#### Removal
I suggest to remove the `Ellipsis` node with the release of the next minor version, i.e. `2.7.0`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |