### PR TITLE
Deprecate Index and ExtSlice nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,15 @@ Release Date: TBA
   ``ast.Ellipsis`` node, along with ``ast.Str``, ``ast.Bytes``, ``ast.Num``,
   and ``ast.NamedConstant`` were merged into ``ast.Constant``.
 
+* Deprecated ``Index`` and ``ExtSlice`` nodes. They will be removed with the
+  next minor release. Both are now part of the ``Subscript`` node.
+  Checkers that already support Python 3.9+ work without issues.
+  It's only necessary to remove all references to the ``astroid.Index`` and
+  ``astroid.ExtSlice`` nodes. This change will make development of checkers
+  easier as the resulting tree for ``ast.Subscript`` nodes will no longer
+  depend on the python version. **Background**: With Python 3.9 ``ast.Index``
+  and ``ast.ExtSlice`` were merged into the ``ast.Subscript`` node.
+
 
 What's New in astroid 2.5.8?
 ============================

--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -302,10 +302,6 @@ class AsStringVisitor:
             )
         return "exec %s" % node.expr.accept(self)
 
-    def visit_extslice(self, node):
-        """return an astroid.ExtSlice node as string"""
-        return ", ".join(dim.accept(self) for dim in node.dims)
-
     def visit_for(self, node):
         """return an astroid.For node as string"""
         fors = "for {} in {}:\n{}".format(
@@ -498,10 +494,6 @@ class AsStringVisitor:
             return "return %s" % node.value.accept(self)
 
         return "return"
-
-    def visit_index(self, node):
-        """return an astroid.Index node as string"""
-        return node.value.accept(self)
 
     def visit_set(self, node):
         """return an astroid.Set node as string"""

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -3070,27 +3070,9 @@ class ExtSlice(NodeNG):
 
     An :class:`ExtSlice` is a complex slice expression.
 
-    >>> node = astroid.extract_node('l[1:3, 5]')
-    >>> node
-    <Subscript l.1 at 0x7f23b2e9e550>
-    >>> node.slice
-    <ExtSlice l.1 at 0x7f23b7b05ef0>
+    Deprecated since v2.6.0 - Now part of the :class:`Subscript` node.
+    Will be removed with the release of v2.7.0
     """
-
-    _astroid_fields = ("dims",)
-    dims = None
-    """The simple dimensions that form the complete slice.
-
-    :type: list(NodeNG) or None
-    """
-
-    def postinit(self, dims=None):
-        """Do some setup after initialisation.
-
-        :param dims: The simple dimensions that form the complete slice.
-        :type dims: list(NodeNG) or None
-        """
-        self.dims = dims
 
 
 class For(
@@ -3557,30 +3539,9 @@ class Index(NodeNG):
 
     An :class:`Index` is a simple subscript.
 
-    >>> node = astroid.extract_node('things[1]')
-    >>> node
-    <Subscript l.1 at 0x7f23b2e9e2b0>
-    >>> node.slice
-    <Index l.1 at 0x7f23b2e9e6a0>
+    Deprecated since v2.6.0 - Now part of the :class:`Subscript` node.
+    Will be removed with the release of v2.7.0
     """
-
-    _astroid_fields = ("value",)
-    value = None
-    """The value to subscript with.
-
-    :type: NodeNG or None
-    """
-
-    def postinit(self, value=None):
-        """Do some setup after initialisation.
-
-        :param value: The value to subscript with.
-        :type value: NodeNG or None
-        """
-        self.value = value
-
-    def get_children(self):
-        yield self.value
 
 
 class Keyword(NodeNG):

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -258,7 +258,7 @@ class TreeRebuilder:
 
     # Not used in Python 3.9+
     @overload
-    def visit(self, node: "ast.ExtSlice", parent: NodeNG) -> nodes.ExtSlice:
+    def visit(self, node: "ast.ExtSlice", parent: nodes.Subscript) -> nodes.Tuple:
         ...
 
     @overload
@@ -311,7 +311,7 @@ class TreeRebuilder:
 
     # Not used in Python 3.9+
     @overload
-    def visit(self, node: "ast.Index", parent: NodeNG) -> nodes.Index:
+    def visit(self, node: "ast.Index", parent: nodes.Subscript) -> NodeNG:
         ...
 
     @overload
@@ -385,7 +385,7 @@ class TreeRebuilder:
         ...
 
     @overload
-    def visit(self, node: "ast.Slice", parent: NodeNG) -> nodes.Slice:
+    def visit(self, node: "ast.Slice", parent: nodes.Subscript) -> nodes.Slice:
         ...
 
     @overload
@@ -913,9 +913,11 @@ class TreeRebuilder:
         return newnode
 
     # Not used in Python 3.9+.
-    def visit_extslice(self, node: "ast.ExtSlice", parent: NodeNG) -> nodes.ExtSlice:
-        """visit an ExtSlice node by returning a fresh instance of it"""
-        newnode = nodes.ExtSlice(parent=parent)
+    def visit_extslice(
+        self, node: "ast.ExtSlice", parent: nodes.Subscript
+    ) -> nodes.Tuple:
+        """visit an ExtSlice node by returning a fresh instance of Tuple"""
+        newnode = nodes.Tuple(ctx=astroid.Load, parent=parent)
         newnode.postinit([self.visit(dim, newnode) for dim in node.dims])  # type: ignore
         return newnode
 
@@ -1135,11 +1137,9 @@ class TreeRebuilder:
         return newnode
 
     # Not used in Python 3.9+.
-    def visit_index(self, node: "ast.Index", parent: NodeNG) -> nodes.Index:
-        """visit a Index node by returning a fresh instance of it"""
-        newnode = nodes.Index(parent=parent)
-        newnode.postinit(self.visit(node.value, newnode))  # type: ignore
-        return newnode
+    def visit_index(self, node: "ast.Index", parent: nodes.Subscript) -> NodeNG:
+        """visit a Index node by returning a fresh instance of NodeNG"""
+        return self.visit(node.value, parent)  # type: ignore
 
     def visit_keyword(self, node: "ast.keyword", parent: NodeNG) -> nodes.Keyword:
         """visit a Keyword node by returning a fresh instance of it"""
@@ -1281,7 +1281,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_slice(self, node: "ast.Slice", parent: NodeNG) -> nodes.Slice:
+    def visit_slice(self, node: "ast.Slice", parent: nodes.Subscript) -> nodes.Slice:
         """visit a Slice node by returning a fresh instance of it"""
         newnode = nodes.Slice(parent=parent)
         newnode.postinit(


### PR DESCRIPTION
## Description
Deprecate `Index` and `ExtSlice` as they are now merged with `Subscript`.

#### Breaking Change
Checkers that already support Python 3.9 work without issues. `pylint` tests pass without any changes. End user code will not be impacted.

#### Required Changes
After the next release of `astroid`, all references to `astroid.Index` and `astroid.ExtSlice` need to be removed from `pylint`. https://github.com/PyCQA/astroid/pull/1026

#### Final Removal
I suggest to remove the nodes with the release of the next minor version, i.e. `2.7.0`

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |