### PR TITLE
Small fix + improvements to Match nodes

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4851,7 +4851,8 @@ class MatchClass(NodeNG):
     <MatchClass l.5 at 0x10ca80880>
     """
 
-    _astroid_fields = ("cls", "patterns", "kwd_attrs", "kwd_patterns")
+    _astroid_fields = ("cls", "patterns", "kwd_patterns")
+    _other_fields = ("kwd_attrs",)
     cls: typing.Optional[NodeNG] = None
     patterns: typing.Optional[typing.List["PatternTypes"]] = None
     kwd_attrs: typing.Optional[typing.List[str]] = None

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -4655,7 +4655,7 @@ class Match(Statement):
     <Match l.2 at 0x10c24e170>
     """
 
-    _astroid_fields = ("subject", "cases")
+    _astroid_fields: typing.Tuple[str, ...] = ("subject", "cases")
     subject: typing.Optional[NodeNG] = None
     cases: typing.Optional[typing.List["MatchCase"]] = None
 
@@ -4687,7 +4687,7 @@ class MatchCase(NodeNG):
     <MatchCase l.3 at 0x10c24e590>
     """
 
-    _astroid_fields = ("pattern", "guard", "body")
+    _astroid_fields: typing.Tuple[str, ...] = ("pattern", "guard", "body")
     pattern: typing.Optional["PatternTypes"] = None
     guard: typing.Optional[NodeNG] = None  # can actually be None
     body: typing.Optional[typing.List[NodeNG]] = None
@@ -4724,7 +4724,7 @@ class MatchValue(NodeNG):
     <MatchValue l.3 at 0x10c24e200>
     """
 
-    _astroid_fields = ("value",)
+    _astroid_fields: typing.Tuple[str, ...] = ("value",)
     value: typing.Optional[NodeNG] = None
 
     def postinit(self, *, value: NodeNG) -> None:
@@ -4755,7 +4755,7 @@ class MatchSingleton(mixins.NoChildrenMixin, NodeNG):
     <MatchSingleton l.7 at 0x10c229f90>
     """
 
-    _other_fields = ("value",)
+    _other_fields: typing.Tuple[str, ...] = ("value",)
 
     def __init__(
         self,
@@ -4785,7 +4785,7 @@ class MatchSequence(NodeNG):
     <MatchSequence l.5 at 0x10ca80b20>
     """
 
-    _astroid_fields = ("patterns",)
+    _astroid_fields: typing.Tuple[str, ...] = ("patterns",)
     patterns: typing.Optional[typing.List["PatternTypes"]] = None
 
     def postinit(
@@ -4810,7 +4810,7 @@ class MatchMapping(mixins.AssignTypeMixin, NodeNG):
     <MatchMapping l.3 at 0x10c8a8850>
     """
 
-    _astroid_fields = ("keys", "patterns", "rest")
+    _astroid_fields: typing.Tuple[str, ...] = ("keys", "patterns", "rest")
     keys: typing.Optional[typing.List[NodeNG]] = None
     patterns: typing.Optional[typing.List["PatternTypes"]] = None
     rest: typing.Optional[AssignName] = None
@@ -4851,8 +4851,8 @@ class MatchClass(NodeNG):
     <MatchClass l.5 at 0x10ca80880>
     """
 
-    _astroid_fields = ("cls", "patterns", "kwd_patterns")
-    _other_fields = ("kwd_attrs",)
+    _astroid_fields: typing.Tuple[str, ...] = ("cls", "patterns", "kwd_patterns")
+    _other_fields: typing.Tuple[str, ...] = ("kwd_attrs",)
     cls: typing.Optional[NodeNG] = None
     patterns: typing.Optional[typing.List["PatternTypes"]] = None
     kwd_attrs: typing.Optional[typing.List[str]] = None
@@ -4892,7 +4892,7 @@ class MatchStar(mixins.AssignTypeMixin, NodeNG):
     <MatchStar l.3 at 0x10ca809a0>
     """
 
-    _astroid_fields = ("name",)
+    _astroid_fields: typing.Tuple[str, ...] = ("name",)
     name: typing.Optional[AssignName] = None
 
     def postinit(self, *, name: typing.Optional[AssignName] = None) -> None:
@@ -4927,7 +4927,7 @@ class MatchAs(mixins.AssignTypeMixin, NodeNG):
     <MatchAs l.9 at 0x10d09b880>
     """
 
-    _astroid_fields = ("pattern", "name")
+    _astroid_fields: typing.Tuple[str, ...] = ("pattern", "name")
     pattern: typing.Optional["PatternTypes"] = None
     name: typing.Optional[AssignName] = None
 
@@ -4961,7 +4961,7 @@ class MatchOr(NodeNG):
     <MatchOr l.3 at 0x10d0b0b50>
     """
 
-    _astroid_fields = ("patterns",)
+    _astroid_fields: typing.Tuple[str, ...] = ("patterns",)
     patterns: typing.Optional[typing.List["PatternTypes"]] = None
 
     def postinit(

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -464,6 +464,7 @@ class NodeNG:
                 yield from attr
             else:
                 yield attr
+        yield from ()
 
     def last_child(self):
         """An optimized version of list(get_children())[-1]
@@ -4668,12 +4669,6 @@ class Match(Statement):
         self.subject = subject
         self.cases = cases
 
-    def get_children(self) -> typing.Generator[NodeNG, None, None]:
-        if self.subject is not None:
-            yield self.subject
-        if self.cases is not None:
-            yield from self.cases
-
 
 class MatchCase(NodeNG):
     """Class representing a :class:`ast.match_case` node.
@@ -4703,14 +4698,6 @@ class MatchCase(NodeNG):
         self.guard = guard
         self.body = body
 
-    def get_children(self) -> typing.Generator[NodeNG, None, None]:
-        if self.pattern is not None:
-            yield self.pattern
-        if self.guard is not None:
-            yield self.guard
-        if self.body is not None:
-            yield from self.body
-
 
 class MatchValue(NodeNG):
     """Class representing a :class:`ast.MatchValue` node.
@@ -4730,12 +4717,8 @@ class MatchValue(NodeNG):
     def postinit(self, *, value: NodeNG) -> None:
         self.value = value
 
-    def get_children(self) -> typing.Generator[NodeNG, None, None]:
-        if self.value is not None:
-            yield self.value
 
-
-class MatchSingleton(mixins.NoChildrenMixin, NodeNG):
+class MatchSingleton(NodeNG):
     """Class representing a :class:`ast.MatchSingleton` node.
 
     >>> node = astroid.extract_node('''
@@ -4793,10 +4776,6 @@ class MatchSequence(NodeNG):
     ) -> None:
         self.patterns = patterns
 
-    def get_children(self) -> typing.Generator["PatternTypes", None, None]:
-        if self.patterns is not None:
-            yield from self.patterns
-
 
 class MatchMapping(mixins.AssignTypeMixin, NodeNG):
     """Class representing a :class:`ast.MatchMapping` node.
@@ -4825,14 +4804,6 @@ class MatchMapping(mixins.AssignTypeMixin, NodeNG):
         self.keys = keys
         self.patterns = patterns
         self.rest = rest
-
-    def get_children(self) -> typing.Generator[NodeNG, None, None]:
-        if self.keys is not None:
-            yield from self.keys
-        if self.patterns is not None:
-            yield from self.patterns
-        if self.rest is not None:
-            yield self.rest
 
 
 class MatchClass(NodeNG):
@@ -4871,14 +4842,6 @@ class MatchClass(NodeNG):
         self.kwd_attrs = kwd_attrs
         self.kwd_patterns = kwd_patterns
 
-    def get_children(self) -> typing.Generator[NodeNG, None, None]:
-        if self.cls is not None:
-            yield self.cls
-        if self.patterns is not None:
-            yield from self.patterns
-        if self.kwd_patterns is not None:
-            yield from self.kwd_patterns
-
 
 class MatchStar(mixins.AssignTypeMixin, NodeNG):
     """Class representing a :class:`ast.MatchStar` node.
@@ -4897,10 +4860,6 @@ class MatchStar(mixins.AssignTypeMixin, NodeNG):
 
     def postinit(self, *, name: typing.Optional[AssignName] = None) -> None:
         self.name = name
-
-    def get_children(self) -> typing.Generator[AssignName, None, None]:
-        if self.name is not None:
-            yield self.name
 
 
 class MatchAs(mixins.AssignTypeMixin, NodeNG):
@@ -4940,14 +4899,6 @@ class MatchAs(mixins.AssignTypeMixin, NodeNG):
         self.pattern = pattern
         self.name = name
 
-    def get_children(
-        self,
-    ) -> typing.Generator[typing.Union[AssignName, "PatternTypes"], None, None]:
-        if self.pattern is not None:
-            yield self.pattern
-        if self.name is not None:
-            yield self.name
-
 
 class MatchOr(NodeNG):
     """Class representing a :class:`ast.MatchOr` node.
@@ -4968,10 +4919,6 @@ class MatchOr(NodeNG):
         self, *, patterns: typing.Optional[typing.List["PatternTypes"]]
     ) -> None:
         self.patterns = patterns
