### PR TITLE
Remove setuptools dependencie, improve release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  DEFAULT_PYTHON: 3.9
+
+jobs:
+  release-pypi:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from Github
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Install requirements
+        run: |
+          python -m pip install -U pip twine wheel
+          python -m pip install -U "setuptools>=56.0.0"
+      - name: Build distributions
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Upload to PyPI
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
+        env:
+          TWINE_REPOSITORY: pypi
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --verbose dist/*

--- a/ChangeLog
+++ b/ChangeLog
@@ -581,7 +581,7 @@ Release Date: 2020-04-27
 
 What's New in astroid 2.3.2?
 ============================
-Release Date: TBA
+Release Date: 2019-10-18
 
 * All type comments have as parent the corresponding `astroid` node
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,9 @@ Release Date: TBA
 
 * Appveyor and travis are no longer used in the continuous integration
 
+* ``setuptools_scm`` has been removed and replaced by ``tbump`` in order to not
+  have hidden runtime dependencies to setuptools
+
 * Update enum brain to improve inference of .name and .value dynamic class
   attributes
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -24,5 +24,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-__version__ = "2.5.9-dev0"
+__version__ = "2.6.0-dev0"
 version = __version__

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -24,13 +24,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-"""astroid packaging information"""
-
-from pkg_resources import DistributionNotFound, get_distribution
-
-try:
-    __version__ = get_distribution("astroid").version
-except DistributionNotFound:
-    __version__ = "2.5.7+"
-
+__version__ = "2.5.9-dev0"
 version = __version__

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -5,8 +5,8 @@
 # Copyright (c) 2020 Simon Hewitt <si@sjhewitt.co.uk>
 # Copyright (c) 2020 Bryce Guinta <bryce.guinta@protonmail.com>
 # Copyright (c) 2020 Ram Rachum <ram@rachum.com>
-# Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
+# Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -23,9 +23,9 @@
 # Copyright (c) 2019 kavins14 <kavinsingh@hotmail.com>
 # Copyright (c) 2020 Raphael Gaschignard <raphael@rtpg.co>
 # Copyright (c) 2020 Bryce Guinta <bryce.guinta@protonmail.com>
-# Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
-# Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
+# Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
+# Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 # Copyright (c) 2021 Federico Bond <federicobond@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2015-2016, 2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2016 Ceridwen <ceridwenv@gmail.com>
 # Copyright (c) 2018 Nick Drozd <nicholasdrozd@gmail.com>
-# Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
+# Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE

--- a/doc/release.md
+++ b/doc/release.md
@@ -42,13 +42,15 @@ issue labelled as blocker.
 
 #### Changelog
 
-- Create a new section, with the name of the release `X.Y.Z+1` or `X.Y+1.0` on the
-  master branch.
+If it was a minor release add a `X.Y+1.0` title following the template:
 
-You need to add the estimated date when it is going to be published. If no date can be
-known at that time, we should use `Undefined`.
+```text
+What's New in astroid x.y.z?
+============================
+Release Date: TBA
+```
 
 #### Whatsnew
 
-If it's a major release, create a new `What's new in Astroid X.Y+1` document. Take a
+If it was a minor release, create a new `What's new in Astroid X.Y+1` document. Take a
 look at the examples from `doc/whatsnew`.

--- a/doc/release.md
+++ b/doc/release.md
@@ -6,11 +6,9 @@ So, you want to release the `X.Y.Z` version of astroid ?
 
 1. Check if the dependencies of the package are correct
 2. Install the release dependencies `pip3 install pre-commit tbump`
-3. Bump the version and release by using `tbump X.Y.Z --no-push`. During the commit
-   pre-commit and pyupgrade should remove the `encode utf8` automatically
-4. Check the result and then push the tag.
-
-Until the release is done via GitHub actions on tag, run the following commands:
+3. Bump the version and release by using `tbump X.Y.Z --no-push`.
+4. Check the result.
+5. Until the release is done via GitHub actions on tag, run the following commands:
 
 ```bash
 git clean -fdx && find . -name '*.pyc' -delete
@@ -20,6 +18,8 @@ pip3 install twine wheel setuptools
 python setup.py sdist --formats=gztar bdist_wheel
 twine upload dist/*
 ```
+
+6. Push the tag.
 
 ## Post release
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -5,7 +5,7 @@ So, you want to release the `X.Y.Z` version of astroid ?
 ## Process
 
 1. Check if the dependencies of the package are correct
-2. Install the release dependencies `pip3 install pre-commit copyrite tbump`
+2. Install the release dependencies `pip3 install pre-commit tbump`
 3. Bump the version and release by using `tbump X.Y.Z --no-push`. During the commit
    pre-commit and pyupgrade should remove the `encode utf8` automatically
 4. Check the result and then push the tag.

--- a/doc/release.md
+++ b/doc/release.md
@@ -4,23 +4,11 @@ So, you want to release the `X.Y.Z` version of astroid ?
 
 ## Process
 
-1. Preparation
-   1. Check if the dependencies of the package are correct
-   2. Put the version numbers, and the release date into the changelog
-   3. Generate the new copyright notices for this release:
-
-```bash
-pip3 install copyrite
-copyrite --contribution-threshold 1 --change-threshold 3 --backend-type \
-git --aliases=.copyrite_aliases . --jobs=8
-# During the commit pre-commit and pyupgrade will remove the encode utf8
-# automatically
-```
-
-4. Submit your changes in a merge request and make sure the tests are passing.
-
-5. Do the actual release by tagging the master with `vX.Y.Z` (ie `v1.6.12` or `v3.0.0a0`
-   for example).
+1. Check if the dependencies of the package are correct
+2. Install the release dependencies `pip3 install pre-commit copyrite tbump`
+3. Bump the version and release by using `tbump X.Y.Z --no-push`. During the commit
+   pre-commit and pyupgrade should remove the `encode utf8` automatically
+4. Check the result and then push the tag.
 
 Until the release is done via GitHub actions on tag, run the following commands:
 
@@ -31,10 +19,19 @@ source venv/bin/activate
 pip3 install twine wheel setuptools
 python setup.py sdist --formats=gztar bdist_wheel
 twine upload dist/*
-# don't forget to tag it as well
 ```
 
 ## Post release
+
+### Back to a dev version
+
+Move back to a dev version with `tbump`:
+
+```bash
+tbump X.Y.Z-dev0 --no-tag --no-push
+```
+
+Check the result and then upgrade the master branch
 
 ### Milestone handling
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -9,6 +9,8 @@ So, you want to release the `X.Y.Z` version of astroid ?
 3. Bump the version and release by using `tbump X.Y.Z --no-push`.
 4. Check the result.
 5. Push the tag.
+6. Release the version on Github with the same name as the tag and copy and paste the
+   appropriate changelog in the description. This trigger the pypi release.
 
 ## Post release
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -8,18 +8,7 @@ So, you want to release the `X.Y.Z` version of astroid ?
 2. Install the release dependencies `pip3 install pre-commit tbump`
 3. Bump the version and release by using `tbump X.Y.Z --no-push`.
 4. Check the result.
-5. Until the release is done via GitHub actions on tag, run the following commands:
-
-```bash
-git clean -fdx && find . -name '*.pyc' -delete
-python3 -m venv venv
-source venv/bin/activate
-pip3 install twine wheel setuptools
-python setup.py sdist --formats=gztar bdist_wheel
-twine upload dist/*
-```
-
-6. Push the tag.
+5. Push the tag.
 
 ## Post release
 
@@ -28,7 +17,7 @@ twine upload dist/*
 Move back to a dev version with `tbump`:
 
 ```bash
-tbump X.Y.Z-dev0 --no-tag --no-push
+tbump X.Y.Z-dev0 --no-tag --no-push # You can interrupt during copyrite
 ```
 
 Check the result and then upgrade the master branch

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ coveralls~=3.0
 coverage~=5.5
 pre-commit~=2.13
 pytest-cov~=2.11
+tbump~=6.3.2

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -21,15 +21,13 @@ NEW_RELEASE_DATE_MESSAGE = "Release Date: {}".format(TODAY.strftime("%Y-%m-%d"))
 
 
 def main() -> None:
-    args = parse_args()
-    if "dev" not in args.version:
-        run(args.version)
-
-
-def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(add_help=__doc__)
     parser.add_argument("version", help="The version we want to release")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if "dev" not in args.version:
+        version = args.version
+        next_version = get_next_version(version)
+        run(version, next_version)
 
 
 def get_next_version(version: str) -> str:
@@ -38,10 +36,9 @@ def get_next_version(version: str) -> str:
     return ".".join(new_version)
 
 
-def run(version: str) -> None:
+def run(version: str, next_version: str) -> None:
     with open(DEFAULT_CHANGELOG_PATH) as f:
         content = f.read()
-    next_version = get_next_version(version)
     content = transform_content(content, version, next_version)
     with open(DEFAULT_CHANGELOG_PATH, "w") as f:
         f.write(content)

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -1,0 +1,75 @@
+"""
+This script permits to upgrade the changelog in astroid or pylint when releasing a version.
+"""
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_CHANGELOG_PATH = Path("ChangeLog")
+err = "in the changelog, fix that first!"
+TBA_ERROR_MSG = "More than one release date 'TBA' %s" % err
+NEW_VERSION_ERROR_MSG = "The text for this version '{version}' did not exists %s" % err
+NEXT_VERSION_ERROR_MSG = (
+    "The text for the next version '{version}' already exists %s" % err
+)
+
+TODAY = datetime.now()
+WHATS_NEW_TEXT = "What's New in astroid"
+FULL_WHATS_NEW_TEXT = WHATS_NEW_TEXT + " {version}?"
+RELEASE_DATE_TEXT = "Release Date: TBA"
+NEW_RELEASE_DATE_MESSAGE = "Release Date: {}".format(TODAY.strftime("%Y-%m-%d"))
+
+
+def main() -> None:
+    args = parse_args()
+    if "dev" not in args.version:
+        run(args.version)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=__doc__)
+    parser.add_argument("version", help="The version we want to release")
+    return parser.parse_args()
+
+
+def get_next_version(version: str) -> str:
+    new_version = version.split(".")
+    new_version[2] = str(int(new_version[2]) + 1)
+    return ".".join(new_version)
+
+
+def run(version: str) -> None:
+    with open(DEFAULT_CHANGELOG_PATH) as f:
+        content = f.read()
+    next_version = get_next_version(version)
+    content = transform_content(content, version, next_version)
+    with open(DEFAULT_CHANGELOG_PATH, "w") as f:
+        f.write(content)
+
+
+def transform_content(content: str, version: str, next_version: str) -> str:
+    wn_new_version = FULL_WHATS_NEW_TEXT.format(version=version)
+    wn_next_version = FULL_WHATS_NEW_TEXT.format(version=next_version)
+    # There is only one field where the release date is TBA
+    assert content.count(RELEASE_DATE_TEXT) == 1, TBA_ERROR_MSG
+    # There is already a release note for the version we want to release
+    assert content.count(wn_new_version) == 1, NEW_VERSION_ERROR_MSG.format(
+        version=version
+    )
+    # There is no release notes for the next version
+    assert content.count(wn_next_version) == 0, NEXT_VERSION_ERROR_MSG.format(
+        version=next_version
+    )
+    index = content.find(WHATS_NEW_TEXT)
+    content = content.replace(RELEASE_DATE_TEXT, NEW_RELEASE_DATE_MESSAGE)
+    end_content = content[index:]
+    content = content[:index]
+    content += wn_next_version + "\n"
+    content += "=" * len(wn_next_version) + "\n"
+    content += RELEASE_DATE_TEXT + "\n" * 4
+    content += end_content
+    return content
+
+
+if __name__ == "__main__":
+    main()

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -32,7 +32,12 @@ def main() -> None:
 
 def get_next_version(version: str) -> str:
     new_version = version.split(".")
-    new_version[2] = str(int(new_version[2]) + 1)
+    patch = new_version[2]
+    reminder = None
+    if "-" in patch:
+        patch, reminder = patch.split("-")
+    patch = str(int(patch) + 1)
+    new_version[2] = patch if reminder is None else f"{patch}-{reminder}"
     return ".".join(new_version)
 
 

--- a/script/test_bump_changelog.py
+++ b/script/test_bump_changelog.py
@@ -1,5 +1,5 @@
 import pytest
-from bump_changelog import get_next_version
+from bump_changelog import get_next_version, transform_content
 
 
 @pytest.mark.parametrize(
@@ -7,3 +7,77 @@ from bump_changelog import get_next_version
 )
 def test_get_next_version(version, expected):
     assert get_next_version(version) == expected
+
+
+@pytest.mark.parametrize(
+    "old_content,expected_error",
+    [
+        [
+            """
+What's New in astroid 2.6.1?
+============================
+Release Date: TBA
+
+What's New in astroid 2.6.0?
+============================
+Release Date: TBA
+""",
+            "More than one release date 'TBA'",
+        ],
+        [
+            """===================
+astroid's ChangeLog
+===================
+
+What's New in astroid 2.6.0?
+============================
+Release Date: TBA
+""",
+            "text for this version '2.6.1' did not exists",
+        ],
+        [
+            """
+What's New in astroid 2.6.2?
+============================
+Release Date: TBA
+
+What's New in astroid 2.6.1?
+============================
+Release Date: 2012-02-05
+""",
+            "the next version '2.6.2' already exists",
+        ],
+    ],
+)
+def test_update_content_error(old_content, expected_error):
+    with pytest.raises(AssertionError, match=expected_error):
+        transform_content(old_content, "2.6.1", "2.6.2")
+
+
+def test_update_content():
+    old_content = """
+===================
+astroid's ChangeLog
+===================
+
+What's New in astroid 2.6.1?
+============================
+Release Date: TBA
+"""
+    expected_beginning = """
+===================
+astroid's ChangeLog
+===================
+
+What's New in astroid 2.6.2?
+============================
+Release Date: TBA
+
+
+
+What's New in astroid 2.6.1?
+============================
+Release Date: 20"""
+
+    new_content = transform_content(old_content, "2.6.1", "2.6.2")
+    assert new_content.startswith(expected_beginning)

--- a/script/test_bump_changelog.py
+++ b/script/test_bump_changelog.py
@@ -1,0 +1,9 @@
+import pytest
+from bump_changelog import get_next_version
+
+
+@pytest.mark.parametrize(
+    "version,expected", [["2.6.1", "2.6.2"], ["2.6.1-dev0", "2.6.2-dev0"]]
+)
+def test_get_next_version(version, expected):
+    assert get_next_version(version) == expected

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = astroid
 description = An abstract syntax tree for Python with inference support.
+version = attr: astroid.__pkginfo__.__version__
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 url = https://github.com/PyCQA/astroid
@@ -39,8 +40,6 @@ install_requires =
     wrapt>=1.11,<1.13
     typed-ast>=1.4.0,<1.5;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.7.4;python_version<"3.8"
-setup_requires =
-  setuptools_scm
 python_requires = ~=3.6
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(use_scm_version=True)
+setup()

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/astroid"
 
 [version]
-current = "2.5.9-dev0"
+current = "2.6.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.
@@ -34,7 +34,7 @@ cmd = "pip3 install copyrite;copyrite --contribution-threshold 1 --change-thresh
 
 [[before_commit]]
 name = "Apply pre-commit"
-cmd = "pre-commit run --all-files"
+cmd = "pre-commit run --all-files||echo 'Hack so this command does not fail'"
 
 # Or run some commands after the git tag and the branch
 # have been pushed:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,35 @@
+github_url = "https://github.com/PyCQA/astroid"
+
+[version]
+current = "2.5.9-dev0"
+regex = '''
+^(?P<major>0|[1-9]\d*)
+\.
+(?P<minor>0|[1-9]\d*)
+\.
+(?P<patch>0|[1-9]\d*)
+(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+'''
+
+[git]
+message_template = "Bump astroid to {new_version}, update changelog"
+tag_template = "v{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "astroid/__pkginfo__.py"
+
+# You can specify a list of commands to
+# run after the files have been patched
+# and before the git commit is made
+[[before_commit]]
+name = "Upgrade changelog changelog"
+cmd = "python3 script/bump_changelog.py {new_version}"
+
+# Or run some commands after the git tag and the branch
+# have been pushed:
+#  [[after_push]]
+#  name = "publish"
+#  cmd = "./publish.sh"

--- a/tbump.toml
+++ b/tbump.toml
@@ -28,6 +28,10 @@ src = "astroid/__pkginfo__.py"
 name = "Upgrade changelog changelog"
 cmd = "python3 script/bump_changelog.py {new_version}"
 
+[[before_commit]]
+name = "Upgrade copyrights"
+cmd = "copyrite --contribution-threshold 1 --change-threshold 3 --backend-type git --aliases=.copyrite_aliases . --jobs=8"
+
 # Or run some commands after the git tag and the branch
 # have been pushed:
 #  [[after_push]]

--- a/tbump.toml
+++ b/tbump.toml
@@ -30,7 +30,7 @@ cmd = "python3 script/bump_changelog.py {new_version}"
 
 [[before_commit]]
 name = "Upgrade copyrights"
-cmd = "copyrite --contribution-threshold 1 --change-threshold 3 --backend-type git --aliases=.copyrite_aliases . --jobs=8"
+cmd = "pip3 install copyrite;copyrite --contribution-threshold 1 --change-threshold 3 --backend-type git --aliases=.copyrite_aliases . --jobs=8"
 
 # Or run some commands after the git tag and the branch
 # have been pushed:

--- a/tbump.toml
+++ b/tbump.toml
@@ -32,6 +32,10 @@ cmd = "python3 script/bump_changelog.py {new_version}"
 name = "Upgrade copyrights"
 cmd = "pip3 install copyrite;copyrite --contribution-threshold 1 --change-threshold 3 --backend-type git --aliases=.copyrite_aliases . --jobs=8"
 
+[[before_commit]]
+name = "Apply pre-commit"
+cmd = "pre-commit run --all-files"
+
 # Or run some commands after the git tag and the branch
 # have been pushed:
 #  [[after_push]]

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -16,8 +16,8 @@
 # Copyright (c) 2019 Alex Hall <alex.mojaki@gmail.com>
 # Copyright (c) 2019 Hugo van Kemenade <hugovk@users.noreply.github.com>
 # Copyright (c) 2020 David Gilman <davidgilman1@gmail.com>
-# Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
+# Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Copyright (c) 2021 Federico Bond <federicobond@gmail.com>
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 


### PR DESCRIPTION
## Description

This MR replace setuptools_scm by tbump and a small script. This should permit to remove the setuptools hidden dependencie and facilitate the release process. Next step is to add the release itself in github actions.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #1016 
