### PR TITLE
Create a statement file from node_classes.

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -68,7 +68,6 @@ from astroid.inference_tip import _inference_tip_cached, inference_tip
 # importing with a wildcard would clash with astroid/nodes/scoped_nodes
 # and astroid/nodes/node_classes.
 from astroid.nodes import (  # pylint: disable=redefined-builtin (Ellipsis)
-    CONST_CLS,
     AnnAssign,
     Arguments,
     Assert,

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (Ellipsis)
+from astroid.nodes import (  # pylint: disable=redefined-builtin (Ellipsis)
     CONST_CLS,
     AnnAssign,
     Arguments,
@@ -46,6 +46,7 @@ from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (E
     JoinedStr,
     Keyword,
     List,
+    LocalsDictNodeNG,
     Match,
     MatchAs,
     MatchCase,

--- a/astroid/nodes/__init__.py
+++ b/astroid/nodes/__init__.py
@@ -27,7 +27,6 @@ from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (E
     CONST_CLS,
     AnnAssign,
     Arguments,
-    Assert,
     Assign,
     AssignAttr,
     AssignName,
@@ -54,7 +53,6 @@ from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (E
     EmptyNode,
     EvaluatedObject,
     ExceptHandler,
-    Expr,
     ExtSlice,
     For,
     FormattedValue,
@@ -83,7 +81,6 @@ from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (E
     Nonlocal,
     Pass,
     Pattern,
-    Raise,
     Return,
     Set,
     Slice,
@@ -98,6 +95,7 @@ from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (E
     With,
     Yield,
     YieldFrom,
+    _BaseContainer,
     are_exclusive,
     const_factory,
     unpack_infer,
@@ -111,11 +109,15 @@ from astroid.nodes.scoped_nodes import (
     GeneratorExp,
     Lambda,
     ListComp,
+    LocalsDictNodeNG,
     Module,
     SetComp,
+    _is_metaclass,
     builtin_lookup,
     function_to_method,
+    get_wrapping_class,
 )
+from astroid.nodes.statement import Assert, Expr, Raise
 
 ALL_NODE_CLASSES = (
     AnnAssign,
@@ -169,6 +171,7 @@ ALL_NODE_CLASSES = (
     Lambda,
     List,
     ListComp,
+    LocalsDictNodeNG,
     Match,
     MatchAs,
     MatchCase,
@@ -291,4 +294,6 @@ __all__ = (
     "With",
     "Yield",
     "YieldFrom",
+    "_is_metaclass",
+    "get_wrapping_class",
 )

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1099,59 +1099,6 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         yield self.expr
 
 
-class Assert(Statement):
-    """Class representing an :class:`ast.Assert` node.
-
-    An :class:`Assert` node represents an assert statement.
-
-    >>> node = astroid.extract_node('assert len(things) == 10, "Not enough things"')
-    >>> node
-    <Assert l.1 at 0x7effe1d527b8>
-    """
-
-    _astroid_fields = ("test", "fail")
-
-    def __init__(
-        self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-        """
-        self.test: Optional[NodeNG] = None
-        """The test that passes or fails the assertion."""
-
-        self.fail: Optional[NodeNG] = None  # can be None
-        """The message shown when the assertion fails."""
-
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
-
-    def postinit(
-        self, test: Optional[NodeNG] = None, fail: Optional[NodeNG] = None
-    ) -> None:
-        """Do some setup after initialisation.
-
-        :param test: The test that passes or fails the assertion.
-
-        :param fail: The message shown when the assertion fails.
-        """
-        self.fail = fail
-        self.test = test
-
-    def get_children(self):
-        yield self.test
-
-        if self.fail is not None:
-            yield self.fail
-
-
 class Assign(mixins.AssignTypeMixin, Statement):
     """Class representing an :class:`ast.Assign` node.
 
@@ -2208,55 +2155,6 @@ class Dict(NodeNG, bases.Instance):
         return bool(self.items)
 
 
-class Expr(Statement):
-    """Class representing an :class:`ast.Expr` node.
-
-    An :class:`Expr` is any expression that does not have its value used or
-    stored.
-
-    >>> node = astroid.extract_node('method()')
-    >>> node
-    <Call l.1 at 0x7f23b2e352b0>
-    >>> node.parent
-    <Expr l.1 at 0x7f23b2e35278>
-    """
-
-    _astroid_fields = ("value",)
-
-    def __init__(
-        self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-        """
-        self.value: Optional[NodeNG] = None
-        """What the expression does."""
-
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
-
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
-        """Do some setup after initialisation.
-
-        :param value: What the expression does.
-        """
-        self.value = value
-
-    def get_children(self):
-        yield self.value
-
-    def _get_yield_nodes_skip_lambdas(self):
-        if not self.value.is_lambda:
-            yield from self.value._get_yield_nodes_skip_lambdas()
-
-
 class Ellipsis(mixins.NoChildrenMixin, NodeNG):  # pylint: disable=redefined-builtin
     """Class representing an :class:`ast.Ellipsis` node.
 
@@ -3078,74 +2976,6 @@ class Pass(mixins.NoChildrenMixin, Statement):
     >>> node
     <Pass l.1 at 0x7f23b2e9e748>
     """
-
-
-class Raise(Statement):
-    """Class representing an :class:`ast.Raise` node.
-
-    >>> node = astroid.extract_node('raise RuntimeError("Something bad happened!")')
-    >>> node
-    <Raise l.1 at 0x7f23b2e9e828>
-    """
-
-    _astroid_fields = ("exc", "cause")
-
-    def __init__(
-        self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-        """
-        self.exc: Optional[NodeNG] = None  # can be None
-        """What is being raised."""
-
-        self.cause: Optional[NodeNG] = None  # can be None
-        """The exception being used to raise this one."""
-
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
-
-    def postinit(
-        self,
-        exc: Optional[NodeNG] = None,
-        cause: Optional[NodeNG] = None,
-    ) -> None:
-        """Do some setup after initialisation.
-
-        :param exc: What is being raised.
-
-        :param cause: The exception being used to raise this one.
-        """
-        self.exc = exc
-        self.cause = cause
-
-    def raises_not_implemented(self):
-        """Check if this node raises a :class:`NotImplementedError`.
-
-        :returns: True if this node raises a :class:`NotImplementedError`,
-            False otherwise.
-        :rtype: bool
-        """
-        if not self.exc:
-            return False
-        for name in self.exc._get_name_nodes():
-            if name.name == "NotImplementedError":
-                return True
-        return False
-
-    def get_children(self):
-        if self.exc is not None:
-            yield self.exc
-
-        if self.cause is not None:
-            yield self.cause
 
 
 class Return(Statement):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -55,6 +55,7 @@ from astroid.exceptions import (
 from astroid.manager import AstroidManager
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.node_ng import NodeNG
+from astroid.nodes.statement import Statement
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -237,38 +238,6 @@ def _container_getitem(instance, elts, index, context=None):
         ) from exc
 
     raise AstroidTypeError("Could not use %s as subscript index" % index)
-
-
-class Statement(NodeNG):
-    """Statement node adding a few attributes"""
-
-    is_statement = True
-    """Whether this node indicates a statement."""
-
-    def next_sibling(self):
-        """The next sibling statement node.
-
-        :returns: The next sibling statement node.
-        :rtype: NodeNG or None
-        """
-        stmts = self.parent.child_sequence(self)
-        index = stmts.index(self)
-        try:
-            return stmts[index + 1]
-        except IndexError:
-            return None
-
-    def previous_sibling(self):
-        """The previous sibling statement.
-
-        :returns: The previous sibling statement node.
-        :rtype: NodeNG or None
-        """
-        stmts = self.parent.child_sequence(self)
-        index = stmts.index(self)
-        if index >= 1:
-            return stmts[index - 1]
-        return None
 
 
 class _BaseContainer(

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2979,6 +2979,10 @@ class Pass(mixins.NoChildrenMixin, Statement):
 
 
 class Return(Statement):
+
+    # TODO Move this in 'astroid.nodes.statement' when importing Tuple
+    # does not create a circular import.
+
     """Class representing an :class:`ast.Return` node.
 
     >>> node = astroid.extract_node('return True')

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -64,6 +64,7 @@ from astroid.interpreter.dunder_lookup import lookup
 from astroid.interpreter.objectmodel import ClassModel, FunctionModel, ModuleModel
 from astroid.manager import AstroidManager
 from astroid.nodes import Const, node_classes
+from astroid.nodes.statement import Raise
 
 ITER_METHODS = ("__iter__", "__getitem__")
 EXCEPTION_BASE_CLASSES = frozenset({"Exception", "BaseException"})
@@ -1697,7 +1698,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                     return True
 
         for child_node in self.body:
-            if isinstance(child_node, node_classes.Raise):
+            if isinstance(child_node, Raise):
                 if any_raise_is_abstract:
                     return True
                 if child_node.raises_not_implemented():

--- a/astroid/nodes/statement.py
+++ b/astroid/nodes/statement.py
@@ -1,0 +1,35 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+from astroid.nodes.node_ng import NodeNG
+
+
+class Statement(NodeNG):
+    """Statement node adding a few attributes"""
+
+    is_statement = True
+    """Whether this node indicates a statement."""
+
+    def next_sibling(self):
+        """The next sibling statement node.
+
+        :returns: The next sibling statement node.
+        :rtype: NodeNG or None
+        """
+        stmts = self.parent.child_sequence(self)
+        index = stmts.index(self)
+        try:
+            return stmts[index + 1]
+        except IndexError:
+            return None
+
+    def previous_sibling(self):
+        """The previous sibling statement.
+
+        :returns: The previous sibling statement node.
+        :rtype: NodeNG or None
+        """
+        stmts = self.parent.child_sequence(self)
+        index = stmts.index(self)
+        if index >= 1:
+            return stmts[index - 1]
+        return None

--- a/astroid/nodes/statement.py
+++ b/astroid/nodes/statement.py
@@ -1,5 +1,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+from typing import Optional
+
 from astroid.nodes.node_ng import NodeNG
 
 
@@ -33,3 +35,176 @@ class Statement(NodeNG):
         if index >= 1:
             return stmts[index - 1]
         return None
+
+
+class Assert(Statement):
+    """Class representing an :class:`ast.Assert` node.
+
+    An :class:`Assert` node represents an assert statement.
+
+    >>> from astroid.builder import extract_node
+    >>> node = extract_node('assert len(things) == 10, "Not enough things"')
+    >>> node
+    <Assert l.1 at 0x7effe1d527b8>
+    """
+
+    _astroid_fields = ("test", "fail")
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        """
+        :param lineno: The line that this node appears on in the source code.
+
+        :param col_offset: The column that this node appears on in the
+            source code.
+
+        :param parent: The parent node in the syntax tree.
+        """
+        self.test: Optional[NodeNG] = None
+        """The test that passes or fails the assertion."""
+
+        self.fail: Optional[NodeNG] = None  # can be None
+        """The message shown when the assertion fails."""
+
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+
+    def postinit(
+        self, test: Optional[NodeNG] = None, fail: Optional[NodeNG] = None
+    ) -> None:
+        """Do some setup after initialisation.
+
+        :param test: The test that passes or fails the assertion.
+
+        :param fail: The message shown when the assertion fails.
+        """
+        self.fail = fail
+        self.test = test
+
+    def get_children(self):
+        yield self.test
+
+        if self.fail is not None:
+            yield self.fail
+
+
+class Expr(Statement):
+    """Class representing an :class:`ast.Expr` node.
+
+    An :class:`Expr` is any expression that does not have its value used or
+    stored.
+
+    >>> from astroid.builder import extract_node
+    >>> node = extract_node('method()')
+    >>> node
+    <Call l.1 at 0x7f23b2e352b0>
+    >>> node.parent
+    <Expr l.1 at 0x7f23b2e35278>
+    """
+
+    _astroid_fields = ("value",)
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        """
+        :param lineno: The line that this node appears on in the source code.
+
+        :param col_offset: The column that this node appears on in the
+            source code.
+
+        :param parent: The parent node in the syntax tree.
+        """
+        self.value: Optional[NodeNG] = None
+        """What the expression does."""
+
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+
+    def postinit(self, value: Optional[NodeNG] = None) -> None:
+        """Do some setup after initialisation.
+
+        :param value: What the expression does.
+        """
+        self.value = value
+
+    def get_children(self):
+        yield self.value
+
+    def _get_yield_nodes_skip_lambdas(self):
+        if not self.value.is_lambda:
+            yield from self.value._get_yield_nodes_skip_lambdas()
+
+
+class Raise(Statement):
+    """Class representing an :class:`ast.Raise` node.
+
+    >>> from astroid.builder import extract_node
+    >>> node = extract_node('raise RuntimeError("Something bad happened!")')
+    >>> node
+    <Raise l.1 at 0x7f23b2e9e828>
+    """
+
+    _astroid_fields = ("exc", "cause")
+
+    def __init__(
+        self,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None,
+    ) -> None:
+        """
+        :param lineno: The line that this node appears on in the source code.
+
+        :param col_offset: The column that this node appears on in the
+            source code.
+
+        :param parent: The parent node in the syntax tree.
+        """
+        self.exc: Optional[NodeNG] = None  # can be None
+        """What is being raised."""
+
+        self.cause: Optional[NodeNG] = None  # can be None
+        """The exception being used to raise this one."""
+
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+
+    def postinit(
+        self,
+        exc: Optional[NodeNG] = None,
+        cause: Optional[NodeNG] = None,
+    ) -> None:
+        """Do some setup after initialisation.
+
+        :param exc: What is being raised.
+
+        :param cause: The exception being used to raise this one.
+        """
+        self.exc = exc
+        self.cause = cause
+
+    def raises_not_implemented(self):
+        """Check if this node raises a :class:`NotImplementedError`.
+
+        :returns: True if this node raises a :class:`NotImplementedError`,
+            False otherwise.
+        :rtype: bool
+        """
+        if not self.exc:
+            return False
+        for name in self.exc._get_name_nodes():
+            if name.name == "NotImplementedError":
+                return True
+        return False
+
+    def get_children(self):
+        if self.exc is not None:
+            yield self.exc
+
+        if self.cause is not None:
+            yield self.cause

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from astroid.nodes.scoped_nodes import (
+from astroid.nodes import (
     AsyncFunctionDef,
     ClassDef,
     ComprehensionScope,

--- a/tests/unittest_python3.py
+++ b/tests/unittest_python3.py
@@ -20,8 +20,7 @@ from textwrap import dedent
 
 from astroid import nodes
 from astroid.builder import AstroidBuilder, extract_node
-from astroid.nodes.node_classes import Assign, Const, Expr, Name, YieldFrom
-from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
+from astroid.nodes import Assign, ClassDef, Const, Expr, FunctionDef, Name, YieldFrom
 from astroid.test_utils import require_version
 
 


### PR DESCRIPTION
## Description

Small step toward bursting node_classes. There is a return Statement that could go in this file too, but right not a typing would create a circular import.

Require #1057 to be merged first.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