-
-    def get_children(self) -> typing.Generator["PatternTypes", None, None]:
-        if self.patterns is not None:
-            yield from self.patterns
 
 
 PatternTypes = typing.Union[

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1440,28 +1440,28 @@ class TestPatternMatching:
         assert isinstance(case.guard, nodes.Compare)
         assert isinstance(case.body[0], nodes.Pass)
 
-        pattern_as = case.pattern.pattern
-        assert isinstance(pattern_as, nodes.MatchSequence)
-        assert isinstance(pattern_as.patterns, list) and len(pattern_as.patterns) == 4
+        pattern_seq = case.pattern.pattern
+        assert isinstance(pattern_seq, nodes.MatchSequence)
+        assert isinstance(pattern_seq.patterns, list) and len(pattern_seq.patterns) == 4
         assert (
-            isinstance(pattern_as.patterns[0], nodes.MatchAs)
-            and isinstance(pattern_as.patterns[0].name, nodes.AssignName)
-            and pattern_as.patterns[0].name.name == "x"
-            and pattern_as.patterns[0].pattern is None
+            isinstance(pattern_seq.patterns[0], nodes.MatchAs)
+            and isinstance(pattern_seq.patterns[0].name, nodes.AssignName)
+            and pattern_seq.patterns[0].name.name == "x"
+            and pattern_seq.patterns[0].pattern is None
         )
         assert (
-            isinstance(pattern_as.patterns[1], nodes.MatchValue)
-            and isinstance(pattern_as.patterns[1].value, nodes.Const)
-            and pattern_as.patterns[1].value.value == 2
+            isinstance(pattern_seq.patterns[1], nodes.MatchValue)
+            and isinstance(pattern_seq.patterns[1].value, nodes.Const)
+            and pattern_seq.patterns[1].value.value == 2
         )
         assert (
-            isinstance(pattern_as.patterns[2], nodes.MatchAs)
-            and pattern_as.patterns[2].name is None
+            isinstance(pattern_seq.patterns[2], nodes.MatchAs)
+            and pattern_seq.patterns[2].name is None
         )
         assert (
-            isinstance(pattern_as.patterns[3], nodes.MatchStar)
-            and isinstance(pattern_as.patterns[3].name, nodes.AssignName)
-            and pattern_as.patterns[3].name.name == "rest"
+            isinstance(pattern_seq.patterns[3], nodes.MatchStar)
+            and isinstance(pattern_seq.patterns[3].name, nodes.AssignName)
+            and pattern_seq.patterns[3].name.name == "rest"
         )
 
     @staticmethod

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1392,14 +1392,17 @@ class TestPatternMatching:
         assert node.subject.name == "status"
         assert isinstance(node.cases, list) and len(node.cases) == 4
         case0, case1, case2, case3 = node.cases
+        assert list(node.get_children()) == [node.subject, *node.cases]
 
         assert isinstance(case0.pattern, nodes.MatchValue)
         assert (
             isinstance(case0.pattern.value, astroid.Const)
             and case0.pattern.value.value == 200
         )
+        assert list(case0.pattern.get_children()) == [case0.pattern.value]
         assert case0.guard is None
         assert isinstance(case0.body[0], astroid.Pass)
+        assert list(case0.get_children()) == [case0.pattern, case0.body[0]]
 
         assert isinstance(case1.pattern, nodes.MatchOr)
         assert (
@@ -1411,13 +1414,16 @@ class TestPatternMatching:
             assert isinstance(match_value, nodes.MatchValue)
             assert isinstance(match_value.value, nodes.Const)
             assert match_value.value.value == (401, 402, 403)[i]
+        assert list(case1.pattern.get_children()) == case1.pattern.patterns
 
         assert isinstance(case2.pattern, nodes.MatchSingleton)
         assert case2.pattern.value is None
+        assert list(case2.pattern.get_children()) == []
 
         assert isinstance(case3.pattern, nodes.MatchAs)
         assert case3.pattern.name is None
         assert case3.pattern.pattern is None
+        assert list(case3.pattern.get_children()) == []
 
     @staticmethod
     def test_match_sequence():
@@ -1437,8 +1443,13 @@ class TestPatternMatching:
         assert isinstance(case.pattern, nodes.MatchAs)
         assert isinstance(case.pattern.name, nodes.AssignName)
         assert case.pattern.name.name == "y"
+        assert list(case.pattern.get_children()) == [
+            case.pattern.pattern,
+            case.pattern.name,
+        ]
         assert isinstance(case.guard, nodes.Compare)
         assert isinstance(case.body[0], nodes.Pass)
+        assert list(case.get_children()) == [case.pattern, case.guard, case.body[0]]
 
         pattern_seq = case.pattern.pattern
         assert isinstance(pattern_seq, nodes.MatchSequence)
@@ -1463,6 +1474,10 @@ class TestPatternMatching:
             and isinstance(pattern_seq.patterns[3].name, nodes.AssignName)
             and pattern_seq.patterns[3].name.name == "rest"
         )
+        assert list(pattern_seq.patterns[3].get_children()) == [
+            pattern_seq.patterns[3].name
+        ]
+        assert list(pattern_seq.get_children()) == pattern_seq.patterns
 
     @staticmethod
     def test_match_mapping():
@@ -1499,6 +1514,10 @@ class TestPatternMatching:
                 assert pattern.name.name == "x"
             elif i == 1:
                 assert pattern.name is None
+        assert list(case0.pattern.get_children()) == [
+            *case0.pattern.keys,
+            *case0.pattern.patterns,
+        ]
 
         assert isinstance(case1.pattern, nodes.MatchMapping)
         assert isinstance(case1.pattern.rest, nodes.AssignName)
@@ -1508,6 +1527,7 @@ class TestPatternMatching:
             isinstance(case1.pattern.patterns, list)
             and len(case1.pattern.patterns) == 0
         )
