### PR TITLE
Create a file for the global manager to prevent cyclic import

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -51,20 +51,17 @@ from astroid.__pkginfo__ import __version__, version
 # isort: on
 
 from astroid import inference, raw_building
+from astroid.astroid_manager import MANAGER
 from astroid.bases import BaseInstance, BoundMethod, Instance, UnboundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
 from astroid.const import Context, Del, Load, Store
 from astroid.exceptions import *
 from astroid.inference_tip import _inference_tip_cached, inference_tip
-from astroid.manager import AstroidManager
 from astroid.node_classes import are_exclusive, unpack_infer
 from astroid.nodes import *  # pylint: disable=redefined-builtin (Ellipsis)
 from astroid.scoped_nodes import builtin_lookup
 from astroid.util import Uninferable
-
-MANAGER = AstroidManager()
-del AstroidManager
 
 # load brain plugins
 ASTROID_INSTALL_DIRECTORY = Path(__file__).parent

--- a/astroid/astroid_manager.py
+++ b/astroid/astroid_manager.py
@@ -1,6 +1,9 @@
 """
 This file contain the global astroid MANAGER, to prevent circular import that happened
 when the only possibility to import it was from astroid.__init__.py.
+
+This AstroidManager is a singleton/borg so it's possible to instantiate an
+AstroidManager() directly.
 """
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html

--- a/astroid/astroid_manager.py
+++ b/astroid/astroid_manager.py
@@ -1,0 +1,12 @@
+"""
+This file contain the global astroid MANAGER, to prevent circular import that happened
+when the only possibility to import it was from astroid.__init__.py.
+"""
+
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+
+
+from astroid.manager import AstroidManager
+
+MANAGER = AstroidManager()

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -40,7 +40,6 @@ objectmodel = util.lazy_import("interpreter.objectmodel")
 helpers = util.lazy_import("helpers")
 BUILTINS = builtins.__name__
 manager = util.lazy_import("manager")
-MANAGER = manager.AstroidManager()
 
 
 # TODO: check if needs special treatment

--- a/astroid/brain/brain_argparse.py
+++ b/astroid/brain/brain_argparse.py
@@ -1,4 +1,5 @@
-from astroid import MANAGER, arguments, inference_tip, nodes
+from astroid import arguments, inference_tip, nodes
+from astroid.astroid_manager import MANAGER
 from astroid.exceptions import UseInferenceDefault
 
 

--- a/astroid/brain/brain_argparse.py
+++ b/astroid/brain/brain_argparse.py
@@ -1,6 +1,6 @@
 from astroid import arguments, inference_tip, nodes
-from astroid.astroid_manager import MANAGER
 from astroid.exceptions import UseInferenceDefault
+from astroid.manager import AstroidManager
 
 
 def infer_namespace(node, context=None):
@@ -30,6 +30,6 @@ def _looks_like_namespace(node):
     return False
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     nodes.Call, inference_tip(infer_namespace), _looks_like_namespace
 )

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -6,7 +6,7 @@ Astroid hook for the attrs library
 Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
 """
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 from astroid.node_classes import AnnAssign, Assign, Call, Unknown
 from astroid.scoped_nodes import ClassDef
 
@@ -59,4 +59,6 @@ def attr_attributes_transform(node):
             node.instance_attrs[target.name] = [rhs_node]
 
 
-MANAGER.register_transform(ClassDef, attr_attributes_transform, is_decorated_with_attrs)
+AstroidManager().register_transform(
+    ClassDef, attr_attributes_transform, is_decorated_with_attrs
+)

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -6,7 +6,7 @@ Astroid hook for the attrs library
 Without this hook pylint reports unsupported-assignment-operation
 for attrs classes
 """
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.node_classes import AnnAssign, Assign, Call, Unknown
 from astroid.scoped_nodes import ClassDef
 

--- a/astroid/brain/brain_boto3.py
+++ b/astroid/brain/brain_boto3.py
@@ -2,7 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for understanding boto3.ServiceRequest()"""
-from astroid import MANAGER, extract_node
+from astroid import extract_node
+from astroid.astroid_manager import MANAGER
 from astroid.scoped_nodes import ClassDef
 
 BOTO_SERVICE_FACTORY_QUALIFIED_NAME = "boto3.resources.base.ServiceResource"

--- a/astroid/brain/brain_boto3.py
+++ b/astroid/brain/brain_boto3.py
@@ -3,7 +3,7 @@
 
 """Astroid hooks for understanding boto3.ServiceRequest()"""
 from astroid import extract_node
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 from astroid.scoped_nodes import ClassDef
 
 BOTO_SERVICE_FACTORY_QUALIFIED_NAME = "boto3.resources.base.ServiceResource"
@@ -24,6 +24,6 @@ def _looks_like_boto3_service_request(node):
     return node.qname() == BOTO_SERVICE_FACTORY_QUALIFIED_NAME
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     ClassDef, service_request_transform, _looks_like_boto3_service_request
 )

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -22,7 +22,6 @@
 from functools import partial
 
 from astroid import (
-    MANAGER,
     arguments,
     helpers,
     inference_tip,
@@ -40,6 +39,7 @@ from astroid.exceptions import (
     NameInferenceError,
     UseInferenceDefault,
 )
+from astroid.manager import AstroidManager
 
 OBJECT_DUNDER_NEW = "object.__new__"
 
@@ -128,7 +128,7 @@ class whatever(object):
 def _extend_string_class(class_node, code, rvalue):
     """function to extend builtin str/unicode class"""
     code = code.format(rvalue=rvalue)
-    fake = AstroidBuilder(MANAGER).string_build(code)["whatever"]
+    fake = AstroidBuilder(AstroidManager()).string_build(code)["whatever"]
     for method in fake.mymethods():
         method.parent = class_node
         method.lineno = None
@@ -140,7 +140,7 @@ def _extend_string_class(class_node, code, rvalue):
 
 
 def _extend_builtins(class_transforms):
-    builtin_ast = MANAGER.builtins_module
+    builtin_ast = AstroidManager().builtins_module
     for class_name, transform in class_transforms.items():
         transform(builtin_ast[class_name])
 
@@ -204,7 +204,7 @@ def register_builtin_transform(transform, builtin_name):
                 result.col_offset = node.col_offset
         return iter([result])
 
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         nodes.Call,
         inference_tip(_transform_wrapper),
         partial(_builtin_filter_predicate, builtin_name=builtin_name),
@@ -925,7 +925,7 @@ register_builtin_transform(infer_dict_fromkeys, "dict.fromkeys")
 
 
 # Infer object.__new__ calls
-MANAGER.register_transform(
+AstroidManager().register_transform(
     nodes.ClassDef,
     inference_tip(_infer_object__new__decorator),
     _infer_object__new__decorator_check,

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -9,7 +9,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
 from astroid.const import PY39

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -9,11 +9,11 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
 from astroid.const import PY39
 from astroid.exceptions import AttributeInferenceError
+from astroid.manager import AstroidManager
 from astroid.scoped_nodes import ClassDef
 
 
@@ -85,7 +85,7 @@ def _ordered_dict_mock():
     return base_ordered_dict_class
 
 
-register_module_extender(MANAGER, "collections", _collections_transform)
+register_module_extender(AstroidManager(), "collections", _collections_transform)
 
 
 def _looks_like_subscriptable(node: ClassDef) -> bool:
@@ -125,6 +125,6 @@ if PY39:
     # thanks to the __class_getitem__ method but the way it is implemented in
     # _collection_abc makes it difficult to infer. (We would have to handle AssignName inference in the
     # getitem method of the ClassDef class) Instead we put here a mock of the __class_getitem__ method
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         ClassDef, easy_class_getitem_inference, _looks_like_subscriptable
     )

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -1,6 +1,6 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY37

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -1,9 +1,9 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY37
+from astroid.manager import AstroidManager
 
 if PY37:
     # Since Python 3.7 Hashing Methods are added
@@ -23,4 +23,4 @@ if PY37:
         """
         )
 
-    register_module_extender(MANAGER, "crypt", _re_transform)
+    register_module_extender(AstroidManager(), "crypt", _re_transform)

--- a/astroid/brain/brain_curses.py
+++ b/astroid/brain/brain_curses.py
@@ -1,6 +1,6 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_curses.py
+++ b/astroid/brain/brain_curses.py
@@ -1,8 +1,8 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def _curses_transform():
@@ -178,4 +178,4 @@ def _curses_transform():
     )
 
 
-register_module_extender(MANAGER, "curses", _curses_transform)
+register_module_extender(AstroidManager(), "curses", _curses_transform)

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -3,7 +3,7 @@
 """
 Astroid hook for the dataclasses library
 """
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 from astroid.node_classes import (
     AnnAssign,
     Assign,
@@ -64,4 +64,6 @@ def dataclass_transform(node):
             node.locals[target.name] = [rhs_node]
 
 
-MANAGER.register_transform(ClassDef, dataclass_transform, is_decorated_with_dataclass)
+AstroidManager().register_transform(
+    ClassDef, dataclass_transform, is_decorated_with_dataclass
+)

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -3,7 +3,7 @@
 """
 Astroid hook for the dataclasses library
 """
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.node_classes import (
     AnnAssign,
     Assign,

--- a/astroid/brain/brain_dateutil.py
+++ b/astroid/brain/brain_dateutil.py
@@ -11,13 +11,13 @@
 
 import textwrap
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
 
 
 def dateutil_transform():
-    return AstroidBuilder(MANAGER).string_build(
+    return AstroidBuilder(AstroidManager()).string_build(
         textwrap.dedent(
             """
     import datetime
@@ -28,4 +28,4 @@ def dateutil_transform():
     )
 
 
-register_module_extender(MANAGER, "dateutil.parser", dateutil_transform)
+register_module_extender(AstroidManager(), "dateutil.parser", dateutil_transform)

--- a/astroid/brain/brain_dateutil.py
+++ b/astroid/brain/brain_dateutil.py
@@ -11,7 +11,7 @@
 
 import textwrap
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -7,7 +7,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 import collections.abc
 
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 from astroid.node_classes import FormattedValue
 
 
@@ -48,4 +48,4 @@ def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-sta
 # The problem is that FormattedValue.value, which is a Name node,
 # has wrong line numbers, usually 1. This creates problems for pylint,
 # which expects correct line numbers for things such as message control.
-MANAGER.register_transform(FormattedValue, _transform_formatted_value)
+AstroidManager().register_transform(FormattedValue, _transform_formatted_value)

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -7,7 +7,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 import collections.abc
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.node_classes import FormattedValue
 
 

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -7,7 +7,8 @@
 from functools import partial
 from itertools import chain
 
-from astroid import MANAGER, BoundMethod, arguments, extract_node, helpers, objects
+from astroid import BoundMethod, arguments, extract_node, helpers, objects
+from astroid.astroid_manager import MANAGER
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.interpreter import objectmodel

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -8,10 +8,10 @@ from functools import partial
 from itertools import chain
 
 from astroid import BoundMethod, arguments, extract_node, helpers, objects
-from astroid.astroid_manager import MANAGER
 from astroid.exceptions import InferenceError, UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.interpreter import objectmodel
+from astroid.manager import AstroidManager
 from astroid.node_classes import AssignName, Attribute, Call, Name
 from astroid.scoped_nodes import FunctionDef
 from astroid.util import Uninferable
@@ -144,10 +144,12 @@ def _looks_like_functools_member(node, member) -> bool:
 _looks_like_partial = partial(_looks_like_functools_member, member="partial")
 
 
-MANAGER.register_transform(FunctionDef, _transform_lru_cache, _looks_like_lru_cache)
+AstroidManager().register_transform(
+    FunctionDef, _transform_lru_cache, _looks_like_lru_cache
+)
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     Call,
     inference_tip(_functools_partial_inference),
     _looks_like_partial,

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -27,7 +27,8 @@ import re
 import sys
 import warnings
 
-from astroid import MANAGER, nodes
+from astroid import nodes
+from astroid.astroid_manager import MANAGER
 from astroid.builder import AstroidBuilder
 from astroid.exceptions import AstroidBuildingError
 

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -28,9 +28,9 @@ import sys
 import warnings
 
 from astroid import nodes
-from astroid.astroid_manager import MANAGER
 from astroid.builder import AstroidBuilder
 from astroid.exceptions import AstroidBuildingError
+from astroid.manager import AstroidManager
 
 _inspected_modules = {}
 
@@ -209,7 +209,7 @@ def _import_gi_module(modname):
         except ImportError:
             astng = _inspected_modules[modname] = None
         else:
-            astng = AstroidBuilder(MANAGER).string_build(modcode, modname)
+            astng = AstroidBuilder(AstroidManager()).string_build(modcode, modname)
             _inspected_modules[modname] = astng
     else:
         astng = _inspected_modules[modname]
@@ -254,7 +254,7 @@ def _register_require_version(node):
     return node
 
 
-MANAGER.register_failed_import_hook(_import_gi_module)
-MANAGER.register_transform(
+AstroidManager().register_failed_import_hook(_import_gi_module)
+AstroidManager().register_transform(
     nodes.Call, _register_require_version, _looks_like_require_version
 )

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -8,7 +8,7 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -8,9 +8,10 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid.astroid_manager import MANAGER
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def _hashlib_transform():
@@ -59,4 +60,4 @@ def _hashlib_transform():
     return parse(classes)
 
 
-register_module_extender(MANAGER, "hashlib", _hashlib_transform)
+register_module_extender(AstroidManager(), "hashlib", _hashlib_transform)

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -8,7 +8,7 @@
 """Astroid brain hints for some of the `http` module."""
 import textwrap
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -8,9 +8,9 @@
 """Astroid brain hints for some of the `http` module."""
 import textwrap
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
 
 
 def _http_transform():
@@ -139,11 +139,11 @@ def _http_transform():
             'The client needs to authenticate to gain network access')
     """
     )
-    return AstroidBuilder(MANAGER).string_build(code)
+    return AstroidBuilder(AstroidManager()).string_build(code)
 
 
 def _http_client_transform():
-    return AstroidBuilder(MANAGER).string_build(
+    return AstroidBuilder(AstroidManager()).string_build(
         textwrap.dedent(
             """
     from http import HTTPStatus
@@ -210,5 +210,5 @@ def _http_client_transform():
     )
 
 
-register_module_extender(MANAGER, "http", _http_transform)
-register_module_extender(MANAGER, "http.client", _http_client_transform)
+register_module_extender(AstroidManager(), "http", _http_transform)
+register_module_extender(AstroidManager(), "http.client", _http_client_transform)

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -15,7 +15,7 @@ defined using the `@hypothesis.strategies.composite` decorator.  For example:
     a_strategy()
 
 """
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.scoped_nodes import FunctionDef
 
 COMPOSITE_NAMES = (

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -15,7 +15,7 @@ defined using the `@hypothesis.strategies.composite` decorator.  For example:
     a_strategy()
 
 """
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 from astroid.scoped_nodes import FunctionDef
 
 COMPOSITE_NAMES = (
@@ -46,7 +46,7 @@ def remove_draw_parameter_from_composite_strategy(node):
     return node
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     node_class=FunctionDef,
     transform=remove_draw_parameter_from_composite_strategy,
     predicate=is_decorated_with_st_composite,

--- a/astroid/brain/brain_io.py
+++ b/astroid/brain/brain_io.py
@@ -6,7 +6,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid brain hints for some of the _io C objects."""
-from astroid import MANAGER, ClassDef
+from astroid import ClassDef
+from astroid.astroid_manager import MANAGER
 
 BUFFERED = {"BufferedWriter", "BufferedReader"}
 TextIOWrapper = "TextIOWrapper"

--- a/astroid/brain/brain_io.py
+++ b/astroid/brain/brain_io.py
@@ -7,7 +7,7 @@
 
 """Astroid brain hints for some of the _io C objects."""
 from astroid import ClassDef
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 
 BUFFERED = {"BufferedWriter", "BufferedReader"}
 TextIOWrapper = "TextIOWrapper"
@@ -18,7 +18,7 @@ BufferedWriter = "BufferedWriter"
 def _generic_io_transform(node, name, cls):
     """Transform the given name, by adding the given *class* as a member of the node."""
 
-    io_module = MANAGER.ast_from_module_name("_io")
+    io_module = AstroidManager().ast_from_module_name("_io")
     attribute_object = io_module[cls]
     instance = attribute_object.instantiate_class()
     node.locals[name] = [instance]
@@ -36,9 +36,9 @@ def _transform_buffered(node):
     return _generic_io_transform(node, name="raw", cls=FileIO)
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     ClassDef, _transform_buffered, lambda node: node.name in BUFFERED
 )
-MANAGER.register_transform(
+AstroidManager().register_transform(
     ClassDef, _transform_text_io_wrapper, lambda node: node.name == TextIOWrapper
 )

--- a/astroid/brain/brain_mechanize.py
+++ b/astroid/brain/brain_mechanize.py
@@ -9,7 +9,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 

--- a/astroid/brain/brain_mechanize.py
+++ b/astroid/brain/brain_mechanize.py
@@ -9,13 +9,13 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
 
 
 def mechanize_transform():
-    return AstroidBuilder(MANAGER).string_build(
+    return AstroidBuilder(AstroidManager()).string_build(
         """
 
 class Browser(object):
@@ -87,4 +87,4 @@ class Browser(object):
     )
 
 
-register_module_extender(MANAGER, "mechanize", mechanize_transform)
+register_module_extender(AstroidManager(), "mechanize", mechanize_transform)

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -7,7 +7,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.bases import BoundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -7,11 +7,11 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid.astroid_manager import MANAGER
 from astroid.bases import BoundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.exceptions import InferenceError
+from astroid.manager import AstroidManager
 from astroid.scoped_nodes import FunctionDef
 
 
@@ -104,6 +104,8 @@ def _multiprocessing_managers_transform():
 
 
 register_module_extender(
-    MANAGER, "multiprocessing.managers", _multiprocessing_managers_transform
+    AstroidManager(), "multiprocessing.managers", _multiprocessing_managers_transform
 )
-register_module_extender(MANAGER, "multiprocessing", _multiprocessing_transform)
+register_module_extender(
+    AstroidManager(), "multiprocessing", _multiprocessing_transform
+)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -28,7 +28,8 @@ import functools
 import keyword
 from textwrap import dedent
 
-from astroid import MANAGER, arguments, inference_tip, nodes, util
+from astroid import arguments, inference_tip, nodes, util
+from astroid.astroid_manager import MANAGER
 from astroid.builder import AstroidBuilder, extract_node
 from astroid.exceptions import (
     AstroidTypeError,

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -15,8 +15,9 @@ import textwrap
 import astroid.builder
 from astroid.brain.helpers import register_module_extender
 from astroid.exceptions import InferenceError
+from astroid.manager import AstroidManager
 
-_BUILDER = astroid.builder.AstroidBuilder(astroid.MANAGER)
+_BUILDER = astroid.builder.AstroidBuilder(AstroidManager())
 
 
 CAPITALS = re.compile("([A-Z])")
@@ -76,8 +77,8 @@ def _nose_tools_trivial_transform():
 
 
 register_module_extender(
-    astroid.MANAGER, "nose.tools.trivial", _nose_tools_trivial_transform
+    AstroidManager(), "nose.tools.trivial", _nose_tools_trivial_transform
 )
-astroid.MANAGER.register_transform(
+AstroidManager().register_transform(
     astroid.Module, _nose_tools_transform, lambda n: n.name == "nose.tools"
 )

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -7,9 +7,9 @@
 
 
 """Astroid hooks for numpy.core.fromnumeric module."""
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def numpy_core_fromnumeric_transform():
@@ -22,5 +22,5 @@ def numpy_core_fromnumeric_transform():
 
 
 register_module_extender(
-    MANAGER, "numpy.core.fromnumeric", numpy_core_fromnumeric_transform
+    AstroidManager(), "numpy.core.fromnumeric", numpy_core_fromnumeric_transform
 )

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -7,7 +7,7 @@
 
 
 """Astroid hooks for numpy.core.fromnumeric module."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -11,11 +11,10 @@
 
 import functools
 
+from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.inference_tip import inference_tip
+from astroid.manager import AstroidManager
 from astroid.node_classes import Attribute
-
-from .. import MANAGER
-from .brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 
 METHODS_TO_BE_INFERRED = {
     "linspace": """def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):
@@ -28,7 +27,7 @@ METHODS_TO_BE_INFERRED = {
 
 for func_name, func_src in METHODS_TO_BE_INFERRED.items():
     inference_function = functools.partial(infer_numpy_member, func_src)
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         Attribute,
         inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, func_name),

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -11,11 +11,11 @@
 
 import functools
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.inference_tip import inference_tip
+from astroid.manager import AstroidManager
 from astroid.node_classes import Attribute, Name
 
 
@@ -33,7 +33,7 @@ def numpy_core_multiarray_transform():
 
 
 register_module_extender(
-    MANAGER, "numpy.core.multiarray", numpy_core_multiarray_transform
+    AstroidManager(), "numpy.core.multiarray", numpy_core_multiarray_transform
 )
 
 
@@ -88,12 +88,12 @@ METHODS_TO_BE_INFERRED = {
 
 for method_name, function_src in METHODS_TO_BE_INFERRED.items():
     inference_function = functools.partial(infer_numpy_member, function_src)
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         Attribute,
         inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),
     )
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         Name,
         inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -11,7 +11,7 @@
 
 import functools
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -11,11 +11,11 @@
 
 import functools
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.inference_tip import inference_tip
+from astroid.manager import AstroidManager
 from astroid.node_classes import Attribute
 
 
@@ -31,7 +31,9 @@ def numpy_core_numeric_transform():
     )
 
 
-register_module_extender(MANAGER, "numpy.core.numeric", numpy_core_numeric_transform)
+register_module_extender(
+    AstroidManager(), "numpy.core.numeric", numpy_core_numeric_transform
+)
 
 
 METHODS_TO_BE_INFERRED = {
@@ -42,7 +44,7 @@ METHODS_TO_BE_INFERRED = {
 
 for method_name, function_src in METHODS_TO_BE_INFERRED.items():
     inference_function = functools.partial(infer_numpy_member, function_src)
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         Attribute,
         inference_tip(inference_function),
         functools.partial(looks_like_numpy_member, method_name),

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -11,7 +11,7 @@
 
 import functools
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.brain_numpy_utils import infer_numpy_member, looks_like_numpy_member
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -8,7 +8,7 @@
 # TODO(hippo91) : correct the methods signature.
 
 """Astroid hooks for numpy.core.numerictypes module."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -8,9 +8,9 @@
 # TODO(hippo91) : correct the methods signature.
 
 """Astroid hooks for numpy.core.numerictypes module."""
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def numpy_core_numerictypes_transform():
@@ -255,5 +255,5 @@ def numpy_core_numerictypes_transform():
 
 
 register_module_extender(
-    MANAGER, "numpy.core.numerictypes", numpy_core_numerictypes_transform
+    AstroidManager(), "numpy.core.numerictypes", numpy_core_numerictypes_transform
 )

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -10,9 +10,9 @@
 # typecheck in `_emit_no_member` function)
 
 """Astroid hooks for numpy.core.umath module."""
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def numpy_core_umath_transform():
@@ -152,4 +152,6 @@ def numpy_core_umath_transform():
     )
 
 
-register_module_extender(MANAGER, "numpy.core.umath", numpy_core_umath_transform)
+register_module_extender(
+    AstroidManager(), "numpy.core.umath", numpy_core_umath_transform
+)

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -10,7 +10,7 @@
 # typecheck in `_emit_no_member` function)
 
 """Astroid hooks for numpy.core.umath module."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -8,9 +8,9 @@
 
 
 """Astroid hooks for numpy ndarray class."""
-from astroid.astroid_manager import MANAGER
 from astroid.builder import extract_node
 from astroid.inference_tip import inference_tip
+from astroid.manager import AstroidManager
 from astroid.node_classes import Attribute
 
 
@@ -150,7 +150,7 @@ def _looks_like_numpy_ndarray(node):
     return isinstance(node, Attribute) and node.attrname == "ndarray"
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     Attribute,
     inference_tip(infer_numpy_ndarray),
     _looks_like_numpy_ndarray,

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -8,7 +8,7 @@
 
 
 """Astroid hooks for numpy ndarray class."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.builder import extract_node
 from astroid.inference_tip import inference_tip
 from astroid.node_classes import Attribute

--- a/astroid/brain/brain_numpy_random_mtrand.py
+++ b/astroid/brain/brain_numpy_random_mtrand.py
@@ -7,7 +7,7 @@
 
 # TODO(hippo91) : correct the functions return types
 """Astroid hooks for numpy.random.mtrand module."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_numpy_random_mtrand.py
+++ b/astroid/brain/brain_numpy_random_mtrand.py
@@ -7,9 +7,9 @@
 
 # TODO(hippo91) : correct the functions return types
 """Astroid hooks for numpy.random.mtrand module."""
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def numpy_random_mtrand_transform():
@@ -69,4 +69,6 @@ def numpy_random_mtrand_transform():
     )
 
 
-register_module_extender(MANAGER, "numpy.random.mtrand", numpy_random_mtrand_transform)
+register_module_extender(
+    AstroidManager(), "numpy.random.mtrand", numpy_random_mtrand_transform
+)

--- a/astroid/brain/brain_pkg_resources.py
+++ b/astroid/brain/brain_pkg_resources.py
@@ -7,8 +7,8 @@
 
 
 from astroid import parse
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.manager import AstroidManager
 
 
 def pkg_resources_transform():
@@ -71,4 +71,4 @@ _namespace_packages = {}
     )
 
 
-register_module_extender(MANAGER, "pkg_resources", pkg_resources_transform)
+register_module_extender(AstroidManager(), "pkg_resources", pkg_resources_transform)

--- a/astroid/brain/brain_pkg_resources.py
+++ b/astroid/brain/brain_pkg_resources.py
@@ -6,7 +6,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 
-from astroid import MANAGER, parse
+from astroid import parse
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 
 

--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -10,7 +10,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for pytest."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 

--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -10,13 +10,13 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for pytest."""
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
 
 
 def pytest_transform():
-    return AstroidBuilder(MANAGER).string_build(
+    return AstroidBuilder(AstroidManager()).string_build(
         """
 
 try:
@@ -86,5 +86,5 @@ except ImportError:
     )
 
 
-register_module_extender(MANAGER, "pytest", pytest_transform)
-register_module_extender(MANAGER, "py.test", pytest_transform)
+register_module_extender(AstroidManager(), "pytest", pytest_transform)
+register_module_extender(AstroidManager(), "py.test", pytest_transform)

--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -12,9 +12,9 @@
 """Astroid hooks for the PyQT library."""
 
 from astroid import nodes, parse
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
 
 
 def _looks_like_signal(node, signal_name="pyqtSignal"):
@@ -65,7 +65,7 @@ def transform_pyside_signal(node):
 
 
 def pyqt4_qtcore_transform():
-    return AstroidBuilder(MANAGER).string_build(
+    return AstroidBuilder(AstroidManager()).string_build(
         """
 
 def SIGNAL(signal_name): pass
@@ -76,9 +76,11 @@ class QObject(object):
     )
 
 
-register_module_extender(MANAGER, "PyQt4.QtCore", pyqt4_qtcore_transform)
-MANAGER.register_transform(nodes.FunctionDef, transform_pyqt_signal, _looks_like_signal)
-MANAGER.register_transform(
+register_module_extender(AstroidManager(), "PyQt4.QtCore", pyqt4_qtcore_transform)
+AstroidManager().register_transform(
+    nodes.FunctionDef, transform_pyqt_signal, _looks_like_signal
+)
+AstroidManager().register_transform(
     nodes.ClassDef,
     transform_pyside_signal,
     lambda node: node.qname() in ("PySide.QtCore.Signal", "PySide2.QtCore.Signal"),

--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -11,7 +11,8 @@
 
 """Astroid hooks for the PyQT library."""
 
-from astroid import MANAGER, nodes, parse
+from astroid import nodes, parse
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -3,9 +3,9 @@
 import random
 
 from astroid import helpers
-from astroid.astroid_manager import MANAGER
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
+from astroid.manager import AstroidManager
 from astroid.node_classes import (
     Attribute,
     Call,
@@ -80,6 +80,6 @@ def _looks_like_random_sample(node):
     return False
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     Call, inference_tip(infer_random_sample), _looks_like_random_sample
 )

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -2,7 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 import random
 
-from astroid import MANAGER, helpers
+from astroid import helpers
+from astroid.astroid_manager import MANAGER
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.node_classes import (

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -1,6 +1,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
-from astroid import MANAGER, context, inference_tip, nodes
+from astroid import context, inference_tip, nodes
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
 from astroid.const import PY37, PY39

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -1,10 +1,10 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 from astroid import context, inference_tip, nodes
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
 from astroid.const import PY37, PY39
+from astroid.manager import AstroidManager
 
 
 def _re_transform():
@@ -34,7 +34,7 @@ def _re_transform():
     )
 
 
-register_module_extender(MANAGER, "re", _re_transform)
+register_module_extender(AstroidManager(), "re", _re_transform)
 
 
 CLASS_GETITEM_TEMPLATE = """
@@ -79,6 +79,6 @@ def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext = None):
 
 
 if PY37:
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         nodes.Call, inference_tip(infer_pattern_match), _looks_like_pattern_or_match
     )

--- a/astroid/brain/brain_responses.py
+++ b/astroid/brain/brain_responses.py
@@ -7,7 +7,7 @@ It might need to be manually updated from the public methods of
 See: https://github.com/getsentry/responses/blob/master/responses.py
 
 """
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_responses.py
+++ b/astroid/brain/brain_responses.py
@@ -7,9 +7,9 @@ It might need to be manually updated from the public methods of
 See: https://github.com/getsentry/responses/blob/master/responses.py
 
 """
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def responses_funcs():
@@ -72,4 +72,4 @@ def responses_funcs():
     )
 
 
-register_module_extender(MANAGER, "responses", responses_funcs)
+register_module_extender(AstroidManager(), "responses", responses_funcs)

--- a/astroid/brain/brain_scipy_signal.py
+++ b/astroid/brain/brain_scipy_signal.py
@@ -8,9 +8,9 @@
 
 
 """Astroid hooks for scipy.signal module."""
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def scipy_signal():
@@ -90,4 +90,4 @@ def scipy_signal():
     )
 
 
-register_module_extender(MANAGER, "scipy.signal", scipy_signal)
+register_module_extender(AstroidManager(), "scipy.signal", scipy_signal)

--- a/astroid/brain/brain_scipy_signal.py
+++ b/astroid/brain/brain_scipy_signal.py
@@ -8,7 +8,7 @@
 
 
 """Astroid hooks for scipy.signal module."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -15,7 +15,8 @@
 
 from textwrap import dedent
 
-from astroid import MANAGER, nodes
+from astroid import nodes
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder
 from astroid.exceptions import (

--- a/astroid/brain/brain_sqlalchemy.py
+++ b/astroid/brain/brain_sqlalchemy.py
@@ -1,6 +1,6 @@
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def _session_transform():
@@ -32,4 +32,4 @@ def _session_transform():
     )
 
 
-register_module_extender(MANAGER, "sqlalchemy.orm.session", _session_transform)
+register_module_extender(AstroidManager(), "sqlalchemy.orm.session", _session_transform)

--- a/astroid/brain/brain_sqlalchemy.py
+++ b/astroid/brain/brain_sqlalchemy.py
@@ -1,4 +1,4 @@
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_ssl.py
+++ b/astroid/brain/brain_ssl.py
@@ -9,7 +9,8 @@
 
 """Astroid hooks for the ssl library."""
 
-from astroid import MANAGER, parse
+from astroid import parse
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 
 

--- a/astroid/brain/brain_ssl.py
+++ b/astroid/brain/brain_ssl.py
@@ -10,8 +10,8 @@
 """Astroid hooks for the ssl library."""
 
 from astroid import parse
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
+from astroid.manager import AstroidManager
 
 
 def ssl_transform():
@@ -73,4 +73,4 @@ def ssl_transform():
     )
 
 
-register_module_extender(MANAGER, "ssl", ssl_transform)
+register_module_extender(AstroidManager(), "ssl", ssl_transform)

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -13,7 +13,7 @@
 
 import textwrap
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY37, PY39

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -13,10 +13,10 @@
 
 import textwrap
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY37, PY39
+from astroid.manager import AstroidManager
 
 
 def _subprocess_transform():
@@ -139,4 +139,4 @@ def _subprocess_transform():
     return parse(code)
 
 
-register_module_extender(MANAGER, "subprocess", _subprocess_transform)
+register_module_extender(AstroidManager(), "subprocess", _subprocess_transform)

--- a/astroid/brain/brain_threading.py
+++ b/astroid/brain/brain_threading.py
@@ -6,7 +6,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 

--- a/astroid/brain/brain_threading.py
+++ b/astroid/brain/brain_threading.py
@@ -6,9 +6,9 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
-from astroid.astroid_manager import MANAGER
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.manager import AstroidManager
 
 
 def _thread_transform():
@@ -32,4 +32,4 @@ def _thread_transform():
     )
 
 
-register_module_extender(MANAGER, "threading", _thread_transform)
+register_module_extender(AstroidManager(), "threading", _thread_transform)

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -16,7 +16,8 @@ Doing this type[int] is allowed whereas str[int] is not.
 Thanks to Lukasz Langa for fruitful discussion.
 """
 
-from astroid import MANAGER, extract_node, inference_tip, nodes
+from astroid import extract_node, inference_tip, nodes
+from astroid.astroid_manager import MANAGER
 from astroid.const import PY39
 from astroid.exceptions import UseInferenceDefault
 

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -17,9 +17,9 @@ Thanks to Lukasz Langa for fruitful discussion.
 """
 
 from astroid import extract_node, inference_tip, nodes
-from astroid.astroid_manager import MANAGER
 from astroid.const import PY39
 from astroid.exceptions import UseInferenceDefault
+from astroid.manager import AstroidManager
 
 
 def _looks_like_type_subscript(node):
@@ -60,6 +60,6 @@ def infer_type_sub(node, context=None):
 
 
 if PY39:
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         nodes.Name, inference_tip(infer_type_sub), _looks_like_type_subscript
     )

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -14,13 +14,13 @@ import typing
 from functools import partial
 
 from astroid import context, extract_node, inference_tip, node_classes
-from astroid.astroid_manager import MANAGER
 from astroid.const import PY37, PY39
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
     UseInferenceDefault,
 )
+from astroid.manager import AstroidManager
 from astroid.node_classes import (
     Assign,
     AssignName,
@@ -343,24 +343,24 @@ def infer_tuple_alias(
     return iter([class_def])
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     Call,
     inference_tip(infer_typing_typevar_or_newtype),
     looks_like_typing_typevar_or_newtype,
 )
-MANAGER.register_transform(
+AstroidManager().register_transform(
     Subscript, inference_tip(infer_typing_attr), _looks_like_typing_subscript
 )
 
 if PY39:
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         FunctionDef, inference_tip(infer_typedDict), _looks_like_typedDict
     )
 
 if PY37:
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         Call, inference_tip(infer_typing_alias), _looks_like_typing_alias
     )
-    MANAGER.register_transform(
+    AstroidManager().register_transform(
         Call, inference_tip(infer_tuple_alias), _looks_like_tuple_alias
     )

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -13,7 +13,8 @@
 import typing
 from functools import partial
 
-from astroid import MANAGER, context, extract_node, inference_tip, node_classes
+from astroid import context, extract_node, inference_tip, node_classes
+from astroid.astroid_manager import MANAGER
 from astroid.const import PY37, PY39
 from astroid.exceptions import (
     AttributeInferenceError,

--- a/astroid/brain/brain_uuid.py
+++ b/astroid/brain/brain_uuid.py
@@ -6,7 +6,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for the UUID module."""
-from astroid import MANAGER
+from astroid.astroid_manager import MANAGER
 from astroid.node_classes import Const
 from astroid.scoped_nodes import ClassDef
 

--- a/astroid/brain/brain_uuid.py
+++ b/astroid/brain/brain_uuid.py
@@ -6,7 +6,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
 
 """Astroid hooks for the UUID module."""
-from astroid.astroid_manager import MANAGER
+from astroid.manager import AstroidManager
 from astroid.node_classes import Const
 from astroid.scoped_nodes import ClassDef
 
@@ -16,6 +16,6 @@ def _patch_uuid_class(node):
     node.locals["int"] = [Const(0, parent=node)]
 
 
-MANAGER.register_transform(
+AstroidManager().register_transform(
     ClassDef, _patch_uuid_class, lambda node: node.qname() == "uuid.UUID"
 )

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -24,9 +24,10 @@ import textwrap
 from tokenize import detect_encoding
 from typing import List, Union
 
-from astroid import bases, manager, modutils, nodes, raw_building, rebuilder, util
+from astroid import bases, modutils, nodes, raw_building, rebuilder, util
 from astroid._ast import get_parser_module
 from astroid.exceptions import AstroidBuildingError, AstroidSyntaxError, InferenceError
+from astroid.manager import AstroidManager
 from astroid.node_classes import NodeNG
 
 objects = util.lazy_import("objects")
@@ -40,7 +41,6 @@ _TRANSIENT_FUNCTION = "__"
 # when calling extract_node.
 _STATEMENT_SELECTOR = "#@"
 MISPLACED_TYPE_ANNOTATION_ERROR = "misplaced type annotation"
-MANAGER = manager.AstroidManager()
 
 
 def open_source_file(filename):
@@ -274,7 +274,9 @@ def parse(code, module_name="", path=None, apply_transforms=True):
         don't want the default transforms to be applied.
     """
     code = textwrap.dedent(code)
-    builder = AstroidBuilder(manager=MANAGER, apply_transforms=apply_transforms)
+    builder = AstroidBuilder(
+        manager=AstroidManager(), apply_transforms=apply_transforms
+    )
     return builder.string_build(code, modname=module_name, path=path)
 
 

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -34,7 +34,7 @@ import wrapt
 
 from astroid import bases
 from astroid import context as contextmod
-from astroid import decorators, helpers, manager, nodes, protocols, util
+from astroid import decorators, helpers, nodes, protocols, util
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidError,
@@ -46,8 +46,8 @@ from astroid.exceptions import (
     _NonDeducibleTypeHierarchy,
 )
 from astroid.interpreter import dunder_lookup
+from astroid.manager import AstroidManager
 
-MANAGER = manager.AstroidManager()
 # Prevents circular imports
 objects = util.lazy_import("objects")
 
@@ -869,7 +869,9 @@ def infer_empty_node(self, context=None):
         yield util.Uninferable
     else:
         try:
-            yield from MANAGER.infer_ast_from_something(self.object, context=context)
+            yield from AstroidManager().infer_ast_from_something(
+                self.object, context=context
+            )
         except AstroidError:
             yield util.Uninferable
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -30,7 +30,7 @@ def _inference_tip_cached(func, instance, args, kwargs, _cache={}):  # noqa:B006
 
 def inference_tip(infer_function, raise_on_overwrite=False):
     """Given an instance specific inference function, return a function to be
-    given to MANAGER.register_transform to set this inference function.
+    given to AstroidManager().register_transform to set this inference function.
 
     :param bool raise_on_overwrite: Raise an `InferenceOverwriteError`
         if the inference tip will overwrite another. Used for debugging
@@ -39,7 +39,7 @@ def inference_tip(infer_function, raise_on_overwrite=False):
 
     .. sourcecode:: python
 
-       MANAGER.register_transform(Call, inference_tip(infer_named_tuple),
+       AstroidManager().register_transform(Call, inference_tip(infer_named_tuple),
                                   predicate)
 
     .. Note::

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -40,6 +40,7 @@ import astroid
 from astroid import context as contextmod
 from astroid import node_classes, util
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
+from astroid.manager import AstroidManager
 
 objects = util.lazy_import("objects")
 
@@ -125,7 +126,7 @@ class ObjectModel:
 
 class ModuleModel(ObjectModel):
     def _builtins(self):
-        builtins_ast_module = astroid.MANAGER.builtins_module
+        builtins_ast_module = AstroidManager().builtins_module
         return builtins_ast_module.special_attributes.lookup("__dict__")
 
     @property
@@ -549,7 +550,7 @@ class GeneratorModel(FunctionModel):
     def __new__(cls, *args, **kwargs):
         # Append the values from the GeneratorType unto this object.
         ret = super().__new__(cls, *args, **kwargs)
-        generator = astroid.MANAGER.builtins_module["generator"]
+        generator = AstroidManager().builtins_module["generator"]
         for name, values in generator.locals.items():
             method = values[0]
 
@@ -577,7 +578,7 @@ class AsyncGeneratorModel(GeneratorModel):
     def __new__(cls, *args, **kwargs):
         # Append the values from the AGeneratorType unto this object.
         ret = super().__new__(cls, *args, **kwargs)
-        astroid_builtins = astroid.MANAGER.builtins_module
+        astroid_builtins = AstroidManager().builtins_module
         generator = astroid_builtins.get("async_generator")
         if generator is None:
             # Make it backward compatible.
@@ -625,7 +626,7 @@ class ExceptionInstanceModel(InstanceModel):
 
     @property
     def attr___traceback__(self):
-        builtins_ast_module = astroid.MANAGER.builtins_module
+        builtins_ast_module = AstroidManager().builtins_module
         traceback_type = builtins_ast_module[types.TracebackType.__name__]
         return traceback_type.instantiate_class()
 

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -27,6 +27,7 @@ from various source and using a cache of built modules)
 
 import os
 import zipimport
+from typing import ClassVar
 
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import spec
@@ -52,14 +53,14 @@ def safe_repr(obj):
 
 
 class AstroidManager:
-    """the astroid manager, responsible to build astroid from files
-     or modules.
+    """Responsible to build astroid from files or modules.
 
-    Use the Borg pattern.
+    Use the Borg (singleton) pattern.
     """
 
     name = "astroid loader"
     brain = {}
+    max_inferable_values: ClassVar[int] = 100
 
     def __init__(self):
         self.__dict__ = AstroidManager.brain
@@ -72,8 +73,6 @@ class AstroidManager:
             self.optimize_ast = False
             self.extension_package_whitelist = set()
             self._transform = TransformVisitor()
-
-            self.max_inferable_values = 100
 
     @property
     def register_transform(self):

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -44,7 +44,7 @@ from typing import ClassVar, Optional
 
 from astroid import as_string, bases
 from astroid import context as contextmod
-from astroid import decorators, manager, mixins, util
+from astroid import decorators, mixins, util
 from astroid.const import Context
 from astroid.exceptions import (
     AstroidError,
@@ -54,6 +54,7 @@ from astroid.exceptions import (
     NoDefault,
     UseInferenceDefault,
 )
+from astroid.manager import AstroidManager
 
 try:
     from typing import Literal
@@ -62,7 +63,6 @@ except ImportError:
     from typing_extensions import Literal
 
 BUILTINS = builtins_mod.__name__
-MANAGER = manager.AstroidManager()
 
 
 def _is_const(value):
@@ -366,7 +366,7 @@ class NodeNG:
 
         # Limit inference amount to help with performance issues with
         # exponentially exploding possible results.
-        limit = MANAGER.max_inferable_values
+        limit = AstroidManager().max_inferable_values
         for i, result in enumerate(generator):
             if i >= limit or (context.nodes_inferred > context.max_inferred):
                 yield util.Uninferable
@@ -3972,7 +3972,7 @@ class Slice(NodeNG):
 
     @decorators.cachedproperty
     def _proxied(self):
-        builtins = MANAGER.builtins_module
+        builtins = AstroidManager().builtins_module
         return builtins.getattr("slice")[0]
 
     def pytype(self):

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -22,13 +22,13 @@ leads to an inferred FrozenSet:
 import builtins
 
 from astroid import bases, decorators, node_classes, scoped_nodes, util
-from astroid.astroid_manager import MANAGER
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
     MroError,
     SuperError,
 )
+from astroid.manager import AstroidManager
 
 BUILTINS = builtins.__name__
 objectmodel = util.lazy_import("interpreter.objectmodel")
@@ -45,7 +45,7 @@ class FrozenSet(node_classes._BaseContainer):
 
     @decorators.cachedproperty
     def _proxied(self):  # pylint: disable=method-hidden
-        ast_builtins = MANAGER.builtins_module
+        ast_builtins = AstroidManager().builtins_module
         return ast_builtins.getattr("frozenset")[0]
 
 
@@ -114,7 +114,7 @@ class Super(node_classes.NodeNG):
 
     @decorators.cachedproperty
     def _proxied(self):
-        ast_builtins = MANAGER.builtins_module
+        ast_builtins = AstroidManager().builtins_module
         return ast_builtins.getattr("super")[0]
 
     def pytype(self):

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -21,7 +21,8 @@ leads to an inferred FrozenSet:
 
 import builtins
 
-from astroid import MANAGER, bases, decorators, node_classes, scoped_nodes, util
+from astroid import bases, decorators, node_classes, scoped_nodes, util
+from astroid.astroid_manager import MANAGER
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -30,11 +30,10 @@ import sys
 import types
 import warnings
 
-from astroid import bases, manager, node_classes, nodes
+from astroid import bases, node_classes, nodes
+from astroid.manager import AstroidManager
 
-MANAGER = manager.AstroidManager()
 # the keys of CONST_CLS eg python builtin types
-
 _CONSTANTS = tuple(node_classes.CONST_CLS)
 _BUILTINS = vars(builtins)
 TYPE_NONE = type(None)
@@ -291,7 +290,7 @@ class InspectBuilder:
     """
 
     def __init__(self, manager_instance=None):
-        self._manager = manager_instance or MANAGER
+        self._manager = manager_instance or AstroidManager()
         self._done = {}
         self._module = None
 

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -46,7 +46,7 @@ from typing import List, Optional
 from astroid import bases
 from astroid import context as contextmod
 from astroid import decorators as decorators_mod
-from astroid import manager, mixins, node_classes, util
+from astroid import mixins, node_classes, util
 from astroid.const import PY39
 from astroid.exceptions import (
     AstroidBuildingError,
@@ -60,6 +60,7 @@ from astroid.exceptions import (
 )
 from astroid.interpreter.dunder_lookup import lookup
 from astroid.interpreter.objectmodel import ClassModel, FunctionModel, ModuleModel
+from astroid.manager import AstroidManager
 
 BUILTINS = builtins.__name__
 ITER_METHODS = ("__iter__", "__getitem__")
@@ -175,15 +176,12 @@ def function_to_method(n, klass):
     return n
 
 
-MANAGER = manager.AstroidManager()
-
-
 def builtin_lookup(name):
     """lookup a name into the builtin module
     return the list of matching statements and the astroid for the builtin
     module
     """
-    builtin_astroid = MANAGER.ast_from_module(builtins)
+    builtin_astroid = AstroidManager().ast_from_module(builtins)
     if name == "__dict__":
         return builtin_astroid, ()
     try:
@@ -687,13 +685,13 @@ class Module(LocalsDictNodeNG):
         absmodname = self.relative_to_absolute_name(modname, level)
 
         try:
-            return MANAGER.ast_from_module_name(absmodname)
+            return AstroidManager().ast_from_module_name(absmodname)
         except AstroidBuildingError:
             # we only want to import a sub module or package of this module,
             # skip here
             if relative_only:
                 raise
-        return MANAGER.ast_from_module_name(modname)
+        return AstroidManager().ast_from_module_name(modname)
 
     def relative_to_absolute_name(self, modname, level):
         """Get the absolute module name for a relative import.
@@ -2258,7 +2256,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         # inside this class.
         lookup_upper_frame = (
             isinstance(node.parent, node_classes.Decorators)
-            and name in MANAGER.builtins_module
+            and name in AstroidManager().builtins_module
         )
         if (
             any(node == base or base.parent_of(node) for base in self.bases)

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -13,8 +13,9 @@
 import os
 import sys
 
-from astroid import MANAGER, builder
+from astroid import builder
 from astroid.bases import BUILTINS
+from astroid.manager import AstroidManager
 
 DATA_DIR = os.path.join("testdata", "python3")
 RESOURCE_PATH = os.path.join(os.path.dirname(__file__), DATA_DIR, "data")
@@ -56,9 +57,9 @@ class AstroidCacheSetupMixin:
 
     @classmethod
     def setup_class(cls):
-        cls._builtins = MANAGER.astroid_cache.get(BUILTINS)
+        cls._builtins = AstroidManager().astroid_cache.get(BUILTINS)
 
     @classmethod
     def teardown_class(cls):
         if cls._builtins:
-            MANAGER.astroid_cache[BUILTINS] = cls._builtins
+            AstroidManager().astroid_cache[BUILTINS] = cls._builtins

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5218,7 +5218,7 @@ def test_limit_inference_result_amount():
     """
     result = extract_node(code).inferred()
     assert len(result) == 16
-    with patch("astroid.node_classes.MANAGER.max_inferable_values", 4):
+    with patch("astroid.manager.AstroidManager.max_inferable_values", 4):
         result_limited = extract_node(code).inferred()
     # Can't guarantee exact size
     assert len(result_limited) < 16

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -39,7 +39,7 @@ from functools import partial
 
 import pytest
 
-from astroid import builder, nodes, objects, scoped_nodes, test_utils, util
+from astroid import MANAGER, builder, nodes, objects, scoped_nodes, test_utils, util
 from astroid.bases import BUILTINS, BoundMethod, Generator, Instance, UnboundMethod
 from astroid.exceptions import (
     AttributeInferenceError,
@@ -1389,7 +1389,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         A1 = astroid.getattr("A1")[0]
         B1 = astroid.getattr("B1")[0]
         C1 = astroid.getattr("C1")[0]
-        object_ = builder.MANAGER.astroid_cache[BUILTINS].getattr("object")[0]
+        object_ = MANAGER.astroid_cache[BUILTINS].getattr("object")[0]
         self.assertEqual(
             cm.exception.mros, [[B1, C1, A1, object_], [C1, B1, A1, object_]]
         )

--- a/tests/unittest_transforms.py
+++ b/tests/unittest_transforms.py
@@ -14,7 +14,7 @@ import contextlib
 import time
 import unittest
 
-from astroid import builder, nodes, parse, transforms
+from astroid import MANAGER, builder, nodes, parse, transforms
 
 
 @contextlib.contextmanager
@@ -152,7 +152,7 @@ class TestTransforms(unittest.TestCase):
                         return next(node.infer_call_result())
             return None
 
-        manager = builder.MANAGER
+        manager = MANAGER
         with add_transform(manager, nodes.FunctionDef, transform_function):
             module = builder.parse(
                 """
@@ -186,7 +186,7 @@ class TestTransforms(unittest.TestCase):
             node.args.args = [name]
             return node
 
-        manager = builder.MANAGER
+        manager = MANAGER
 
         def predicate(node):
             return node.root().name == "time"
@@ -204,7 +204,7 @@ class TestTransforms(unittest.TestCase):
         def transform_function(node):
             return nodes.const_factory(42)
 
-        manager = builder.MANAGER
+        manager = MANAGER
         with add_transform(manager, nodes.FunctionDef, transform_function):
             astroid_builder = builder.AstroidBuilder(apply_transforms=False)
             module = astroid_builder.string_build("""def test(): pass""")


### PR DESCRIPTION
## Description

This remove 6 cyclic imports. There was a global ``MANAGER`` that was directly in ``astroid.__init__.py`` that could not be imported another way than by using directly ``from astroid import MANAGER``. I also realized that ``AstroidManager`` is a singleton so the intermediate variables do not matter.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Need #1045 to be merged first.
