### PR TITLE
Create a astroid.constants.py and put the python interpreter check in it

### DIFF
--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Optional
 
 import astroid
+from astroid.constants import PY38
 
 try:
     import typed_ast.ast3 as _ast_py3
@@ -12,7 +13,6 @@ except ImportError:
     _ast_py3 = None
 
 
-PY38 = sys.version_info[:2] >= (3, 8)
 if PY38:
     # On Python 3.8, typed_ast was merged back into `ast`
     _ast_py3 = ast

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -25,10 +25,10 @@ inference utils.
 
 import builtins
 import collections
-import sys
 
 from astroid import context as contextmod
 from astroid import util
+from astroid.constants import PY310
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -42,7 +42,6 @@ BUILTINS = builtins.__name__
 manager = util.lazy_import("manager")
 MANAGER = manager.AstroidManager()
 
-PY310 = sys.version_info >= (3, 10)
 
 # TODO: check if needs special treatment
 BUILTINS = "builtins"

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -8,11 +8,9 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-import sys
 
 import astroid
-
-PY39 = sys.version_info >= (3, 9)
+from astroid.constants import PY39
 
 
 def _collections_transform():

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -1,10 +1,8 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-import sys
 
 import astroid
-
-PY37 = sys.version_info >= (3, 7)
+from astroid.constants import PY37
 
 if PY37:
     # Since Python 3.7 Hashing Methods are added

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -8,7 +8,6 @@
 import collections.abc
 
 import astroid
-from astroid.constants import PY36
 
 
 def _clone_node_with_lineno(node, parent, lineno):
@@ -44,11 +43,8 @@ def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-sta
             return new_node
 
 
-if PY36:
-    # TODO: this fix tries to *patch* http://bugs.python.org/issue29051
-    # The problem is that FormattedValue.value, which is a Name node,
-    # has wrong line numbers, usually 1. This creates problems for pylint,
-    # which expects correct line numbers for things such as message control.
-    astroid.MANAGER.register_transform(
-        astroid.FormattedValue, _transform_formatted_value
-    )
+# TODO: this fix tries to *patch* http://bugs.python.org/issue29051
+# The problem is that FormattedValue.value, which is a Name node,
+# has wrong line numbers, usually 1. This creates problems for pylint,
+# which expects correct line numbers for things such as message control.
+astroid.MANAGER.register_transform(astroid.FormattedValue, _transform_formatted_value)

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -6,9 +6,9 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 import collections.abc
-import sys
 
 import astroid
+from astroid.constants import PY36
 
 
 def _clone_node_with_lineno(node, parent, lineno):
@@ -44,7 +44,7 @@ def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-sta
             return new_node
 
 
-if sys.version_info[:2] >= (3, 6):
+if PY36:
     # TODO: this fix tries to *patch* http://bugs.python.org/issue29051
     # The problem is that FormattedValue.value, which is a Name node,
     # has wrong line numbers, usually 1. This creates problems for pylint,

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -10,7 +10,6 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 import astroid
-from astroid.constants import PY36
 
 
 def _hashlib_transform():
@@ -38,21 +37,20 @@ def _hashlib_transform():
     algorithms_with_signature = dict.fromkeys(
         ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"], signature
     )
-    if PY36:
-        blake2b_signature = "data=b'', *, digest_size=64, key=b'', salt=b'', \
-                person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, \
-                node_depth=0, inner_size=0, last_node=False"
-        blake2s_signature = "data=b'', *, digest_size=32, key=b'', salt=b'', \
-                person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, \
-                node_depth=0, inner_size=0, last_node=False"
-        new_algorithms = dict.fromkeys(
-            ["sha3_224", "sha3_256", "sha3_384", "sha3_512", "shake_128", "shake_256"],
-            signature,
-        )
-        algorithms_with_signature.update(new_algorithms)
-        algorithms_with_signature.update(
-            {"blake2b": blake2b_signature, "blake2s": blake2s_signature}
-        )
+    blake2b_signature = "data=b'', *, digest_size=64, key=b'', salt=b'', \
+            person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, \
+            node_depth=0, inner_size=0, last_node=False"
+    blake2s_signature = "data=b'', *, digest_size=32, key=b'', salt=b'', \
+            person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, \
+            node_depth=0, inner_size=0, last_node=False"
+    new_algorithms = dict.fromkeys(
+        ["sha3_224", "sha3_256", "sha3_384", "sha3_512", "shake_128", "shake_256"],
+        signature,
+    )
+    algorithms_with_signature.update(new_algorithms)
+    algorithms_with_signature.update(
+        {"blake2b": blake2b_signature, "blake2s": blake2s_signature}
+    )
     classes = "".join(
         template % {"name": hashfunc, "digest": 'b""', "signature": signature}
         for hashfunc, signature in algorithms_with_signature.items()

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -8,11 +8,9 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-import sys
 
 import astroid
-
-PY36 = sys.version_info >= (3, 6)
+from astroid.constants import PY36
 
 
 def _hashlib_transform():

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -1,13 +1,9 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-import sys
 
 import astroid
 from astroid import MANAGER, context, inference_tip, nodes
-
-PY36 = sys.version_info >= (3, 6)
-PY37 = sys.version_info[:2] >= (3, 7)
-PY39 = sys.version_info[:2] >= (3, 9)
+from astroid.constants import PY36, PY37, PY39
 
 if PY36:
     # Since Python 3.6 there is the RegexFlag enum

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -3,37 +3,37 @@
 
 import astroid
 from astroid import MANAGER, context, inference_tip, nodes
-from astroid.constants import PY36, PY37, PY39
+from astroid.constants import PY37, PY39
 
-if PY36:
+
+def _re_transform():
     # Since Python 3.6 there is the RegexFlag enum
     # where every entry will be exposed via updating globals()
-
-    def _re_transform():
-        return astroid.parse(
-            """
-        import sre_compile
-        ASCII = sre_compile.SRE_FLAG_ASCII
-        IGNORECASE = sre_compile.SRE_FLAG_IGNORECASE
-        LOCALE = sre_compile.SRE_FLAG_LOCALE
-        UNICODE = sre_compile.SRE_FLAG_UNICODE
-        MULTILINE = sre_compile.SRE_FLAG_MULTILINE
-        DOTALL = sre_compile.SRE_FLAG_DOTALL
-        VERBOSE = sre_compile.SRE_FLAG_VERBOSE
-        A = ASCII
-        I = IGNORECASE
-        L = LOCALE
-        U = UNICODE
-        M = MULTILINE
-        S = DOTALL
-        X = VERBOSE
-        TEMPLATE = sre_compile.SRE_FLAG_TEMPLATE
-        T = TEMPLATE
-        DEBUG = sre_compile.SRE_FLAG_DEBUG
+    return astroid.parse(
         """
-        )
+    import sre_compile
+    ASCII = sre_compile.SRE_FLAG_ASCII
+    IGNORECASE = sre_compile.SRE_FLAG_IGNORECASE
+    LOCALE = sre_compile.SRE_FLAG_LOCALE
+    UNICODE = sre_compile.SRE_FLAG_UNICODE
+    MULTILINE = sre_compile.SRE_FLAG_MULTILINE
+    DOTALL = sre_compile.SRE_FLAG_DOTALL
+    VERBOSE = sre_compile.SRE_FLAG_VERBOSE
+    A = ASCII
+    I = IGNORECASE
+    L = LOCALE
+    U = UNICODE
+    M = MULTILINE
+    S = DOTALL
+    X = VERBOSE
+    TEMPLATE = sre_compile.SRE_FLAG_TEMPLATE
+    T = TEMPLATE
+    DEBUG = sre_compile.SRE_FLAG_DEBUG
+    """
+    )
 
-    astroid.register_module_extender(astroid.MANAGER, "re", _re_transform)
+
+astroid.register_module_extender(astroid.MANAGER, "re", _re_transform)
 
 
 CLASS_GETITEM_TEMPLATE = """

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -14,44 +14,22 @@
 import textwrap
 
 import astroid
-from astroid.constants import PY36, PY37, PY39
+from astroid.constants import PY37, PY39
 
 
 def _subprocess_transform():
     communicate = (bytes("string", "ascii"), bytes("string", "ascii"))
     communicate_signature = "def communicate(self, input=None, timeout=None)"
+    args = """\
+        self, args, bufsize=0, executable=None, stdin=None, stdout=None, stderr=None,
+        preexec_fn=None, close_fds=False, shell=False, cwd=None, env=None,
+        universal_newlines=False, startupinfo=None, creationflags=0, restore_signals=True,
+        start_new_session=False, pass_fds=(), *, encoding=None, errors=None"""
     if PY37:
-        init = """
-        def __init__(self, args, bufsize=0, executable=None,
-                     stdin=None, stdout=None, stderr=None,
-                     preexec_fn=None, close_fds=False, shell=False,
-                     cwd=None, env=None, universal_newlines=False,
-                     startupinfo=None, creationflags=0, restore_signals=True,
-                     start_new_session=False, pass_fds=(), *,
-                     encoding=None, errors=None, text=None):
-            pass
-        """
-    elif PY36:
-        init = """
-        def __init__(self, args, bufsize=0, executable=None,
-                     stdin=None, stdout=None, stderr=None,
-                     preexec_fn=None, close_fds=False, shell=False,
-                     cwd=None, env=None, universal_newlines=False,
-                     startupinfo=None, creationflags=0, restore_signals=True,
-                     start_new_session=False, pass_fds=(), *,
-                     encoding=None, errors=None):
-            pass
-        """
-    else:
-        init = """
-        def __init__(self, args, bufsize=0, executable=None,
-                     stdin=None, stdout=None, stderr=None,
-                     preexec_fn=None, close_fds=False, shell=False,
-                     cwd=None, env=None, universal_newlines=False,
-                     startupinfo=None, creationflags=0, restore_signals=True,
-                     start_new_session=False, pass_fds=()):
-            pass
-        """
+        args += ", text=None"
+    init = f"""
+        def __init__({args}):
+            pass"""
     wait_signature = "def wait(self, timeout=None)"
     ctx_manager = """
         def __enter__(self): return self

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -11,14 +11,10 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-import sys
 import textwrap
 
 import astroid
-
-PY39 = sys.version_info >= (3, 9)
-PY37 = sys.version_info >= (3, 7)
-PY36 = sys.version_info >= (3, 6)
+from astroid.constants import PY36, PY37, PY39
 
 
 def _subprocess_transform():

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -15,12 +15,10 @@ Doing this type[int] is allowed whereas str[int] is not.
 
 Thanks to Lukasz Langa for fruitful discussion.
 """
-import sys
 
 from astroid import MANAGER, extract_node, inference_tip, nodes
+from astroid.constants import PY39
 from astroid.exceptions import UseInferenceDefault
-
-PY39 = sys.version_info >= (3, 9)
 
 
 def _looks_like_type_subscript(node):

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -10,20 +10,17 @@
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 
 """Astroid hooks for typing.py support."""
-import sys
 import typing
 from functools import partial
 
 import astroid
 from astroid import MANAGER, context, extract_node, inference_tip, node_classes, nodes
+from astroid.constants import PY37, PY39
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
     UseInferenceDefault,
 )
-
-PY37 = sys.version_info[:2] >= (3, 7)
-PY39 = sys.version_info[:2] >= (3, 9)
 
 TYPING_NAMEDTUPLE_BASENAMES = {"NamedTuple", "typing.NamedTuple"}
 TYPING_TYPEVARS = {"TypeVar", "NewType"}

--- a/astroid/constants.py
+++ b/astroid/constants.py
@@ -1,6 +1,5 @@
 import sys
 
-PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)

--- a/astroid/constants.py
+++ b/astroid/constants.py
@@ -1,0 +1,7 @@
+import sys
+
+PY36 = sys.version_info >= (3, 6)
+PY37 = sys.version_info >= (3, 7)
+PY38 = sys.version_info >= (3, 8)
+PY39 = sys.version_info >= (3, 9)
+PY310 = sys.version_info >= (3, 10)

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -29,7 +29,6 @@
 order to get a single Astroid representation
 """
 
-import sys
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -44,6 +43,8 @@ from typing import (
     cast,
     overload,
 )
+
+from astroid.constants import PY37, PY38, PY39
 
 try:
     from typing import Final
@@ -70,9 +71,7 @@ REDIRECT: Final[Dict[str, str]] = {
     "keyword": "Keyword",
     "match_case": "MatchCase",
 }
-PY37 = sys.version_info >= (3, 7)
-PY38 = sys.version_info >= (3, 8)
-PY39 = sys.version_info >= (3, 9)
+
 
 T_Doc = TypeVar(
     "T_Doc",

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -41,13 +41,13 @@ Lambda, GeneratorExp, DictComp and SetComp to some extent).
 import builtins
 import io
 import itertools
-import sys
 from typing import List, Optional
 
 from astroid import bases
 from astroid import context as contextmod
 from astroid import decorators as decorators_mod
 from astroid import manager, mixins, node_classes, util
+from astroid.constants import PY36, PY39
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidTypeError,
@@ -59,8 +59,6 @@ from astroid.exceptions import (
     TooManyLevelsError,
 )
 from astroid.interpreter import dunder_lookup, objectmodel
-
-PY39 = sys.version_info[:2] >= (3, 9)
 
 BUILTINS = builtins.__name__
 ITER_METHODS = ("__iter__", "__getitem__")
@@ -1516,7 +1514,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         if isinstance(frame, ClassDef):
             if self.name == "__new__":
                 return "classmethod"
-            if sys.version_info >= (3, 6) and self.name == "__init_subclass__":
+            if PY36 and self.name == "__init_subclass__":
                 return "classmethod"
 
             type_name = "method"

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -47,7 +47,7 @@ from astroid import bases
 from astroid import context as contextmod
 from astroid import decorators as decorators_mod
 from astroid import manager, mixins, node_classes, util
-from astroid.constants import PY36, PY39
+from astroid.constants import PY39
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidTypeError,
@@ -1514,7 +1514,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         if isinstance(frame, ClassDef):
             if self.name == "__new__":
                 return "classmethod"
-            if PY36 and self.name == "__init_subclass__":
+            if self.name == "__init_subclass__":
                 return "classmethod"
 
             type_name = "method"

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -39,7 +39,7 @@ def require_version(minver=None, maxver=None):
             ) from exc
 
     def check_require_version(f):
-        current = sys.version_info[:3]
+        current = sys.version_info[:3]  # TODO
         if parse(minver, "0") < current <= parse(maxver, "4"):
             return f
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1355,7 +1355,6 @@ class CollectionsBrain(unittest.TestCase):
         )
 
 
-@test_utils.require_version("3.6")
 class TypingBrain(unittest.TestCase):
     def test_namedtuple_base(self):
         klass = builder.extract_node(

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -44,6 +44,7 @@ import pytest
 
 import astroid
 from astroid import MANAGER, bases, builder, nodes, objects, test_utils, util
+from astroid.constants import PY37
 from astroid.exceptions import AttributeInferenceError, InferenceError
 
 try:
@@ -2730,7 +2731,7 @@ def test_http_client_brain():
     assert isinstance(inferred, astroid.Instance)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="Needs 3.7+")
+@pytest.mark.skipif(not PY37, reason="Needs 3.7+")
 def test_http_status_brain():
     node = astroid.extract_node(
         """
@@ -2767,9 +2768,7 @@ def test_oserror_model():
     assert strerror.value == ""
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Dynamic module attributes since Python 3.7"
-)
+@pytest.mark.skipif(not PY37, reason="Dynamic module attributes since Python 3.7")
 def test_crypt_brain():
     module = MANAGER.ast_from_module_name("crypt")
     dynamic_attrs = [
@@ -2783,7 +2782,7 @@ def test_crypt_brain():
         assert attr in module
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="Dataclasses were added in 3.7")
+@pytest.mark.skipif(not PY37, reason="Dataclasses were added in 3.7")
 def test_dataclasses():
     code = """
     import dataclasses

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -31,6 +31,7 @@ import unittest
 import pytest
 
 from astroid import Instance, builder, manager, nodes, test_utils, util
+from astroid.constants import PY38
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -42,7 +43,6 @@ from . import resources
 
 MANAGER = manager.AstroidManager()
 BUILTINS = builtins.__name__
-PY38 = sys.version_info[:2] >= (3, 8)
 
 
 class FromToLineNoTest(unittest.TestCase):
@@ -750,7 +750,7 @@ def test_module_build_dunder_file():
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] >= (3, 8),
+    PY38,
     reason=(
         "The builtin ast module does not fail with a specific error "
         "for syntax error caused by invalid type comments."

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -37,7 +37,6 @@
 """Tests for the astroid inference capabilities"""
 
 import platform
-import sys
 import textwrap
 import unittest
 from functools import partial
@@ -50,6 +49,7 @@ from astroid import decorators as decoratorsmod
 from astroid import helpers, nodes, objects, test_utils, util
 from astroid.bases import BUILTINS, BoundMethod, Instance, UnboundMethod
 from astroid.builder import extract_node, parse
+from astroid.constants import PY38, PY39
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -932,7 +932,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual("module.D", should_be_D[0].qname())
 
     @pytest.mark.skipif(
-        sys.version_info >= (3, 8),
+        PY38,
         reason="pathlib.Path cannot be inferred on Python 3.8",
     )
     def test_factory_methods_inside_binary_operation(self):
@@ -2495,7 +2495,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ]
 
         # PEP-584 supports | for dictionary union
-        if sys.version_info < (3, 9):
+        if not PY39:
             ast_nodes.append(extract_node("{} | {} #@"))
             expected.append(msg.format(op="|", lhs="dict", rhs="dict"))
 
@@ -5882,9 +5882,9 @@ def test_custom_decorators_for_classmethod_and_staticmethods(code, obj, obj_type
     assert inferred.type == obj_type
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="Needs dataclasses available")
+@pytest.mark.skipif(not PY38, reason="Needs dataclasses available")
 @pytest.mark.skipif(
-    sys.version_info >= (3, 9),
+    PY39,
     reason="Exact inference with dataclasses (replace function) in python3.9",
 )
 def test_dataclasses_subscript_inference_recursion_error():
@@ -5908,7 +5908,7 @@ def test_dataclasses_subscript_inference_recursion_error():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 9),
+    not PY39,
     reason="Exact inference with dataclasses (replace function) in python3.9",
 )
 def test_dataclasses_subscript_inference_recursion_error_39():

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -40,6 +40,7 @@ import astroid
 from astroid import bases, builder
 from astroid import context as contextmod
 from astroid import node_classes, nodes, parse, test_utils, transforms, util
+from astroid.constants import PY38, PY310
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -50,7 +51,6 @@ from . import resources
 
 abuilder = builder.AstroidBuilder()
 BUILTINS = builtins.__name__
-PY38 = sys.version_info[:2] >= (3, 8)
 try:
     import typed_ast  # pylint: disable=unused-import
 
@@ -265,7 +265,7 @@ class D(metaclass=abc.ABCMeta):
     # This test is disabled on PyPy because we cannot get a release that has proper
     # support for f-strings (we need 7.2 at least)
     @pytest.mark.skipif(
-        sys.version_info[:2] < (3, 6) or platform.python_implementation() == "PyPy",
+        platform.python_implementation() == "PyPy",
         reason="Needs f-string support.",
     )
     def test_f_strings(self):
@@ -1237,7 +1237,6 @@ class AsyncGeneratorTest:
         assert inferred.display_type() == "Generator"
 
 
-@pytest.mark.skipif(sys.version_info[:2] < (3, 6), reason="needs f-string support")
 def test_f_string_correct_line_numbering():
     """Test that we generate correct line numbers for f-strings"""
     node = astroid.extract_node(
@@ -1253,9 +1252,7 @@ def test_f_string_correct_line_numbering():
     assert node.last_child().last_child().lineno == 5
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 8), reason="needs assignment expressions"
-)
+@pytest.mark.skipif(not PY38, reason="needs assignment expressions")
 def test_assignment_expression():
     code = """
     if __(a := 1):
@@ -1371,9 +1368,7 @@ def test_is_generator_for_yield_in_aug_assign():
     assert bool(node.is_generator())
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="pattern matching was added in PY310"
-)
+@pytest.mark.skipif(not PY310, reason="pattern matching was added in PY310")
 class TestPatternMatching:
     @staticmethod
     def test_match_simple():

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -13,13 +13,13 @@
 
 
 import contextlib
-import sys
 import unittest
 
 import pytest
 
 import astroid
 from astroid import extract_node, nodes, util
+from astroid.constants import PY38
 from astroid.exceptions import InferenceError
 from astroid.node_classes import AssignName, Const, Name, Starred
 
@@ -211,9 +211,7 @@ class ProtocolTests(unittest.TestCase):
         parsed.accept(Visitor())
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 8), reason="needs assignment expressions"
-)
+@pytest.mark.skipif(not PY38, reason="needs assignment expressions")
 def test_named_expr_inference():
     code = """
     if (a := 2) == 2:


### PR DESCRIPTION

## Description

Little clearer code, the constants.py will be useful to avoid circular imports, and this is a performance improvment as the version checks will be done once instead of multiple time during parsing.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
