### PR TITLE
Break avoidable cyclic import, apply isort on ``astroid.__init__.py``

### DIFF
--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -13,6 +13,7 @@
 from astroid import bases
 from astroid import context as contextmod
 from astroid import nodes, util
+from astroid.context import CallContext
 from astroid.exceptions import InferenceError, NoDefault
 
 
@@ -33,7 +34,9 @@ class CallSite:
         An instance of :class:`astroid.context.Context`.
     """
 
-    def __init__(self, callcontext, argument_context_map=None, context=None):
+    def __init__(
+        self, callcontext: CallContext, argument_context_map=None, context=None
+    ):
         if argument_context_map is None:
             argument_context_map = {}
         self.argument_context_map = argument_context_map

--- a/astroid/brain/brain_boto3.py
+++ b/astroid/brain/brain_boto3.py
@@ -2,8 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for understanding boto3.ServiceRequest()"""
-import astroid
 from astroid import MANAGER, extract_node
+from astroid.scoped_nodes import ClassDef
 
 BOTO_SERVICE_FACTORY_QUALIFIED_NAME = "boto3.resources.base.ServiceResource"
 
@@ -24,5 +24,5 @@ def _looks_like_boto3_service_request(node):
 
 
 MANAGER.register_transform(
-    astroid.ClassDef, service_request_transform, _looks_like_boto3_service_request
+    ClassDef, service_request_transform, _looks_like_boto3_service_request
 )

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -1,8 +1,8 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 from astroid.const import PY37
 
 if PY37:
@@ -10,7 +10,7 @@ if PY37:
     # dynamically to globals()
 
     def _re_transform():
-        return astroid.parse(
+        return parse(
             """
         from collections import namedtuple
         _Method = namedtuple('_Method', 'name ident salt_chars total_size')
@@ -23,4 +23,4 @@ if PY37:
         """
         )
 
-    register_module_extender(astroid.MANAGER, "crypt", _re_transform)
+    register_module_extender(MANAGER, "crypt", _re_transform)

--- a/astroid/brain/brain_curses.py
+++ b/astroid/brain/brain_curses.py
@@ -1,11 +1,12 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def _curses_transform():
-    return astroid.parse(
+    return parse(
         """
     A_ALTCHARSET = 1
     A_BLINK = 1
@@ -177,4 +178,4 @@ def _curses_transform():
     )
 
 
-register_module_extender(astroid.MANAGER, "curses", _curses_transform)
+register_module_extender(MANAGER, "curses", _curses_transform)

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -7,7 +7,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 import collections.abc
 
-import astroid
+from astroid import MANAGER
+from astroid.node_classes import FormattedValue
 
 
 def _clone_node_with_lineno(node, parent, lineno):
@@ -33,7 +34,7 @@ def _clone_node_with_lineno(node, parent, lineno):
 def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-statements
     if node.value and node.value.lineno == 1:
         if node.lineno != node.value.lineno:
-            new_node = astroid.FormattedValue(
+            new_node = FormattedValue(
                 lineno=node.lineno, col_offset=node.col_offset, parent=node.parent
             )
             new_value = _clone_node_with_lineno(
@@ -47,4 +48,4 @@ def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-sta
 # The problem is that FormattedValue.value, which is a Name node,
 # has wrong line numbers, usually 1. This creates problems for pylint,
 # which expects correct line numbers for things such as message control.
-astroid.MANAGER.register_transform(astroid.FormattedValue, _transform_formatted_value)
+MANAGER.register_transform(FormattedValue, _transform_formatted_value)

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -8,9 +8,9 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def _hashlib_transform():
@@ -56,7 +56,7 @@ def _hashlib_transform():
         template % {"name": hashfunc, "digest": 'b""', "signature": signature}
         for hashfunc, signature in algorithms_with_signature.items()
     )
-    return astroid.parse(classes)
+    return parse(classes)
 
 
-register_module_extender(astroid.MANAGER, "hashlib", _hashlib_transform)
+register_module_extender(MANAGER, "hashlib", _hashlib_transform)

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -8,7 +8,7 @@
 """Astroid brain hints for some of the `http` module."""
 import textwrap
 
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 
@@ -139,11 +139,11 @@ def _http_transform():
             'The client needs to authenticate to gain network access')
     """
     )
-    return AstroidBuilder(astroid.MANAGER).string_build(code)
+    return AstroidBuilder(MANAGER).string_build(code)
 
 
 def _http_client_transform():
-    return AstroidBuilder(astroid.MANAGER).string_build(
+    return AstroidBuilder(MANAGER).string_build(
         textwrap.dedent(
             """
     from http import HTTPStatus
@@ -210,5 +210,5 @@ def _http_client_transform():
     )
 
 
-register_module_extender(astroid.MANAGER, "http", _http_transform)
-register_module_extender(astroid.MANAGER, "http.client", _http_client_transform)
+register_module_extender(MANAGER, "http", _http_transform)
+register_module_extender(MANAGER, "http.client", _http_client_transform)

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -15,8 +15,8 @@ defined using the `@hypothesis.strategies.composite` decorator.  For example:
     a_strategy()
 
 """
-
-import astroid
+from astroid import MANAGER
+from astroid.scoped_nodes import FunctionDef
 
 COMPOSITE_NAMES = (
     "composite",
@@ -46,8 +46,8 @@ def remove_draw_parameter_from_composite_strategy(node):
     return node
 
 
-astroid.MANAGER.register_transform(
-    node_class=astroid.FunctionDef,
+MANAGER.register_transform(
+    node_class=FunctionDef,
     transform=remove_draw_parameter_from_composite_strategy,
     predicate=is_decorated_with_st_composite,
 )

--- a/astroid/brain/brain_io.py
+++ b/astroid/brain/brain_io.py
@@ -6,8 +6,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid brain hints for some of the _io C objects."""
-
-import astroid
+from astroid import MANAGER, ClassDef
 
 BUFFERED = {"BufferedWriter", "BufferedReader"}
 TextIOWrapper = "TextIOWrapper"
@@ -18,7 +17,7 @@ BufferedWriter = "BufferedWriter"
 def _generic_io_transform(node, name, cls):
     """Transform the given name, by adding the given *class* as a member of the node."""
 
-    io_module = astroid.MANAGER.ast_from_module_name("_io")
+    io_module = MANAGER.ast_from_module_name("_io")
     attribute_object = io_module[cls]
     instance = attribute_object.instantiate_class()
     node.locals[name] = [instance]
@@ -36,11 +35,9 @@ def _transform_buffered(node):
     return _generic_io_transform(node, name="raw", cls=FileIO)
 
 
-astroid.MANAGER.register_transform(
-    astroid.ClassDef, _transform_buffered, lambda node: node.name in BUFFERED
+MANAGER.register_transform(
+    ClassDef, _transform_buffered, lambda node: node.name in BUFFERED
 )
-astroid.MANAGER.register_transform(
-    astroid.ClassDef,
-    _transform_text_io_wrapper,
-    lambda node: node.name == TextIOWrapper,
+MANAGER.register_transform(
+    ClassDef, _transform_text_io_wrapper, lambda node: node.name == TextIOWrapper
 )

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -12,7 +12,6 @@
 import re
 import textwrap
 
-import astroid
 import astroid.builder
 from astroid.brain.helpers import register_module_extender
 from astroid.exceptions import InferenceError

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -7,13 +7,13 @@
 
 
 """Astroid hooks for numpy.core.fromnumeric module."""
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def numpy_core_fromnumeric_transform():
-    return astroid.parse(
+    return parse(
         """
     def sum(a, axis=None, dtype=None, out=None, keepdims=None, initial=None):
         return numpy.ndarray([0, 0])
@@ -22,5 +22,5 @@ def numpy_core_fromnumeric_transform():
 
 
 register_module_extender(
-    astroid.MANAGER, "numpy.core.fromnumeric", numpy_core_fromnumeric_transform
+    MANAGER, "numpy.core.fromnumeric", numpy_core_fromnumeric_transform
 )

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -11,8 +11,10 @@
 
 import functools
 
-import astroid
+from astroid.inference_tip import inference_tip
+from astroid.node_classes import Attribute
 
+from .. import MANAGER
 from .brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 
 METHODS_TO_BE_INFERRED = {
@@ -26,8 +28,8 @@ METHODS_TO_BE_INFERRED = {
 
 for func_name, func_src in METHODS_TO_BE_INFERRED.items():
     inference_function = functools.partial(infer_numpy_member, func_src)
-    astroid.MANAGER.register_transform(
-        astroid.Attribute,
-        astroid.inference_tip(inference_function),
+    MANAGER.register_transform(
+        Attribute,
+        inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, func_name),
     )

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -11,13 +11,16 @@
 
 import functools
 
-import astroid
+from astroid import MANAGER
 from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
+from astroid.inference_tip import inference_tip
+from astroid.node_classes import Attribute, Name
 
 
 def numpy_core_multiarray_transform():
-    return astroid.parse(
+    return parse(
         """
     # different functions defined in multiarray.py
     def inner(a, b):
@@ -30,7 +33,7 @@ def numpy_core_multiarray_transform():
 
 
 register_module_extender(
-    astroid.MANAGER, "numpy.core.multiarray", numpy_core_multiarray_transform
+    MANAGER, "numpy.core.multiarray", numpy_core_multiarray_transform
 )
 
 
@@ -85,13 +88,13 @@ METHODS_TO_BE_INFERRED = {
 
 for method_name, function_src in METHODS_TO_BE_INFERRED.items():
     inference_function = functools.partial(infer_numpy_member, function_src)
-    astroid.MANAGER.register_transform(
-        astroid.Attribute,
-        astroid.inference_tip(inference_function),
+    MANAGER.register_transform(
+        Attribute,
+        inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),
     )
-    astroid.MANAGER.register_transform(
-        astroid.Name,
-        astroid.inference_tip(inference_function),
+    MANAGER.register_transform(
+        Name,
+        inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),
     )

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -11,13 +11,16 @@
 
 import functools
 
-import astroid
+from astroid import MANAGER
 from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
+from astroid.inference_tip import inference_tip
+from astroid.node_classes import Attribute
 
 
 def numpy_core_numeric_transform():
-    return astroid.parse(
+    return parse(
         """
     # different functions defined in numeric.py
     import numpy
@@ -28,9 +31,7 @@ def numpy_core_numeric_transform():
     )
 
 
-register_module_extender(
-    astroid.MANAGER, "numpy.core.numeric", numpy_core_numeric_transform
-)
+register_module_extender(MANAGER, "numpy.core.numeric", numpy_core_numeric_transform)
 
 
 METHODS_TO_BE_INFERRED = {
@@ -41,8 +42,8 @@ METHODS_TO_BE_INFERRED = {
 
 for method_name, function_src in METHODS_TO_BE_INFERRED.items():
     inference_function = functools.partial(infer_numpy_member, function_src)
-    astroid.MANAGER.register_transform(
-        astroid.Attribute,
-        astroid.inference_tip(inference_function),
+    MANAGER.register_transform(
+        Attribute,
+        inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),
     )

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -8,9 +8,9 @@
 # TODO(hippo91) : correct the methods signature.
 
 """Astroid hooks for numpy.core.numerictypes module."""
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def numpy_core_numerictypes_transform():
@@ -18,7 +18,7 @@ def numpy_core_numerictypes_transform():
     #       According to numpy doc the generic object should expose
     #       the same API than ndarray. This has been done here partially
     #       through the astype method.
-    return astroid.parse(
+    return parse(
         """
     # different types defined in numerictypes.py
     class generic(object):
@@ -255,5 +255,5 @@ def numpy_core_numerictypes_transform():
 
 
 register_module_extender(
-    astroid.MANAGER, "numpy.core.numerictypes", numpy_core_numerictypes_transform
+    MANAGER, "numpy.core.numerictypes", numpy_core_numerictypes_transform
 )

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -10,9 +10,9 @@
 # typecheck in `_emit_no_member` function)
 
 """Astroid hooks for numpy.core.umath module."""
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def numpy_core_umath_transform():
@@ -20,7 +20,7 @@ def numpy_core_umath_transform():
         """out=None, where=True, casting='same_kind', order='K', """
         """dtype=None, subok=True"""
     )
-    return astroid.parse(
+    return parse(
         """
     class FakeUfunc:
         def __init__(self):
@@ -152,6 +152,4 @@ def numpy_core_umath_transform():
     )
 
 
-register_module_extender(
-    astroid.MANAGER, "numpy.core.umath", numpy_core_umath_transform
-)
+register_module_extender(MANAGER, "numpy.core.umath", numpy_core_umath_transform)

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -8,8 +8,10 @@
 
 
 """Astroid hooks for numpy ndarray class."""
-
-import astroid
+from astroid import MANAGER
+from astroid.builder import extract_node
+from astroid.inference_tip import inference_tip
+from astroid.node_classes import Attribute
 
 
 def infer_numpy_ndarray(node, context=None):
@@ -140,16 +142,16 @@ def infer_numpy_ndarray(node, context=None):
         def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False): return np.ndarray([0, 0])
         def view(self, dtype=None, type=None): return np.ndarray([0, 0])
     """
-    node = astroid.extract_node(ndarray)
+    node = extract_node(ndarray)
     return node.infer(context=context)
 
 
 def _looks_like_numpy_ndarray(node):
-    return isinstance(node, astroid.Attribute) and node.attrname == "ndarray"
+    return isinstance(node, Attribute) and node.attrname == "ndarray"
 
 
-astroid.MANAGER.register_transform(
-    astroid.Attribute,
-    astroid.inference_tip(infer_numpy_ndarray),
+MANAGER.register_transform(
+    Attribute,
+    inference_tip(infer_numpy_ndarray),
     _looks_like_numpy_ndarray,
 )

--- a/astroid/brain/brain_numpy_random_mtrand.py
+++ b/astroid/brain/brain_numpy_random_mtrand.py
@@ -7,13 +7,13 @@
 
 # TODO(hippo91) : correct the functions return types
 """Astroid hooks for numpy.random.mtrand module."""
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def numpy_random_mtrand_transform():
-    return astroid.parse(
+    return parse(
         """
     def beta(a, b, size=None): return uninferable
     def binomial(n, p, size=None): return uninferable
@@ -69,6 +69,4 @@ def numpy_random_mtrand_transform():
     )
 
 
-register_module_extender(
-    astroid.MANAGER, "numpy.random.mtrand", numpy_random_mtrand_transform
-)
+register_module_extender(MANAGER, "numpy.random.mtrand", numpy_random_mtrand_transform)

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -7,17 +7,16 @@
 
 
 """Different utilities for the numpy brains"""
-
-
-import astroid
+from astroid.builder import extract_node
+from astroid.node_classes import Attribute, Import, Name, NodeNG
 
 
 def infer_numpy_member(src, node, context=None):
-    node = astroid.extract_node(src)
+    node = extract_node(src)
     return node.infer(context=context)
 
 
-def _is_a_numpy_module(node: astroid.node_classes.Name) -> bool:
+def _is_a_numpy_module(node: Name) -> bool:
     """
     Returns True if the node is a representation of a numpy module.
 
@@ -31,7 +30,7 @@ def _is_a_numpy_module(node: astroid.node_classes.Name) -> bool:
     """
     module_nickname = node.name
     potential_import_target = [
-        x for x in node.lookup(module_nickname)[1] if isinstance(x, astroid.Import)
+        x for x in node.lookup(module_nickname)[1] if isinstance(x, Import)
     ]
     for target in potential_import_target:
         if ("numpy", module_nickname) in target.names or (
@@ -42,9 +41,7 @@ def _is_a_numpy_module(node: astroid.node_classes.Name) -> bool:
     return False
 
 
-def looks_like_numpy_member(
-    member_name: str, node: astroid.node_classes.NodeNG
-) -> bool:
+def looks_like_numpy_member(member_name: str, node: NodeNG) -> bool:
     """
     Returns True if the node is a member of numpy whose
     name is member_name.
@@ -54,14 +51,14 @@ def looks_like_numpy_member(
     :return: True if the node is a member of numpy
     """
     if (
-        isinstance(node, astroid.Attribute)
+        isinstance(node, Attribute)
         and node.attrname == member_name
-        and isinstance(node.expr, astroid.Name)
+        and isinstance(node.expr, Name)
         and _is_a_numpy_module(node.expr)
     ):
         return True
     if (
-        isinstance(node, astroid.Name)
+        isinstance(node, Name)
         and node.name == member_name
         and node.root().name.startswith("numpy")
     ):

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -1,16 +1,15 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-
-import astroid
 from astroid import MANAGER, context, inference_tip, nodes
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import extract_node, parse
 from astroid.const import PY37, PY39
 
 
 def _re_transform():
     # Since Python 3.6 there is the RegexFlag enum
     # where every entry will be exposed via updating globals()
-    return astroid.parse(
+    return parse(
         """
     import sre_compile
     ASCII = sre_compile.SRE_FLAG_ASCII
@@ -34,7 +33,7 @@ def _re_transform():
     )
 
 
-register_module_extender(astroid.MANAGER, "re", _re_transform)
+register_module_extender(MANAGER, "re", _re_transform)
 
 
 CLASS_GETITEM_TEMPLATE = """
@@ -73,7 +72,7 @@ def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext = None):
         parent=node.parent,
     )
     if PY39:
-        func_to_add = astroid.extract_node(CLASS_GETITEM_TEMPLATE)
+        func_to_add = extract_node(CLASS_GETITEM_TEMPLATE)
         class_def.locals["__class_getitem__"] = [func_to_add]
     return iter([class_def])
 

--- a/astroid/brain/brain_responses.py
+++ b/astroid/brain/brain_responses.py
@@ -7,12 +7,13 @@ It might need to be manually updated from the public methods of
 See: https://github.com/getsentry/responses/blob/master/responses.py
 
 """
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def responses_funcs():
-    return astroid.parse(
+    return parse(
         """
         DELETE = "DELETE"
         GET = "GET"
@@ -71,4 +72,4 @@ def responses_funcs():
     )
 
 
-register_module_extender(astroid.MANAGER, "responses", responses_funcs)
+register_module_extender(MANAGER, "responses", responses_funcs)

--- a/astroid/brain/brain_scipy_signal.py
+++ b/astroid/brain/brain_scipy_signal.py
@@ -8,13 +8,13 @@
 
 
 """Astroid hooks for scipy.signal module."""
-
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def scipy_signal():
-    return astroid.parse(
+    return parse(
         """
     # different functions defined in scipy.signals
 
@@ -90,4 +90,4 @@ def scipy_signal():
     )
 
 
-register_module_extender(astroid.MANAGER, "scipy.signal", scipy_signal)
+register_module_extender(MANAGER, "scipy.signal", scipy_signal)

--- a/astroid/brain/brain_sqlalchemy.py
+++ b/astroid/brain/brain_sqlalchemy.py
@@ -1,9 +1,10 @@
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def _session_transform():
-    return astroid.parse(
+    return parse(
         """
     from sqlalchemy.orm.session import Session
 
@@ -31,4 +32,4 @@ def _session_transform():
     )
 
 
-register_module_extender(astroid.MANAGER, "sqlalchemy.orm.session", _session_transform)
+register_module_extender(MANAGER, "sqlalchemy.orm.session", _session_transform)

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -13,8 +13,9 @@
 
 import textwrap
 
-import astroid
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 from astroid.const import PY37, PY39
 
 
@@ -135,7 +136,7 @@ def _subprocess_transform():
     init_lines = textwrap.dedent(init).splitlines()
     indented_init = "\n".join(" " * 4 + line for line in init_lines)
     code += indented_init
-    return astroid.parse(code)
+    return parse(code)
 
 
-register_module_extender(astroid.MANAGER, "subprocess", _subprocess_transform)
+register_module_extender(MANAGER, "subprocess", _subprocess_transform)

--- a/astroid/brain/brain_threading.py
+++ b/astroid/brain/brain_threading.py
@@ -5,12 +5,14 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-import astroid
+
+from astroid import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.builder import parse
 
 
 def _thread_transform():
-    return astroid.parse(
+    return parse(
         """
     class lock(object):
         def acquire(self, blocking=True, timeout=-1):
@@ -30,4 +32,4 @@ def _thread_transform():
     )
 
 
-register_module_extender(astroid.MANAGER, "threading", _thread_transform)
+register_module_extender(MANAGER, "threading", _thread_transform)

--- a/astroid/brain/brain_uuid.py
+++ b/astroid/brain/brain_uuid.py
@@ -6,16 +6,16 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for the UUID module."""
-
-
-from astroid import MANAGER, nodes
+from astroid import MANAGER
+from astroid.node_classes import Const
+from astroid.scoped_nodes import ClassDef
 
 
 def _patch_uuid_class(node):
     # The .int member is patched using __dict__
-    node.locals["int"] = [nodes.Const(0, parent=node)]
+    node.locals["int"] = [Const(0, parent=node)]
 
 
 MANAGER.register_transform(
-    nodes.ClassDef, _patch_uuid_class, lambda node: node.qname() == "uuid.UUID"
+    ClassDef, _patch_uuid_class, lambda node: node.qname() == "uuid.UUID"
 )

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -44,23 +44,21 @@ from typing import (
     overload,
 )
 
-from astroid.const import PY37, PY38, PY39, Context
-
 try:
     from typing import Final
 except ImportError:
     # typing.Final was added in Python 3.8
     from typing_extensions import Final
 
-import astroid
 from astroid import node_classes, nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
-from astroid.node_classes import NodeNG
+from astroid.const import PY37, PY38, PY39, Context
+from astroid.manager import AstroidManager
+from astroid.node_classes import ExceptHandler, NodeNG
 
 if TYPE_CHECKING:
     import ast
 
-    from astroid.manager import AstroidManager
 
 REDIRECT: Final[Dict[str, str]] = {
     "arguments": "Arguments",
@@ -88,7 +86,7 @@ class TreeRebuilder:
     """Rebuilds the _ast tree to become an Astroid tree"""
 
     def __init__(
-        self, manager: "AstroidManager", parser_module: Optional[ParserModule] = None
+        self, manager: AstroidManager, parser_module: Optional[ParserModule] = None
     ):
         self._manager = manager
         self._global_names: List[Dict[str, List[nodes.Global]]] = []
@@ -1041,7 +1039,7 @@ class TreeRebuilder:
         elif context == Context.Store:
             newnode = nodes.AssignAttr(node.attr, node.lineno, node.col_offset, parent)
             # Prohibit a local save if we are in an ExceptHandler.
-            if not isinstance(parent, astroid.ExceptHandler):
+            if not isinstance(parent, ExceptHandler):
                 self._delayed_assattr.append(newnode)
         else:
             newnode = nodes.Attribute(node.attr, node.lineno, node.col_offset, parent)

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -58,7 +58,8 @@ from astroid.exceptions import (
     MroError,
     TooManyLevelsError,
 )
-from astroid.interpreter import dunder_lookup, objectmodel
+from astroid.interpreter.dunder_lookup import lookup
+from astroid.interpreter.objectmodel import ClassModel, FunctionModel, ModuleModel
 
 BUILTINS = builtins.__name__
 ITER_METHODS = ("__iter__", "__getitem__")
@@ -427,7 +428,7 @@ class Module(LocalsDictNodeNG):
 
     :type: set(str) or None
     """
-    special_attributes = objectmodel.ModuleModel()
+    special_attributes = ModuleModel()
     """The names of special attributes that this module has.
 
     :type: objectmodel.ModuleModel
@@ -1349,7 +1350,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
 
     :type: Decorators or None
     """
-    special_attributes = objectmodel.FunctionModel()
+    special_attributes = FunctionModel()
     """The names of special attributes that this function has.
 
     :type: objectmodel.FunctionModel
@@ -1945,7 +1946,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
     :type: Decorators or None
     """
-    special_attributes = objectmodel.ClassModel()
+    special_attributes = ClassModel()
     """The names of special attributes that this class has.
 
     :type: objectmodel.ClassModel
@@ -2653,7 +2654,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             ``__getitem__`` method.
         """
         try:
-            methods = dunder_lookup.lookup(self, "__getitem__")
+            methods = lookup(self, "__getitem__")
         except AttributeInferenceError as exc:
             if isinstance(self, ClassDef):
                 # subscripting a class definition may be


### PR DESCRIPTION
## Description

This breaks a number of existing cyclic import. Enough to sort ``__init__.py``, not enough to enable the cyclic-import warning in pylint.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