+        assert list(case1.pattern.get_children()) == [case1.pattern.rest]
 
     @staticmethod
     def test_match_class():
@@ -1546,6 +1566,10 @@ class TestPatternMatching:
             and isinstance(match_as.name, nodes.AssignName)
             and match_as.name.name == "a"
         )
+        assert list(case0.pattern.get_children()) == [
+            case0.pattern.cls,
+            *case0.pattern.patterns,
+        ]
 
         assert isinstance(case1.pattern, nodes.MatchClass)
         assert isinstance(case1.pattern.cls, nodes.Name)
@@ -1576,6 +1600,10 @@ class TestPatternMatching:
             and isinstance(kwd_pattern.name, nodes.AssignName)
             and kwd_pattern.name.name == "b"
         )
+        assert list(case1.pattern.get_children()) == [
+            case1.pattern.cls,
+            *case1.pattern.kwd_patterns,
+        ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
* Small fix for `MatchClass`: `kwd_attrs` isn't an `_astroid_field`. Instead it should belong to `_other_fields`.
* Added additional tests for Match `get_children` methods.
* Added type annotations for `_astroid_fields` and `_other_fields` for Match nodes.
* Removed `get_children` methods from Match nodes. As long as `_astroid_fields` is set correctly, `NodeNG.get_children` handles it perfectly fine. My focus here was just on the Match nodes, but it can probably be removed from others as well.
* Added `yield  from ()` as default for `NodeNG.get_children`, just in case a node doesn't have any items for `_astroid_fields`. That should make `mixins.NoChildrenMixin` redundant.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |