### PR TITLE
Small fixes in pre commit configuration before adding mypy/pylint.extensions.docparams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,4 +59,4 @@ repos:
         language: system
         types: [python]
         args: ["-rn", "-sn", "--rcfile=pylintrc"]
-        exclude: tests/testdata|setup.py|conf.py
+        exclude: tests/testdata|conf.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,12 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        args: ["-rn", "-sn", "--rcfile=pylintrc"]
+        args: [
+            "-rn",
+            "-sn",
+            "--rcfile=pylintrc",
+            # "--load-plugins=pylint.extensions.docparams", We're not ready for that
+          ]
         exclude: tests/testdata|conf.py
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,14 @@
 ci:
   skip: [pylint]
+
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+        exclude: .github/|tests/testdata
+      - id: end-of-file-fixer
+        exclude: tests/testdata
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -12,6 +20,12 @@ repos:
           - --expand-star-imports
           - --remove-duplicate-keys
           - --remove-unused-variables
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.19.4
+    hooks:
+      - id: pyupgrade
+        exclude: tests/testdata
+        args: [--py36-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.8.0
     hooks:
@@ -21,30 +35,12 @@ repos:
     rev: 1.0.1
     hooks:
       - id: black-disable-checker
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
-    hooks:
-      - id: pyupgrade
-        exclude: tests/testdata
-        args: [--py36-plus]
   - repo: https://github.com/psf/black
     rev: 21.6b0
     hooks:
       - id: black
         args: [--safe, --quiet]
         exclude: tests/testdata|doc/
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
-    hooks:
-      - id: trailing-whitespace
-        exclude: .github/|tests/testdata
-      - id: end-of-file-fixer
-        exclude: tests/testdata
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.1
-    hooks:
-      - id: prettier
-        args: [--prose-wrap=always, --print-width=88]
   - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
@@ -60,3 +56,8 @@ repos:
         types: [python]
         args: ["-rn", "-sn", "--rcfile=pylintrc"]
         exclude: tests/testdata|conf.py
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.1
+    hooks:
+      - id: prettier
+        args: [--prose-wrap=always, --print-width=88]

--- a/doc/release.md
+++ b/doc/release.md
@@ -9,7 +9,7 @@ So, you want to release the `X.Y.Z` version of astroid ?
 3. Bump the version and release by using `tbump X.Y.Z --no-push`.
 4. Check the result.
 5. Push the tag.
-6. Release the version on Github with the same name as the tag and copy and paste the
+6. Release the version on GitHub with the same name as the tag and copy and paste the
    appropriate changelog in the description. This trigger the pypi release.
 
 ## Post release


### PR DESCRIPTION
## Description

Some preliminary fix while trying to add mypy and pylint.extensions.docparams that we're not ready for yet.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |
