### PR TITLE
Reduce cyclic import by always importing exceptions from astroid.exceptions internally

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -60,7 +60,34 @@ del _Context
 # pylint: disable=wrong-import-order,wrong-import-position,redefined-builtin
 
 # make all exception classes accessible from astroid package
-from astroid.exceptions import *
+from astroid.exceptions import (
+    AstroidBuildingError,
+    AstroidBuildingException,
+    AstroidError,
+    AstroidImportError,
+    AstroidIndexError,
+    AstroidSyntaxError,
+    AstroidTypeError,
+    AstroidValueError,
+    AttributeInferenceError,
+    BinaryOperationError,
+    DuplicateBasesError,
+    InconsistentMroError,
+    InferenceError,
+    InferenceOverwriteError,
+    MroError,
+    NameInferenceError,
+    NoDefault,
+    NotFoundError,
+    OperationError,
+    ResolveError,
+    SuperArgumentTypeError,
+    SuperError,
+    TooManyLevelsError,
+    UnaryOperationError,
+    UnresolvableName,
+    UseInferenceDefault,
+)
 
 # make all node classes accessible from astroid package
 from astroid.nodes import *

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -60,34 +60,7 @@ del _Context
 # pylint: disable=wrong-import-order,wrong-import-position,redefined-builtin
 
 # make all exception classes accessible from astroid package
-from astroid.exceptions import (
-    AstroidBuildingError,
-    AstroidBuildingException,
-    AstroidError,
-    AstroidImportError,
-    AstroidIndexError,
-    AstroidSyntaxError,
-    AstroidTypeError,
-    AstroidValueError,
-    AttributeInferenceError,
-    BinaryOperationError,
-    DuplicateBasesError,
-    InconsistentMroError,
-    InferenceError,
-    InferenceOverwriteError,
-    MroError,
-    NameInferenceError,
-    NoDefault,
-    NotFoundError,
-    OperationError,
-    ResolveError,
-    SuperArgumentTypeError,
-    SuperError,
-    TooManyLevelsError,
-    UnaryOperationError,
-    UnresolvableName,
-    UseInferenceDefault,
-)
+from astroid.exceptions import *
 
 # make all node classes accessible from astroid package
 from astroid.nodes import *

--- a/astroid/brain/brain_argparse.py
+++ b/astroid/brain/brain_argparse.py
@@ -1,4 +1,5 @@
-from astroid import MANAGER, UseInferenceDefault, arguments, inference_tip, nodes
+from astroid import MANAGER, arguments, inference_tip, nodes
+from astroid.exceptions import UseInferenceDefault
 
 
 def infer_namespace(node, context=None):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -23,12 +23,6 @@ from functools import partial
 
 from astroid import (
     MANAGER,
-    AstroidTypeError,
-    AttributeInferenceError,
-    InferenceError,
-    MroError,
-    NameInferenceError,
-    UseInferenceDefault,
     arguments,
     helpers,
     inference_tip,
@@ -38,6 +32,14 @@ from astroid import (
     util,
 )
 from astroid.builder import AstroidBuilder
+from astroid.exceptions import (
+    AstroidTypeError,
+    AttributeInferenceError,
+    InferenceError,
+    MroError,
+    NameInferenceError,
+    UseInferenceDefault,
+)
 
 OBJECT_DUNDER_NEW = "object.__new__"
 

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -27,8 +27,9 @@ import re
 import sys
 import warnings
 
-from astroid import MANAGER, AstroidBuildingError, nodes
+from astroid import MANAGER, nodes
 from astroid.builder import AstroidBuilder
+from astroid.exceptions import AstroidBuildingError
 
 _inspected_modules = {}
 

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -9,7 +9,7 @@
 
 
 import astroid
-from astroid import exceptions
+from astroid.exceptions import InferenceError
 
 
 def _multiprocessing_transform():
@@ -33,7 +33,7 @@ def _multiprocessing_transform():
     try:
         context = next(node["default"].infer())
         base = next(node["base"].infer())
-    except exceptions.InferenceError:
+    except InferenceError:
         return module
 
     for node in (context, base):

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -28,19 +28,14 @@ import functools
 import keyword
 from textwrap import dedent
 
-from astroid import (
-    MANAGER,
+from astroid import MANAGER, arguments, inference_tip, nodes, util
+from astroid.builder import AstroidBuilder, extract_node
+from astroid.exceptions import (
     AstroidTypeError,
     AstroidValueError,
     InferenceError,
     UseInferenceDefault,
-    arguments,
-    exceptions,
-    inference_tip,
-    nodes,
-    util,
 )
-from astroid.builder import AstroidBuilder, extract_node
 
 TYPING_NAMEDTUPLE_BASENAMES = {"NamedTuple", "typing.NamedTuple"}
 ENUM_BASE_NAMES = {
@@ -131,7 +126,7 @@ def infer_func_form(node, base_type, context=None, enum=False):
                     raise AttributeError from exc
                 if not attributes:
                     raise AttributeError from exc
-    except (AttributeError, exceptions.InferenceError) as exc:
+    except (AttributeError, InferenceError) as exc:
         raise UseInferenceDefault from exc
 
     if not enum:

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -14,6 +14,7 @@ import textwrap
 
 import astroid
 import astroid.builder
+from astroid.exceptions import InferenceError
 
 _BUILDER = astroid.builder.AstroidBuilder(astroid.MANAGER)
 
@@ -40,7 +41,7 @@ def _nose_tools_functions():
     )
     try:
         case = next(module["a"].infer())
-    except astroid.InferenceError:
+    except InferenceError:
         return
     for method in case.methods():
         if method.name.startswith("assert") and "_" not in method.name:

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -4,6 +4,7 @@ import random
 
 import astroid
 from astroid import MANAGER, helpers
+from astroid.exceptions import UseInferenceDefault
 
 ACCEPTED_ITERABLES_FOR_SAMPLE = (astroid.List, astroid.Set, astroid.Tuple)
 
@@ -26,29 +27,29 @@ def _clone_node_with_lineno(node, parent, lineno):
 
 def infer_random_sample(node, context=None):
     if len(node.args) != 2:
-        raise astroid.UseInferenceDefault
+        raise UseInferenceDefault
 
     length = node.args[1]
     if not isinstance(length, astroid.Const):
-        raise astroid.UseInferenceDefault
+        raise UseInferenceDefault
     if not isinstance(length.value, int):
-        raise astroid.UseInferenceDefault
+        raise UseInferenceDefault
 
     inferred_sequence = helpers.safe_infer(node.args[0], context=context)
     if not inferred_sequence:
-        raise astroid.UseInferenceDefault
+        raise UseInferenceDefault
 
     if not isinstance(inferred_sequence, ACCEPTED_ITERABLES_FOR_SAMPLE):
-        raise astroid.UseInferenceDefault
+        raise UseInferenceDefault
 
     if length.value > len(inferred_sequence.elts):
         # In this case, this will raise a ValueError
-        raise astroid.UseInferenceDefault
+        raise UseInferenceDefault
 
     try:
         elts = random.sample(inferred_sequence.elts, length.value)
     except ValueError as exc:
-        raise astroid.UseInferenceDefault from exc
+        raise UseInferenceDefault from exc
 
     new_node = astroid.List(
         lineno=node.lineno, col_offset=node.col_offset, parent=node.scope()

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -17,7 +17,8 @@ Thanks to Lukasz Langa for fruitful discussion.
 """
 import sys
 
-from astroid import MANAGER, UseInferenceDefault, extract_node, inference_tip, nodes
+from astroid import MANAGER, extract_node, inference_tip, nodes
+from astroid.exceptions import UseInferenceDefault
 
 PY39 = sys.version_info >= (3, 9)
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -15,16 +15,11 @@ import typing
 from functools import partial
 
 import astroid
-from astroid import (
-    MANAGER,
+from astroid import MANAGER, context, extract_node, inference_tip, node_classes, nodes
+from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
     UseInferenceDefault,
-    context,
-    extract_node,
-    inference_tip,
-    node_classes,
-    nodes,
 )
 
 PY37 = sys.version_info[:2] >= (3, 7)

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -24,17 +24,9 @@ import textwrap
 from tokenize import detect_encoding
 from typing import List, Union
 
-from astroid import (
-    bases,
-    exceptions,
-    manager,
-    modutils,
-    nodes,
-    raw_building,
-    rebuilder,
-    util,
-)
+from astroid import bases, manager, modutils, nodes, raw_building, rebuilder, util
 from astroid._ast import get_parser_module
+from astroid.exceptions import AstroidBuildingError, AstroidSyntaxError, InferenceError
 from astroid.node_classes import NodeNG
 
 objects = util.lazy_import("objects")
@@ -113,14 +105,14 @@ class AstroidBuilder(raw_building.InspectBuilder):
         try:
             stream, encoding, data = open_source_file(path)
         except OSError as exc:
-            raise exceptions.AstroidBuildingError(
+            raise AstroidBuildingError(
                 "Unable to load file {path}:\n{error}",
                 modname=modname,
                 path=path,
                 error=exc,
             ) from exc
         except (SyntaxError, LookupError) as exc:
-            raise exceptions.AstroidSyntaxError(
+            raise AstroidSyntaxError(
                 "Python 3 encoding specification error or unknown encoding:\n"
                 "{error}",
                 modname=modname,
@@ -129,7 +121,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
             ) from exc
         except UnicodeError as exc:  # wrong encoding
             # detect_encoding returns utf-8 if no encoding specified
-            raise exceptions.AstroidBuildingError(
+            raise AstroidBuildingError(
                 "Wrong or no encoding specified for {filename}.", filename=path
             ) from exc
         with stream:
@@ -173,7 +165,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
         try:
             node, parser_module = _parse_string(data, type_comments=True)
         except (TypeError, ValueError, SyntaxError) as exc:
-            raise exceptions.AstroidSyntaxError(
+            raise AstroidSyntaxError(
                 "Parsing Python code failed:\n{error}",
                 source=data,
                 modname=modname,
@@ -215,7 +207,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
             if name == "*":
                 try:
                     imported = node.do_import_module()
-                except exceptions.AstroidBuildingError:
+                except AstroidBuildingError:
                     continue
                 for name in imported.public_names():
                     node.parent.set_local(name, node)
@@ -264,7 +256,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
                     values.insert(0, node)
                 else:
                     values.append(node)
-        except exceptions.InferenceError:
+        except InferenceError:
             pass
 
 

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -22,7 +22,8 @@ import functools
 import wrapt
 
 from astroid import context as contextmod
-from astroid import exceptions, util
+from astroid import util
+from astroid.exceptions import InferenceError
 
 
 @wrapt.decorator
@@ -137,8 +138,8 @@ def raise_if_nothing_inferred(func, instance, args, kwargs):
         # generator is empty
         if error.args:
             # pylint: disable=not-a-mapping
-            raise exceptions.InferenceError(**error.args[0]) from error
-        raise exceptions.InferenceError(
+            raise InferenceError(**error.args[0]) from error
+        raise InferenceError(
             "StopIteration raised without any error information."
         ) from error
 

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -15,6 +15,35 @@
 """
 from astroid import util
 
+__all__ = (
+    "AstroidBuildingError",
+    "AstroidBuildingException",
+    "AstroidError",
+    "AstroidImportError",
+    "AstroidIndexError",
+    "AstroidSyntaxError",
+    "AstroidTypeError",
+    "AstroidValueError",
+    "AttributeInferenceError",
+    "BinaryOperationError",
+    "DuplicateBasesError",
+    "InconsistentMroError",
+    "InferenceError",
+    "InferenceOverwriteError",
+    "MroError",
+    "NameInferenceError",
+    "NoDefault",
+    "NotFoundError",
+    "OperationError",
+    "ResolveError",
+    "SuperArgumentTypeError",
+    "SuperError",
+    "TooManyLevelsError",
+    "UnaryOperationError",
+    "UnresolvableName",
+    "UseInferenceDefault",
+)
+
 
 class AstroidError(Exception):
     """base exception class for all astroid related exceptions

--- a/astroid/interpreter/dunder_lookup.py
+++ b/astroid/interpreter/dunder_lookup.py
@@ -16,7 +16,7 @@ the dot attribute access.
 import itertools
 
 import astroid
-from astroid import exceptions
+from astroid.exceptions import AttributeInferenceError
 
 
 def _lookup_in_mro(node, name):
@@ -27,7 +27,7 @@ def _lookup_in_mro(node, name):
     )
     values = list(itertools.chain(attrs, nodes))
     if not values:
-        raise exceptions.AttributeInferenceError(attribute=name, target=node)
+        raise AttributeInferenceError(attribute=name, target=node)
 
     return values
 
@@ -48,13 +48,13 @@ def lookup(node, name):
     if isinstance(node, astroid.ClassDef):
         return _class_lookup(node, name)
 
-    raise exceptions.AttributeInferenceError(attribute=name, target=node)
+    raise AttributeInferenceError(attribute=name, target=node)
 
 
 def _class_lookup(node, name):
     metaclass = node.metaclass()
     if metaclass is None:
-        raise exceptions.AttributeInferenceError(attribute=name, target=node)
+        raise AttributeInferenceError(attribute=name, target=node)
 
     return _lookup_in_mro(metaclass, name)
 
@@ -62,6 +62,6 @@ def _class_lookup(node, name):
 def _builtin_lookup(node, name):
     values = node.locals.get(name, [])
     if not values:
-        raise exceptions.AttributeInferenceError(attribute=name, target=node)
+        raise AttributeInferenceError(attribute=name, target=node)
 
     return values

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -17,7 +17,8 @@
 """
 import itertools
 
-from astroid import decorators, exceptions
+from astroid import decorators
+from astroid.exceptions import AttributeInferenceError
 
 
 class BlockRangeMixIn:
@@ -111,7 +112,7 @@ class ImportFromMixin(FilterStmtsMixin):
                 _asname = name
             if asname == _asname:
                 return name
-        raise exceptions.AttributeInferenceError(
+        raise AttributeInferenceError(
             "Could not find original name for {attribute} in {target!r}",
             target=self,
             attribute=asname,

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -43,7 +43,15 @@ from functools import singledispatch as _singledispatch
 
 from astroid import as_string, bases
 from astroid import context as contextmod
-from astroid import decorators, exceptions, manager, mixins, util
+from astroid import decorators, manager, mixins, util
+from astroid.exceptions import (
+    AstroidError,
+    AstroidIndexError,
+    AstroidTypeError,
+    InferenceError,
+    NoDefault,
+    UseInferenceDefault,
+)
 
 try:
     from typing import Literal
@@ -180,7 +188,7 @@ def _slice_value(index, context=None):
         # we'll stop at the first possible value.
         try:
             inferred = next(index.infer(context=context))
-        except exceptions.InferenceError:
+        except InferenceError:
             pass
         else:
             if isinstance(inferred, Const):
@@ -200,7 +208,7 @@ def _infer_slice(node, context=None):
     if all(elem is not _SLICE_SENTINEL for elem in (lower, upper, step)):
         return slice(lower, upper, step)
 
-    raise exceptions.AstroidTypeError(
+    raise AstroidTypeError(
         message="Could not infer slice used in subscript",
         node=node,
         index=node.parent,
@@ -220,18 +228,18 @@ def _container_getitem(instance, elts, index, context=None):
         if isinstance(index, Const):
             return elts[index.value]
     except IndexError as exc:
-        raise exceptions.AstroidIndexError(
+        raise AstroidIndexError(
             message="Index {index!s} out of range",
             node=instance,
             index=index,
             context=context,
         ) from exc
     except TypeError as exc:
-        raise exceptions.AstroidTypeError(
+        raise AstroidTypeError(
             message="Type error {error!r}", node=instance, index=index, context=context
         ) from exc
 
-    raise exceptions.AstroidTypeError("Could not use %s as subscript index" % index)
+    raise AstroidTypeError("Could not use %s as subscript index" % index)
 
 
 OP_PRECEDENCE = {
@@ -361,7 +369,7 @@ class NodeNG:
                     context.nodes_inferred += len(results)
                 yield from results
                 return
-            except exceptions.UseInferenceDefault:
+            except UseInferenceDefault:
                 pass
 
         if not context:
@@ -564,7 +572,7 @@ class NodeNG:
                 return node_or_sequence
 
         msg = "Could not find %s in %s's children"
-        raise exceptions.AstroidError(msg % (repr(child), repr(self)))
+        raise AstroidError(msg % (repr(child), repr(self)))
 
     def locate_child(self, child):
         """Find the field of this node that contains the given child.
@@ -590,7 +598,7 @@ class NodeNG:
             ):
                 return field, node_or_sequence
         msg = "Could not find %s in %s's children"
-        raise exceptions.AstroidError(msg % (repr(child), repr(self)))
+        raise AstroidError(msg % (repr(child), repr(self)))
 
     # FIXME : should we merge child_sequence and locate_child ? locate_child
     # is only used in are_exclusive, child_sequence one time in pylint.
@@ -738,7 +746,7 @@ class NodeNG:
     def _infer(self, context=None):
         """we don't know how to resolve a statement by default"""
         # this method is overridden by most concrete classes
-        raise exceptions.InferenceError(
+        raise InferenceError(
             "No inference function for {node!r}.", node=self, context=context
         )
 
@@ -1722,7 +1730,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         index = _find_arg(argname, self.kwonlyargs)[0]
         if index is not None and self.kw_defaults[index] is not None:
             return self.kw_defaults[index]
-        raise exceptions.NoDefault(func=self.parent, name=argname)
+        raise NoDefault(func=self.parent, name=argname)
 
     def is_argument(self, name):
         """Check if the given name is defined in the arguments.
@@ -2124,7 +2132,7 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
                 for result in results
                 if isinstance(result, util.BadBinaryOperationMessage)
             ]
-        except exceptions.InferenceError:
+        except InferenceError:
             return []
 
     def get_children(self):
@@ -2215,7 +2223,7 @@ class BinOp(NodeNG):
                 for result in results
                 if isinstance(result, util.BadBinaryOperationMessage)
             ]
-        except exceptions.InferenceError:
+        except InferenceError:
             return []
 
     def get_children(self):
@@ -2592,7 +2600,7 @@ class Const(mixins.NoChildrenMixin, NodeNG, bases.Instance):
             index_value = _infer_slice(index, context=context)
 
         else:
-            raise exceptions.AstroidTypeError(
+            raise AstroidTypeError(
                 f"Could not use type {type(index)} as subscript index"
             )
 
@@ -2600,18 +2608,18 @@ class Const(mixins.NoChildrenMixin, NodeNG, bases.Instance):
             if isinstance(self.value, (str, bytes)):
                 return Const(self.value[index_value])
         except IndexError as exc:
-            raise exceptions.AstroidIndexError(
+            raise AstroidIndexError(
                 message="Index {index!r} out of range",
                 node=self,
                 index=index,
                 context=context,
             ) from exc
         except TypeError as exc:
-            raise exceptions.AstroidTypeError(
+            raise AstroidTypeError(
                 message="Type error {error!r}", node=self, index=index, context=context
             ) from exc
 
-        raise exceptions.AstroidTypeError(f"{self!r} (value={self.value})")
+        raise AstroidTypeError(f"{self!r} (value={self.value})")
 
     def has_dynamic_getattr(self):
         """Check if the node has a custom __getattr__ or __getattribute__.
@@ -2905,7 +2913,7 @@ class Dict(NodeNG, bases.Instance):
             if isinstance(key, DictUnpack):
                 try:
                     return value.getitem(index, context)
-                except (exceptions.AstroidTypeError, exceptions.AstroidIndexError):
+                except (AstroidTypeError, AstroidIndexError):
                     continue
             for inferredkey in key.infer(context):
                 if inferredkey is util.Uninferable:
@@ -2914,7 +2922,7 @@ class Dict(NodeNG, bases.Instance):
                     if inferredkey.value == index.value:
                         return value
 
-        raise exceptions.AstroidIndexError(index)
+        raise AstroidIndexError(index)
 
     def bool_value(self, context=None):
         """Determine the boolean value of this node.
@@ -3051,7 +3059,7 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
         return self.lineno
 
     def catch(self, exceptions):  # pylint: disable=redefined-outer-name
-        """Check if this node handles any of the given exceptions.
+        """Check if this node handles any of the given
 
         If ``exceptions`` is empty, this will default to ``True``.
 
@@ -4272,7 +4280,7 @@ class UnaryOp(NodeNG):
                 for result in results
                 if isinstance(result, util.BadUnaryOperationMessage)
             ]
-        except exceptions.InferenceError:
+        except InferenceError:
             return []
 
     def get_children(self):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -44,6 +44,7 @@ import pytest
 
 import astroid
 from astroid import MANAGER, bases, builder, nodes, objects, test_utils, util
+from astroid.exceptions import AttributeInferenceError, InferenceError
 
 try:
     import multiprocessing  # pylint: disable=unused-import
@@ -141,7 +142,7 @@ class CollectionsDequeTests(unittest.TestCase):
     @test_utils.require_version(maxver="3.8")
     def test_deque_not_py39methods(self):
         inferred = self._inferred_queue_instance()
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
     @test_utils.require_version(minver="3.9")
@@ -220,7 +221,7 @@ class NamedTupleTest(unittest.TestCase):
         instance = next(result.infer())
         self.assertGreaterEqual(len(instance.getattr("scheme")), 1)
         self.assertGreaterEqual(len(instance.getattr("port")), 1)
-        with self.assertRaises(astroid.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             instance.getattr("foo")
         self.assertGreaterEqual(len(instance.getattr("geturl")), 1)
         self.assertEqual(instance.name, "ParseResult")
@@ -1158,7 +1159,7 @@ class TypeBrain(unittest.TestCase):
         val_inf = src.annotation.value.inferred()[0]
         self.assertIsInstance(val_inf, astroid.ClassDef)
         self.assertEqual(val_inf.name, "str")
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             # pylint: disable=expression-not-assigned
             val_inf.getattr("__class_getitem__")[0]
 
@@ -1197,7 +1198,7 @@ class CollectionsBrain(unittest.TestCase):
         collections.abc.Hashable[int]
         """
         )
-        with self.assertRaises(astroid.exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(wrong_node.infer())
         right_node = builder.extract_node(
             """
@@ -1214,7 +1215,7 @@ class CollectionsBrain(unittest.TestCase):
                 "builtins.object",
             ],
         )
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
     @test_utils.require_version(minver="3.9")
@@ -1256,7 +1257,7 @@ class CollectionsBrain(unittest.TestCase):
         collections.abc.MutableSet[int]
         """
         )
-        with self.assertRaises(astroid.exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(wrong_node.infer())
         right_node = builder.extract_node(
             """
@@ -1278,7 +1279,7 @@ class CollectionsBrain(unittest.TestCase):
                 "builtins.object",
             ],
         )
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
     @test_utils.require_version(minver="3.9")
@@ -1312,7 +1313,7 @@ class CollectionsBrain(unittest.TestCase):
         collections.abc.Iterator[int]
         """
         )
-        with self.assertRaises(astroid.exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(node.infer())
 
     @test_utils.require_version(minver="3.9")
@@ -1693,7 +1694,7 @@ class TypingBrain(unittest.TestCase):
         typing.Hashable[int]
         """
         )
-        with self.assertRaises(astroid.exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(wrong_node.infer())
         right_node = builder.extract_node(
             """
@@ -1710,7 +1711,7 @@ class TypingBrain(unittest.TestCase):
                 "builtins.object",
             ],
         )
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
     @test_utils.require_version(minver="3.7")
@@ -1775,7 +1776,7 @@ class TypingBrain(unittest.TestCase):
         )
         inferred = next(right_node.infer())
         check_metaclass_is_abc(inferred)
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             self.assertIsInstance(
                 inferred.getattr("__class_getitem__")[0], nodes.FunctionDef
             )
@@ -1821,7 +1822,7 @@ class ReBrainTest(unittest.TestCase):
         )
         inferred1 = next(right_node1.infer())
         assert isinstance(inferred1, nodes.ClassDef)
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             assert isinstance(
                 inferred1.getattr("__class_getitem__")[0], nodes.FunctionDef
             )
@@ -1834,7 +1835,7 @@ class ReBrainTest(unittest.TestCase):
         )
         inferred2 = next(right_node2.infer())
         assert isinstance(inferred2, nodes.ClassDef)
-        with self.assertRaises(astroid.exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             assert isinstance(
                 inferred2.getattr("__class_getitem__")[0], nodes.FunctionDef
             )
@@ -1845,7 +1846,7 @@ class ReBrainTest(unittest.TestCase):
         re.Pattern[int]
         """
         )
-        with self.assertRaises(astroid.exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(wrong_node1.infer())
 
         wrong_node2 = builder.extract_node(
@@ -1854,7 +1855,7 @@ class ReBrainTest(unittest.TestCase):
         re.Match[int]
         """
         )
-        with self.assertRaises(astroid.exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(wrong_node2.infer())
 
     @test_utils.require_version(minver="3.9")
@@ -2197,21 +2198,21 @@ class TestIsinstanceInference:
 
     def test_uninferable_bad_type(self):
         """The second argument must be a class or a tuple of classes"""
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("isinstance(int, 1)")
 
     def test_uninferable_keywords(self):
         """isinstance does not allow keywords"""
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("isinstance(1, class_or_tuple=int)")
 
     def test_too_many_args(self):
         """isinstance must have two arguments"""
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("isinstance(1, int, str)")
 
     def test_first_param_is_uninferable(self):
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("isinstance(something, int)")
 
 
@@ -2306,17 +2307,17 @@ class TestIssubclassBrain:
     def test_uninferable_bad_type(self):
         """The second argument must be a class or a tuple of classes"""
         # Should I subclass
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("issubclass(int, 1)")
 
     def test_uninferable_keywords(self):
         """issubclass does not allow keywords"""
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("issubclass(int, class_or_tuple=int)")
 
     def test_too_many_args(self):
         """issubclass must have two arguments"""
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             _get_result_node("issubclass(int, int, str)")
 
 
@@ -2423,7 +2424,7 @@ class TestLenBuiltinInference:
         len(F)
         """
         )
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             next(node.infer())
 
     def test_len_string(self):
@@ -2443,7 +2444,7 @@ class TestLenBuiltinInference:
         len(gen())
         """
         )
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             next(node.infer())
 
     def test_len_failure_missing_variable(self):
@@ -2452,7 +2453,7 @@ class TestLenBuiltinInference:
         len(a)
         """
         )
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             next(node.infer())
 
     def test_len_bytes(self):
@@ -2505,7 +2506,7 @@ class TestLenBuiltinInference:
         code = 'len(str("F"))'
         try:
             next(astroid.extract_node(code).infer())
-        except astroid.InferenceError:
+        except InferenceError:
             pass
 
     def test_len_builtin_inference_recursion_error_self_referential_attribute(self):
@@ -2586,7 +2587,7 @@ def test_infer_dict_from_keys():
     """
     )
     for node in bad_nodes:
-        with pytest.raises(astroid.InferenceError):
+        with pytest.raises(InferenceError):
             next(node.infer())
 
     # Test uninferable values
@@ -2846,7 +2847,7 @@ def test_no_recursionerror_on_self_referential_length_check():
     """
     Regression test for https://github.com/PyCQA/astroid/issues/777
     """
-    with pytest.raises(astroid.InferenceError):
+    with pytest.raises(InferenceError):
         node = astroid.extract_node(
             """
         class Crash:

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -30,7 +30,13 @@ import unittest
 
 import pytest
 
-from astroid import Instance, builder, exceptions, manager, nodes, test_utils, util
+from astroid import Instance, builder, manager, nodes, test_utils, util
+from astroid.exceptions import (
+    AstroidBuildingError,
+    AstroidSyntaxError,
+    AttributeInferenceError,
+    InferenceError,
+)
 
 from . import resources
 
@@ -266,11 +272,11 @@ class BuilderTest(unittest.TestCase):
         self.builder = builder.AstroidBuilder()
 
     def test_data_build_null_bytes(self):
-        with self.assertRaises(exceptions.AstroidSyntaxError):
+        with self.assertRaises(AstroidSyntaxError):
             self.builder.string_build("\x00")
 
     def test_data_build_invalid_x_escape(self):
-        with self.assertRaises(exceptions.AstroidSyntaxError):
+        with self.assertRaises(AstroidSyntaxError):
             self.builder.string_build('"\\x1"')
 
     def test_missing_newline(self):
@@ -278,7 +284,7 @@ class BuilderTest(unittest.TestCase):
         resources.build_file("data/noendingnewline.py")
 
     def test_missing_file(self):
-        with self.assertRaises(exceptions.AstroidBuildingError):
+        with self.assertRaises(AstroidBuildingError):
             resources.build_file("data/inexistant.py")
 
     def test_inspect_build0(self):
@@ -419,9 +425,9 @@ class BuilderTest(unittest.TestCase):
         self.assertIsInstance(astroid.getattr("CSTE")[0], nodes.AssignName)
         self.assertEqual(astroid.getattr("CSTE")[0].fromlineno, 2)
         self.assertEqual(astroid.getattr("CSTE")[1].fromlineno, 6)
-        with self.assertRaises(exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             astroid.getattr("CSTE2")
-        with self.assertRaises(exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(astroid["global_no_effect"].ilookup("CSTE2"))
 
     def test_socket_build(self):
@@ -733,7 +739,7 @@ class FileBuildTest(unittest.TestCase):
         self.assertEqual(keys, ["autre", "local", "self"])
 
     def test_unknown_encoding(self):
-        with self.assertRaises(exceptions.AstroidSyntaxError):
+        with self.assertRaises(AstroidSyntaxError):
             resources.build_file("data/invalid_encoding.py")
 
 

--- a/tests/unittest_helpers.py
+++ b/tests/unittest_helpers.py
@@ -12,7 +12,8 @@
 import builtins
 import unittest
 
-from astroid import builder, exceptions, helpers, manager, raw_building, util
+from astroid import builder, helpers, manager, raw_building, util
+from astroid.exceptions import _NonDeducibleTypeHierarchy
 
 
 class TestHelpers(unittest.TestCase):
@@ -202,7 +203,7 @@ class TestHelpers(unittest.TestCase):
         self.assertFalse(helpers.is_subtype(cls_e, cls_f))
 
         self.assertFalse(helpers.is_subtype(cls_e, cls_f))
-        with self.assertRaises(exceptions._NonDeducibleTypeHierarchy):
+        with self.assertRaises(_NonDeducibleTypeHierarchy):
             helpers.is_subtype(cls_f, cls_e)
         self.assertFalse(helpers.is_supertype(cls_f, cls_e))
 
@@ -214,9 +215,9 @@ class TestHelpers(unittest.TestCase):
         class B(A): pass #@
         """
         )
-        with self.assertRaises(exceptions._NonDeducibleTypeHierarchy):
+        with self.assertRaises(_NonDeducibleTypeHierarchy):
             helpers.is_subtype(cls_a, cls_b)
-        with self.assertRaises(exceptions._NonDeducibleTypeHierarchy):
+        with self.assertRaises(_NonDeducibleTypeHierarchy):
             helpers.is_supertype(cls_a, cls_b)
 
     def test_is_subtype_supertype_unrelated_classes(self):

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -45,11 +45,17 @@ from unittest.mock import patch
 
 import pytest
 
-from astroid import InferenceError, Slice, arguments, builder
+from astroid import Slice, arguments, builder
 from astroid import decorators as decoratorsmod
-from astroid import exceptions, helpers, nodes, objects, test_utils, util
+from astroid import helpers, nodes, objects, test_utils, util
 from astroid.bases import BUILTINS, BoundMethod, Instance, UnboundMethod
 from astroid.builder import extract_node, parse
+from astroid.exceptions import (
+    AstroidTypeError,
+    AttributeInferenceError,
+    InferenceError,
+    NotFoundError,
+)
 from astroid.inference import infer_end as inference_infer_end
 from astroid.objects import ExceptionInstance
 
@@ -1695,7 +1701,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         ast = extract_node(code, __name__)
         expr = ast.func.expr
-        with pytest.raises(exceptions.InferenceError):
+        with pytest.raises(InferenceError):
             next(expr.infer())
 
     def test_tuple_builtin_inference(self):
@@ -3958,7 +3964,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         )
         inferred = next(ast_node.infer())
-        with self.assertRaises(exceptions.NotFoundError):
+        with self.assertRaises(NotFoundError):
             inferred.getattr("teta")
         inferred.getattr("a")
 
@@ -4033,7 +4039,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         )
         inferred = next(node.infer())
-        with self.assertRaises(exceptions.AstroidTypeError):
+        with self.assertRaises(AstroidTypeError):
             inferred.getitem(nodes.Const("4"))
 
     def test_infer_arg_called_type_is_uninferable(self):
@@ -5379,7 +5385,7 @@ def test_cannot_getattr_ann_assigns():
     """
     )
     inferred = next(node.infer())
-    with pytest.raises(exceptions.AttributeInferenceError):
+    with pytest.raises(AttributeInferenceError):
         inferred.getattr("ann")
 
     # But if it had a value, then it would be okay.
@@ -5972,10 +5978,10 @@ def test_getattr_fails_on_empty_values():
     """
     node = extract_node(code)
     inferred = next(node.infer())
-    with pytest.raises(exceptions.InferenceError):
+    with pytest.raises(InferenceError):
         next(inferred.igetattr(""))
 
-    with pytest.raises(exceptions.AttributeInferenceError):
+    with pytest.raises(AttributeInferenceError):
         inferred.getattr("")
 
 

--- a/tests/unittest_lookup.py
+++ b/tests/unittest_lookup.py
@@ -16,7 +16,12 @@
 import functools
 import unittest
 
-from astroid import builder, exceptions, nodes, scoped_nodes
+from astroid import builder, nodes, scoped_nodes
+from astroid.exceptions import (
+    AttributeInferenceError,
+    InferenceError,
+    NameInferenceError,
+)
 
 from . import resources
 
@@ -67,7 +72,7 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(obj, nodes.ClassDef)
         self.assertEqual(obj.name, "object")
         self.assertRaises(
-            exceptions.InferenceError, functools.partial(next, astroid.ilookup("YOAA"))
+            InferenceError, functools.partial(next, astroid.ilookup("YOAA"))
         )
 
         # XXX
@@ -95,7 +100,7 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         none = next(method.ilookup("None"))
         self.assertIsNone(none.value)
         self.assertRaises(
-            exceptions.InferenceError, functools.partial(next, method.ilookup("YOAA"))
+            InferenceError, functools.partial(next, method.ilookup("YOAA"))
         )
 
     def test_function_argument_with_default(self):
@@ -115,7 +120,7 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(obj, nodes.ClassDef)
         self.assertEqual(obj.name, "object")
         self.assertRaises(
-            exceptions.InferenceError, functools.partial(next, klass.ilookup("YOAA"))
+            InferenceError, functools.partial(next, klass.ilookup("YOAA"))
         )
 
     def test_inner_classes(self):
@@ -167,7 +172,7 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         """
         )
         var = astroid.body[1].value
-        self.assertRaises(exceptions.NameInferenceError, var.inferred)
+        self.assertRaises(NameInferenceError, var.inferred)
 
     def test_dict_comps(self):
         astroid = builder.parse(
@@ -211,7 +216,7 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         """
         )
         var = astroid.body[1].value
-        self.assertRaises(exceptions.NameInferenceError, var.inferred)
+        self.assertRaises(NameInferenceError, var.inferred)
 
     def test_generator_attributes(self):
         tree = builder.parse(
@@ -250,7 +255,7 @@ class LookupTest(resources.SysPathSetup, unittest.TestCase):
         self.assertTrue(p2.getattr("__name__"))
         self.assertTrue(astroid["NoName"].getattr("__name__"))
         p3 = next(astroid["p3"].infer())
-        self.assertRaises(exceptions.AttributeInferenceError, p3.getattr, "__name__")
+        self.assertRaises(AttributeInferenceError, p3.getattr, "__name__")
 
     def test_function_module_special(self):
         astroid = builder.parse(

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -29,7 +29,8 @@ import unittest
 import pkg_resources
 
 import astroid
-from astroid import exceptions, manager
+from astroid import manager
+from astroid.exceptions import AstroidBuildingError, AstroidImportError
 
 from . import resources
 
@@ -70,7 +71,7 @@ class AstroidManagerTest(
 
     def test_ast_from_file_name_astro_builder_exception(self):
         self.assertRaises(
-            exceptions.AstroidBuildingError, self.manager.ast_from_file, "unhandledName"
+            AstroidBuildingError, self.manager.ast_from_file, "unhandledName"
         )
 
     def test_ast_from_string(self):
@@ -102,7 +103,7 @@ class AstroidManagerTest(
 
     def test_ast_from_module_name_astro_builder_exception(self):
         self.assertRaises(
-            exceptions.AstroidBuildingError,
+            AstroidBuildingError,
             self.manager.ast_from_module_name,
             "unhandledModule",
         )
@@ -151,7 +152,7 @@ class AstroidManagerTest(
             submodule = next(module.igetattr("a"))
             value = next(submodule.igetattr("x"))
             self.assertIsInstance(value, astroid.Const)
-            with self.assertRaises(exceptions.AstroidImportError):
+            with self.assertRaises(AstroidImportError):
                 self.manager.ast_from_module_name("foogle.moogle")
         finally:
             del pkg_resources._namespace_packages["foogle"]
@@ -176,7 +177,7 @@ class AstroidManagerTest(
         site.addpackage(resources.RESOURCE_PATH, pth, [])
         pkg_resources._namespace_packages["foogle"] = []
         try:
-            with self.assertRaises(exceptions.AstroidImportError):
+            with self.assertRaises(AstroidImportError):
                 self.manager.ast_from_module_name("unittest.foogle.fax")
         finally:
             del pkg_resources._namespace_packages["foogle"]
@@ -235,7 +236,7 @@ class AstroidManagerTest(
     def test_file_from_module_name_astro_building_exception(self):
         """check if the method raises an exception with a wrong module name"""
         self.assertRaises(
-            exceptions.AstroidBuildingError,
+            AstroidBuildingError,
             self.manager.file_from_module_name,
             "unhandledModule",
             None,
@@ -276,22 +277,20 @@ class AstroidManagerTest(
 
     def test_ast_from_class_attr_error(self):
         """give a wrong class at the ast_from_class method"""
-        self.assertRaises(
-            exceptions.AstroidBuildingError, self.manager.ast_from_class, None
-        )
+        self.assertRaises(AstroidBuildingError, self.manager.ast_from_class, None)
 
     def testFailedImportHooks(self):
         def hook(modname):
             if modname == "foo.bar":
                 return unittest
 
-            raise exceptions.AstroidBuildingError()
+            raise AstroidBuildingError()
 
-        with self.assertRaises(exceptions.AstroidBuildingError):
+        with self.assertRaises(AstroidBuildingError):
             self.manager.ast_from_module_name("foo.bar")
         self.manager.register_failed_import_hook(hook)
         self.assertEqual(unittest, self.manager.ast_from_module_name("foo.bar"))
-        with self.assertRaises(exceptions.AstroidBuildingError):
+        with self.assertRaises(AstroidBuildingError):
             self.manager.ast_from_module_name("foo.bar.baz")
         del self.manager._failed_import_hooks[0]
 

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -39,7 +39,12 @@ import pytest
 import astroid
 from astroid import bases, builder
 from astroid import context as contextmod
-from astroid import exceptions, node_classes, nodes, parse, test_utils, transforms, util
+from astroid import node_classes, nodes, parse, test_utils, transforms, util
+from astroid.exceptions import (
+    AstroidBuildingError,
+    AstroidSyntaxError,
+    AttributeInferenceError,
+)
 
 from . import resources
 
@@ -435,13 +440,13 @@ class ImportNodeTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(from_.real_name("NameNode"), "Name")
         imp_ = self.module["os"]
         self.assertEqual(imp_.real_name("os"), "os")
-        self.assertRaises(exceptions.AttributeInferenceError, imp_.real_name, "os.path")
+        self.assertRaises(AttributeInferenceError, imp_.real_name, "os.path")
         imp_ = self.module["NameNode"]
         self.assertEqual(imp_.real_name("NameNode"), "Name")
-        self.assertRaises(exceptions.AttributeInferenceError, imp_.real_name, "Name")
+        self.assertRaises(AttributeInferenceError, imp_.real_name, "Name")
         imp_ = self.module2["YO"]
         self.assertEqual(imp_.real_name("YO"), "YO")
-        self.assertRaises(exceptions.AttributeInferenceError, imp_.real_name, "data")
+        self.assertRaises(AttributeInferenceError, imp_.real_name, "data")
 
     def test_as_string(self):
         ast = self.module["modutils"]
@@ -573,7 +578,7 @@ class NameNodeTest(unittest.TestCase):
                 pass
             del True
         """
-        with self.assertRaises(exceptions.AstroidBuildingError):
+        with self.assertRaises(AstroidBuildingError):
             builder.parse(code)
 
 
@@ -689,7 +694,7 @@ class UnboundMethodNodeTest(unittest.TestCase):
         """
         )
         node = next(ast["meth"].infer())
-        with self.assertRaises(exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             node.getattr("__missssing__")
         name = node.getattr("__name__")[0]
         self.assertIsInstance(name, nodes.Const)
@@ -943,7 +948,7 @@ class ContextTest(unittest.TestCase):
         self.assertIs(node.targets[0].ctx, astroid.Del)
 
     def test_list_store(self):
-        with self.assertRaises(exceptions.AstroidSyntaxError):
+        with self.assertRaises(AstroidSyntaxError):
             builder.extract_node("[0] = 2")
 
     def test_tuple_load(self):
@@ -951,7 +956,7 @@ class ContextTest(unittest.TestCase):
         self.assertIs(node.ctx, astroid.Load)
 
     def test_tuple_store(self):
-        with self.assertRaises(exceptions.AstroidSyntaxError):
+        with self.assertRaises(AstroidSyntaxError):
             builder.extract_node("(1, ) = 3")
 
     def test_starred_load(self):

--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -17,7 +17,8 @@ import xml
 import pytest
 
 import astroid
-from astroid import MANAGER, builder, exceptions, objects, test_utils, util
+from astroid import MANAGER, builder, objects, test_utils, util
+from astroid.exceptions import InferenceError
 
 BUILTINS = MANAGER.astroid_cache[builtins.__name__]
 
@@ -239,7 +240,7 @@ class ModuleModelTest(unittest.TestCase):
         sys.__path__ #@
         """
         )
-        with self.assertRaises(exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(ast_node.infer())
 
     def test_module_model(self):
@@ -356,7 +357,7 @@ class FunctionModelTest(unittest.TestCase):
         """
         )
         for node in ast_nodes:
-            with self.assertRaises(exceptions.InferenceError):
+            with self.assertRaises(InferenceError):
                 next(node.infer())
 
     def test_descriptor_error_regression(self):
@@ -548,7 +549,7 @@ class ExceptionModelTest(unittest.TestCase):
         self.assertIsInstance(tb, astroid.Instance)
         self.assertEqual(tb.name, "traceback")
 
-        with self.assertRaises(exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(ast_nodes[2].infer())
 
     def test_syntax_error(self):

--- a/tests/unittest_objects.py
+++ b/tests/unittest_objects.py
@@ -12,7 +12,8 @@
 
 import unittest
 
-from astroid import bases, builder, exceptions, nodes, objects
+from astroid import bases, builder, nodes, objects
+from astroid.exceptions import AttributeInferenceError, InferenceError, SuperError
 
 
 class ObjectsTest(unittest.TestCase):
@@ -216,14 +217,14 @@ class SuperTests(unittest.TestCase):
         )
         first = next(ast_nodes[0].infer())
         self.assertIsInstance(first, objects.Super)
-        with self.assertRaises(exceptions.SuperError) as cm:
+        with self.assertRaises(SuperError) as cm:
             first.super_mro()
         self.assertIsInstance(cm.exception.super_.mro_pointer, nodes.Const)
         self.assertEqual(cm.exception.super_.mro_pointer.value, 1)
         for node, invalid_type in zip(ast_nodes[1:], (nodes.Const, bases.Instance)):
             inferred = next(node.infer())
             self.assertIsInstance(inferred, objects.Super, node)
-            with self.assertRaises(exceptions.SuperError) as cm:
+            with self.assertRaises(SuperError) as cm:
                 inferred.super_mro()
             self.assertIsInstance(cm.exception.super_.type, invalid_type)
 
@@ -325,12 +326,12 @@ class SuperTests(unittest.TestCase):
         self.assertIsInstance(second, bases.BoundMethod)
         self.assertEqual(second.bound.name, "First")
 
-        with self.assertRaises(exceptions.InferenceError):
+        with self.assertRaises(InferenceError):
             next(ast_nodes[2].infer())
         fourth = next(ast_nodes[3].infer())
-        with self.assertRaises(exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             fourth.getattr("test3")
-        with self.assertRaises(exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             next(fourth.igetattr("test3"))
 
         first_unbound = next(ast_nodes[4].infer())
@@ -354,7 +355,7 @@ class SuperTests(unittest.TestCase):
         """
         )
         inferred = next(node.infer())
-        with self.assertRaises(exceptions.AttributeInferenceError):
+        with self.assertRaises(AttributeInferenceError):
             next(inferred.getattr("test"))
 
     def test_super_complex_mro(self):
@@ -458,10 +459,10 @@ class SuperTests(unittest.TestCase):
         self.assertEqualMro(third, ["A", "object"])
 
         fourth = next(ast_nodes[3].infer())
-        with self.assertRaises(exceptions.SuperError):
+        with self.assertRaises(SuperError):
             fourth.super_mro()
         fifth = next(ast_nodes[4].infer())
-        with self.assertRaises(exceptions.SuperError):
+        with self.assertRaises(SuperError):
             fifth.super_mro()
 
     def test_super_yes_objects(self):
@@ -489,9 +490,9 @@ class SuperTests(unittest.TestCase):
         """
         )
         inferred = next(node.infer())
-        with self.assertRaises(exceptions.SuperError):
+        with self.assertRaises(SuperError):
             inferred.super_mro()
-        with self.assertRaises(exceptions.SuperError):
+        with self.assertRaises(SuperError):
             inferred.super_mro()
 
     def test_super_properties(self):

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -19,7 +19,8 @@ import unittest
 import pytest
 
 import astroid
-from astroid import InferenceError, extract_node, nodes, util
+from astroid import extract_node, nodes, util
+from astroid.exceptions import InferenceError
 from astroid.node_classes import AssignName, Const, Name, Starred
 
 

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -20,9 +20,10 @@ import sys
 import textwrap
 import unittest
 
-from astroid import MANAGER, Instance, exceptions, nodes, transforms
+from astroid import MANAGER, Instance, nodes, transforms
 from astroid.bases import BUILTINS
 from astroid.builder import AstroidBuilder, extract_node
+from astroid.exceptions import InferenceError
 from astroid.manager import AstroidManager
 from astroid.raw_building import build_module
 
@@ -222,7 +223,7 @@ def test():
         next(GEN)
         """
         )
-        self.assertRaises(exceptions.InferenceError, next, node.infer())
+        self.assertRaises(InferenceError, next, node.infer())
 
     def test_unicode_in_docstring(self):
         # Crashed for astroid==1.4.1

--- a/tests/unittest_utils.py
+++ b/tests/unittest_utils.py
@@ -12,8 +12,9 @@
 
 import unittest
 
-from astroid import InferenceError, builder, node_classes, nodes
+from astroid import builder, node_classes, nodes
 from astroid import util as astroid_util
+from astroid.exceptions import InferenceError
 
 
 class InferenceUtil(unittest.TestCase):


### PR DESCRIPTION
## Description

This normalize the way the exceptions are imported. Previously there was a wildcard import of exceptions in ``astroid.__init__.py`` and then:
```python
from astroid import exceptions

exceptions.InferenceError
```

```python
import astroid

astroid.InferenceError
```
This created circular imports in all the file where it was used. The one true way **internally** is:

```python
from astroid.exceptions import InferenceError

InferenceError
```

The import should be done from astroid like before for external code (in pylint for example).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
