### PR TITLE
Update Match nodes to be internally consistent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ Release Date: TBA
   depend on the python version. **Background**: With Python 3.9 ``ast.Index``
   and ``ast.ExtSlice`` were merged into the ``ast.Subscript`` node.
 
+* Updated all Match nodes to be internally consistent.
 
 
 What's New in astroid 2.5.8?

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -40,6 +40,7 @@ import pprint
 import typing
 from functools import lru_cache
 from functools import singledispatch as _singledispatch
+from typing import Optional
 
 from astroid import as_string, bases
 from astroid import context as contextmod
@@ -4657,14 +4658,22 @@ class Match(Statement):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("subject", "cases")
-    subject: typing.Optional[NodeNG] = None
-    cases: typing.Optional[typing.List["MatchCase"]] = None
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        self.subject: Optional[NodeNG] = None
+        self.cases: typing.List["MatchCase"] = []
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
         self,
         *,
-        subject: typing.Optional[NodeNG] = None,
-        cases: typing.Optional[typing.List["MatchCase"]] = None,
+        subject: NodeNG,
+        cases: typing.List["MatchCase"],
     ) -> None:
         self.subject = subject
         self.cases = cases
@@ -4683,16 +4692,19 @@ class MatchCase(NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("pattern", "guard", "body")
-    pattern: typing.Optional["PatternTypes"] = None
-    guard: typing.Optional[NodeNG] = None  # can actually be None
-    body: typing.Optional[typing.List[NodeNG]] = None
+
+    def __init__(self, *, parent: Optional[NodeNG] = None) -> None:
+        self.pattern: Optional["PatternTypes"] = None
+        self.guard: Optional[NodeNG] = None  # can actually be None
+        self.body: typing.List[NodeNG] = []
+        super().__init__(parent=parent)
 
     def postinit(
         self,
         *,
-        pattern: typing.Optional["PatternTypes"] = None,
-        guard: typing.Optional[NodeNG] = None,
-        body: typing.Optional[typing.List[NodeNG]] = None,
+        pattern: "PatternTypes",
+        guard: Optional[NodeNG],
+        body: typing.List[NodeNG],
     ) -> None:
         self.pattern = pattern
         self.guard = guard
@@ -4712,7 +4724,15 @@ class MatchValue(NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("value",)
-    value: typing.Optional[NodeNG] = None
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        self.value: Optional[NodeNG] = None
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(self, *, value: NodeNG) -> None:
         self.value = value
@@ -4742,14 +4762,14 @@ class MatchSingleton(NodeNG):
 
     def __init__(
         self,
-        lineno: int,
-        col_offset: int,
-        parent: NodeNG,
         *,
         value: Literal[True, False, None],
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
     ) -> None:
         self.value = value
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
 
 class MatchSequence(NodeNG):
@@ -4769,11 +4789,17 @@ class MatchSequence(NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("patterns",)
-    patterns: typing.Optional[typing.List["PatternTypes"]] = None
 
-    def postinit(
-        self, *, patterns: typing.Optional[typing.List["PatternTypes"]]
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
     ) -> None:
+        self.patterns: typing.List["PatternTypes"] = []
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+
+    def postinit(self, *, patterns: typing.List["PatternTypes"]) -> None:
         self.patterns = patterns
 
 
@@ -4790,16 +4816,24 @@ class MatchMapping(mixins.AssignTypeMixin, NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("keys", "patterns", "rest")
-    keys: typing.Optional[typing.List[NodeNG]] = None
-    patterns: typing.Optional[typing.List["PatternTypes"]] = None
-    rest: typing.Optional[AssignName] = None
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        self.keys: typing.List[NodeNG] = []
+        self.patterns: typing.List["PatternTypes"] = []
+        self.rest: Optional[AssignName] = None  # can actually be None
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
         self,
         *,
-        keys: typing.Optional[typing.List[NodeNG]] = None,
-        patterns: typing.Optional[typing.List["PatternTypes"]] = None,
-        rest: typing.Optional[AssignName] = None,
+        keys: typing.List[NodeNG],
+        patterns: typing.List["PatternTypes"],
+        rest: Optional[AssignName],
     ) -> None:
         self.keys = keys
         self.patterns = patterns
@@ -4824,18 +4858,26 @@ class MatchClass(NodeNG):
 
     _astroid_fields: typing.Tuple[str, ...] = ("cls", "patterns", "kwd_patterns")
     _other_fields: typing.Tuple[str, ...] = ("kwd_attrs",)
-    cls: typing.Optional[NodeNG] = None
-    patterns: typing.Optional[typing.List["PatternTypes"]] = None
-    kwd_attrs: typing.Optional[typing.List[str]] = None
-    kwd_patterns: typing.Optional[typing.List["PatternTypes"]] = None
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        self.cls: Optional[NodeNG] = None
+        self.patterns: typing.List["PatternTypes"] = []
+        self.kwd_attrs: typing.List[str] = []
+        self.kwd_patterns: typing.List["PatternTypes"] = []
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
         self,
         *,
-        cls: typing.Optional[NodeNG] = None,
-        patterns: typing.Optional[typing.List["PatternTypes"]] = None,
-        kwd_attrs: typing.Optional[typing.List[str]] = None,
-        kwd_patterns: typing.Optional[typing.List["PatternTypes"]] = None,
+        cls: NodeNG,
+        patterns: typing.List["PatternTypes"],
+        kwd_attrs: typing.List[str],
+        kwd_patterns: typing.List["PatternTypes"],
     ) -> None:
         self.cls = cls
         self.patterns = patterns
@@ -4856,9 +4898,17 @@ class MatchStar(mixins.AssignTypeMixin, NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("name",)
-    name: typing.Optional[AssignName] = None
 
-    def postinit(self, *, name: typing.Optional[AssignName] = None) -> None:
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        self.name: Optional[AssignName] = None  # can actually be None
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+
+    def postinit(self, *, name: Optional[AssignName]) -> None:
         self.name = name
 
 
@@ -4887,14 +4937,22 @@ class MatchAs(mixins.AssignTypeMixin, NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("pattern", "name")
-    pattern: typing.Optional["PatternTypes"] = None
-    name: typing.Optional[AssignName] = None
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        self.pattern: Optional["PatternTypes"] = None  # can actually be None
+        self.name: Optional[AssignName] = None  # can actually be None
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
         self,
         *,
-        pattern: typing.Optional["PatternTypes"] = None,
-        name: typing.Optional[AssignName] = None,
+        pattern: Optional["PatternTypes"],
+        name: Optional[AssignName],
     ) -> None:
         self.pattern = pattern
         self.name = name
@@ -4913,11 +4971,17 @@ class MatchOr(NodeNG):
     """
 
     _astroid_fields: typing.Tuple[str, ...] = ("patterns",)
-    patterns: typing.Optional[typing.List["PatternTypes"]] = None
 
-    def postinit(
-        self, *, patterns: typing.Optional[typing.List["PatternTypes"]]
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
     ) -> None:
+        self.patterns: typing.List["PatternTypes"] = []
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+
+    def postinit(self, *, patterns: typing.List["PatternTypes"]) -> None:
         self.patterns = patterns
 
 

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -40,7 +40,7 @@ import pprint
 import typing
 from functools import lru_cache
 from functools import singledispatch as _singledispatch
-from typing import Optional
+from typing import ClassVar, Optional
 
 from astroid import as_string, bases
 from astroid import context as contextmod
@@ -4657,7 +4657,7 @@ class Match(Statement):
     <Match l.2 at 0x10c24e170>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("subject", "cases")
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("subject", "cases")
 
     def __init__(
         self,
@@ -4691,7 +4691,7 @@ class MatchCase(NodeNG):
     <MatchCase l.3 at 0x10c24e590>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("pattern", "guard", "body")
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("pattern", "guard", "body")
 
     def __init__(self, *, parent: Optional[NodeNG] = None) -> None:
         self.pattern: Optional["PatternTypes"] = None
@@ -4723,7 +4723,7 @@ class MatchValue(NodeNG):
     <MatchValue l.3 at 0x10c24e200>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("value",)
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("value",)
 
     def __init__(
         self,
@@ -4758,7 +4758,7 @@ class MatchSingleton(NodeNG):
     <MatchSingleton l.7 at 0x10c229f90>
     """
 
-    _other_fields: typing.Tuple[str, ...] = ("value",)
+    _other_fields: ClassVar[typing.Tuple[str, ...]] = ("value",)
 
     def __init__(
         self,
@@ -4788,7 +4788,7 @@ class MatchSequence(NodeNG):
     <MatchSequence l.5 at 0x10ca80b20>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("patterns",)
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("patterns",)
 
     def __init__(
         self,
@@ -4815,7 +4815,7 @@ class MatchMapping(mixins.AssignTypeMixin, NodeNG):
     <MatchMapping l.3 at 0x10c8a8850>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("keys", "patterns", "rest")
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("keys", "patterns", "rest")
 
     def __init__(
         self,
@@ -4856,8 +4856,12 @@ class MatchClass(NodeNG):
     <MatchClass l.5 at 0x10ca80880>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("cls", "patterns", "kwd_patterns")
-    _other_fields: typing.Tuple[str, ...] = ("kwd_attrs",)
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = (
+        "cls",
+        "patterns",
+        "kwd_patterns",
+    )
+    _other_fields: ClassVar[typing.Tuple[str, ...]] = ("kwd_attrs",)
 
     def __init__(
         self,
@@ -4897,7 +4901,7 @@ class MatchStar(mixins.AssignTypeMixin, NodeNG):
     <MatchStar l.3 at 0x10ca809a0>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("name",)
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("name",)
 
     def __init__(
         self,
@@ -4936,7 +4940,7 @@ class MatchAs(mixins.AssignTypeMixin, NodeNG):
     <MatchAs l.9 at 0x10d09b880>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("pattern", "name")
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("pattern", "name")
 
     def __init__(
         self,
@@ -4970,7 +4974,7 @@ class MatchOr(NodeNG):
     <MatchOr l.3 at 0x10d0b0b50>
     """
 
-    _astroid_fields: typing.Tuple[str, ...] = ("patterns",)
+    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ("patterns",)
 
     def __init__(
         self,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1457,7 +1457,10 @@ class TreeRebuilder:
         self, node: "ast.MatchSingleton", parent: NodeNG
     ) -> nodes.MatchSingleton:
         return nodes.MatchSingleton(
-            node.lineno, node.col_offset, parent, value=node.value
+            value=node.value,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            parent=parent,
         )
 
     def visit_matchsequence(


### PR DESCRIPTION
## Description
* Define instance variables in `__init__` even if they are `None` at first
* At `ClassVar` to class variables: `_astroid_fields`, `_other_fields`
* Remove default parameter from `postinit`. Those should just always be called with all necessary parameters. Reduces the possibility of unknowingly missing one. If you really what to set just one, do it through direct assignment. At the end `postinit` is just a helper method anyway.
* Removed `Optional` annotation from `postinit` arguments where instance variable can't actually be `None`. Unfortunately `Optional` is still needed as most instance variables are initialized with `None`.
* Replaced `None` with empty list for initialization (where possible)
* Require keyword arguments for init of `MatchClass` as it accepts neither `lineno` nor `col_offset`
* Reorder arguments for `MatchSingleton.__init__`. `value` is require and thus should come first, `lineno`, `col_offset`, and `parent` can be optional. Change to require keyword arguments here as well.
* I was thinking about requiring keyword arguments for all `__init__` methods, but decided that the default (just `lineno`, `col_offset`, and `parent`) is probably fine. Only if that changes should we require keywords.

#### Breaking change
Technically this is a breaking change for all `Match` nodes. However, as it was just added recently, I think it's probably fine to do it. Better now than later, anyway.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |