### PR TITLE
Fix inter-test ordering dependencies caused by AstroidManager

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -75,8 +75,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
 
     # pylint: disable=redefined-outer-name
     def __init__(self, manager=None, apply_transforms=True):
-        super().__init__()
-        self._manager = manager or MANAGER
+        super().__init__(manager)
         self._apply_transforms = apply_transforms
 
     def module_build(self, module, modname=None):

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -64,10 +64,16 @@ class AstroidManager:
             self.extension_package_whitelist = set()
             self._transform = transforms.TransformVisitor()
 
-            # Export these APIs for convenience
-            self.register_transform = self._transform.register_transform
-            self.unregister_transform = self._transform.unregister_transform
             self.max_inferable_values = 100
+
+    @property
+    def register_transform(self):
+        # This and unregister_transform below are exported for convenience
+        return self._transform.register_transform
+
+    @property
+    def unregister_transform(self):
+        return self._transform.unregister_transform
 
     @property
     def builtins_module(self):

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -290,7 +290,8 @@ class InspectBuilder:
     FunctionDef and ClassDef nodes and some others as guessed.
     """
 
-    def __init__(self):
+    def __init__(self, manager_instance=None):
+        self._manager = manager_instance or MANAGER
         self._done = {}
         self._module = None
 
@@ -309,7 +310,7 @@ class InspectBuilder:
             node = build_module(modname)
         node.file = node.path = os.path.abspath(path) if path else path
         node.name = modname
-        MANAGER.cache_module(node)
+        self._manager.cache_module(node)
         node.package = hasattr(module, "__path__")
         self._done = {}
         self.object_build(node, module)

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -20,7 +20,7 @@ from typing import Callable, Tuple
 
 import pytest
 
-from astroid import nodes
+from astroid import manager, nodes, transforms
 
 
 def require_version(minver: str = "0.0.0", maxver: str = "4.0.0") -> Callable:
@@ -70,3 +70,15 @@ def enable_warning(warning):
         # Reset it to default value, so it will take
         # into account the values from the -W flag.
         warnings.simplefilter("default", warning)
+
+
+def brainless_manager():
+    m = manager.AstroidManager()
+    # avoid caching into the AstroidManager borg since we get problems
+    # with other tests :
+    m.__dict__ = {}
+    m._failed_import_hooks = []
+    m.astroid_cache = {}
+    m._mod_file_cache = {}
+    m._transform = transforms.TransformVisitor()
+    return m

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -30,7 +30,7 @@ from contextlib import contextmanager
 import pkg_resources
 
 import astroid
-from astroid import manager
+from astroid import manager, test_utils
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 
 from . import resources
@@ -49,7 +49,7 @@ class AstroidManagerTest(
 ):
     def setUp(self):
         super().setUp()
-        self.manager = manager.AstroidManager()
+        self.manager = test_utils.brainless_manager()
 
     def test_ast_from_file(self):
         filepath = unittest.__file__

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -20,11 +20,10 @@ import sys
 import textwrap
 import unittest
 
-from astroid import MANAGER, Instance, nodes, transforms
+from astroid import MANAGER, Instance, nodes, test_utils
 from astroid.bases import BUILTINS
 from astroid.builder import AstroidBuilder, extract_node
 from astroid.exceptions import InferenceError
-from astroid.manager import AstroidManager
 from astroid.raw_building import build_module
 
 from . import resources
@@ -47,19 +46,8 @@ class NonRegressionTests(resources.AstroidCacheSetupMixin, unittest.TestCase):
         sys.path.pop(0)
         sys.path_importer_cache.pop(resources.find("data"), None)
 
-    def brainless_manager(self):
-        manager = AstroidManager()
-        # avoid caching into the AstroidManager borg since we get problems
-        # with other tests :
-        manager.__dict__ = {}
-        manager._failed_import_hooks = []
-        manager.astroid_cache = {}
-        manager._mod_file_cache = {}
-        manager._transform = transforms.TransformVisitor()
-        return manager
-
     def test_module_path(self):
-        man = self.brainless_manager()
+        man = test_utils.brainless_manager()
         mod = man.ast_from_module_name("package.import_package_subpackage_module")
         package = next(mod.igetattr("package"))
         self.assertEqual(package.name, "package")
@@ -71,7 +59,7 @@ class NonRegressionTests(resources.AstroidCacheSetupMixin, unittest.TestCase):
         self.assertEqual(module.name, "package.subpackage.module")
 
     def test_package_sidepackage(self):
-        manager = self.brainless_manager()
+        manager = test_utils.brainless_manager()
         assert "package.sidepackage" not in MANAGER.astroid_cache
         package = manager.ast_from_module_name("absimp")
         self.assertIsInstance(package, nodes.Module)


### PR DESCRIPTION
## Steps

- [ ] ~For new features or bug fixes, add a ChangeLog entry describing what your PR does.~
- [X] Write a good description on what the PR does.

## Description

A number of tests are affected by global state in the AstroidManager, which causes failures if tests are run outside of the default pytest collection order and demonstrates a failure of isolation.

### Examples

```
py.test -- tests/unittest_manager.py::AstroidManagerTest::testFailedImportHooks tests/unittest_brain.py::SixBrainTest::test_from_imports tests/unittest_brain.py::SixBrainTest::test_from_submodule_imports
py.test -- tests/unittest_builder.py::BuilderTest::test_inspect_build3 tests/unittest_manager.py::AstroidManagerTest::test_ast_from_module
py.test -- tests/unittest_manager.py::AstroidManagerTest::test_zip_import_data tests/unittest_manager.py::AstroidManagerTest::test_ast_from_module_name_zip
py.test -- tests/unittest_manager.py::AstroidManagerTest::test_zip_import_data  tests/unittest_manager.py::AstroidManagerTest::test_ast_from_module_name_egg
```

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Related Issue

None