### PR TITLE
Fix/pylint2036 enum py310

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ Release Date: TBA
 
   Closes PyCQA/pylint#1932
   Closes PyCQA/pylint#2062
+  Closes PyCQA/pylint#2306
 
 * Removed ``Repr``, ``Exec``, and ``Print`` nodes as the ``ast`` nodes
   they represented have been removed with the change to Python 3

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -25,6 +25,7 @@ inference utils.
 
 import builtins
 import collections
+import sys
 
 from astroid import context as contextmod
 from astroid import exceptions, util
@@ -35,11 +36,16 @@ BUILTINS = builtins.__name__
 manager = util.lazy_import("manager")
 MANAGER = manager.AstroidManager()
 
+PY310 = sys.version_info >= (3, 10)
+
 # TODO: check if needs special treatment
 BUILTINS = "builtins"
 BOOL_SPECIAL_METHOD = "__bool__"
 
 PROPERTIES = {BUILTINS + ".property", "abc.abstractproperty"}
+if PY310:
+    PROPERTIES.add("enum.property")
+
 # List of possible property names. We use this list in order
 # to see if a method is a property or not. This should be
 # pretty reliable and fast, the alternative being to check each


### PR DESCRIPTION
## Steps

- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

Add Python 3.10's `enum.property` class descriptor to list of properties for `bases._is_property` check.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Fixes PyCQA/pylint#2306 (when combined with #1020)
