### PR TITLE
Fix some invalid name for pep8

### DIFF
--- a/astroid/const.py
+++ b/astroid/const.py
@@ -13,6 +13,7 @@ class Context(enum.Enum):
     Del = 3
 
 
-Load = Context.Load
-Store = Context.Store
-Del = Context.Del
+# TODO Remove in 3.0 in favor of Context
+Load = Context.Load  # pylint: disable=invalid-name
+Store = Context.Store  # pylint: disable=invalid-name
+Del = Context.Del  # pylint: disable=invalid-name

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -174,12 +174,12 @@ class AstroidManager:
                     return self._build_stub_module(modname)
                 try:
                     module = load_module_from_name(modname)
-                except Exception as ex:
+                except Exception as e:
                     raise AstroidImportError(
                         "Loading {modname} failed with:\n{error}",
                         modname=modname,
                         path=found_spec.location,
-                    ) from ex
+                    ) from e
                 return self.ast_from_module(module, modname)
 
             elif found_spec.type == spec.ModuleType.PY_COMPILED:
@@ -249,12 +249,12 @@ class AstroidManager:
                 value = file_info_from_modpath(
                     modname.split("."), context_file=contextfile
                 )
-            except ImportError as ex:
+            except ImportError as e:
                 value = AstroidImportError(
                     "Failed to import module {modname} with error:\n{error}.",
                     modname=modname,
                     # we remove the traceback here to save on memory usage (since these exceptions are cached)
-                    error=ex.with_traceback(None),
+                    error=e.with_traceback(None),
                 )
             self._mod_file_cache[(modname, contextfile)] = value
         if isinstance(value, AstroidBuildingError):

--- a/pylintrc
+++ b/pylintrc
@@ -123,7 +123,7 @@ enable=useless-suppression
 bad-functions=
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=i,j,k,e,f,m,cm,Run,_,n,op,it
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -462,7 +462,7 @@ class DefaultDictTest(unittest.TestCase):
 
 
 class ModuleExtenderTest(unittest.TestCase):
-    def testExtensionModules(self):
+    def test_extension_modules(self):
         transformer = MANAGER._transform
         for extender, _ in transformer.transforms[nodes.Module]:
             n = nodes.Module("__main__", None)
@@ -1612,7 +1612,7 @@ class TypingBrain(unittest.TestCase):
         self.assertIsInstance(inferred, astroid.Instance)
 
     @test_utils.require_version("3.8")
-    def test_typedDict(self):
+    def test_typed_dict(self):
         node = builder.extract_node(
             """
         from typing import TypedDict

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -901,12 +901,12 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """,
             "module",
         )
-        should_be_C = list(ast[0].infer())
-        should_be_D = list(ast[1].infer())
-        self.assertEqual(1, len(should_be_C))
-        self.assertEqual(1, len(should_be_D))
-        self.assertEqual("module.C", should_be_C[0].qname())
-        self.assertEqual("module.D", should_be_D[0].qname())
+        should_be_c = list(ast[0].infer())
+        should_be_d = list(ast[1].infer())
+        self.assertEqual(1, len(should_be_c))
+        self.assertEqual(1, len(should_be_d))
+        self.assertEqual("module.C", should_be_c[0].qname())
+        self.assertEqual("module.D", should_be_d[0].qname())
 
     def test_factory_methods_object_new_call(self):
         ast = extract_node(
@@ -924,12 +924,12 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """,
             "module",
         )
-        should_be_C = list(ast[0].infer())
-        should_be_D = list(ast[1].infer())
-        self.assertEqual(1, len(should_be_C))
-        self.assertEqual(1, len(should_be_D))
-        self.assertEqual("module.C", should_be_C[0].qname())
-        self.assertEqual("module.D", should_be_D[0].qname())
+        should_be_c = list(ast[0].infer())
+        should_be_d = list(ast[1].infer())
+        self.assertEqual(1, len(should_be_c))
+        self.assertEqual(1, len(should_be_d))
+        self.assertEqual("module.C", should_be_c[0].qname())
+        self.assertEqual("module.D", should_be_d[0].qname())
 
     @pytest.mark.skipif(
         PY38,
@@ -3776,7 +3776,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(inferred.name, "B")
 
     @unittest.skipUnless(HAS_SIX, "These tests require the six library")
-    def test_With_metaclass_subclasses_arguments_are_classes_not_instances(self):
+    def test_with_metaclass_subclasses_arguments_are_classes_not_instances(self):
         ast_node = extract_node(
             """
         class A(type):
@@ -3794,7 +3794,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(inferred.name, "B")
 
     @unittest.skipUnless(HAS_SIX, "These tests require the six library")
-    def test_With_metaclass_with_partial_imported_name(self):
+    def test_with_metaclass_with_partial_imported_name(self):
         ast_node = extract_node(
             """
         class A(type):

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -285,7 +285,7 @@ class AstroidManagerTest(
         """give a wrong class at the ast_from_class method"""
         self.assertRaises(AstroidBuildingError, self.manager.ast_from_class, None)
 
-    def testFailedImportHooks(self):
+    def test_failed_import_hooks(self):
         def hook(modname):
             if modname == "foo.bar":
                 return unittest

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -80,10 +80,10 @@ class ModuleFileTest(unittest.TestCase):
 class LoadModuleFromNameTest(unittest.TestCase):
     """load a python module from it's name"""
 
-    def test_knownValues_load_module_from_name_1(self):
+    def test_known_values_load_module_from_name_1(self):
         self.assertEqual(modutils.load_module_from_name("sys"), sys)
 
-    def test_knownValues_load_module_from_name_2(self):
+    def test_known_values_load_module_from_name_2(self):
         self.assertEqual(modutils.load_module_from_name("os.path"), os.path)
 
     def test_raise_load_module_from_name_1(self):
@@ -95,29 +95,29 @@ class LoadModuleFromNameTest(unittest.TestCase):
 class GetModulePartTest(unittest.TestCase):
     """given a dotted name return the module part of the name"""
 
-    def test_knownValues_get_module_part_1(self):
+    def test_known_values_get_module_part_1(self):
         self.assertEqual(
             modutils.get_module_part("astroid.modutils"), "astroid.modutils"
         )
 
-    def test_knownValues_get_module_part_2(self):
+    def test_known_values_get_module_part_2(self):
         self.assertEqual(
             modutils.get_module_part("astroid.modutils.get_module_part"),
             "astroid.modutils",
         )
 
-    def test_knownValues_get_module_part_3(self):
+    def test_known_values_get_module_part_3(self):
         """relative import from given file"""
         self.assertEqual(
             modutils.get_module_part("node_classes.AssName", modutils.__file__),
             "node_classes",
         )
 
-    def test_knownValues_get_compiled_module_part(self):
+    def test_known_values_get_compiled_module_part(self):
         self.assertEqual(modutils.get_module_part("math.log10"), "math")
         self.assertEqual(modutils.get_module_part("math.log10", __file__), "math")
 
-    def test_knownValues_get_builtin_module_part(self):
+    def test_known_values_get_builtin_module_part(self):
         self.assertEqual(modutils.get_module_part("sys.path"), "sys")
         self.assertEqual(modutils.get_module_part("sys.path", "__file__"), "sys")
 
@@ -130,13 +130,13 @@ class GetModulePartTest(unittest.TestCase):
 class ModPathFromFileTest(unittest.TestCase):
     """given an absolute file path return the python module's path as a list"""
 
-    def test_knownValues_modpath_from_file_1(self):
+    def test_known_values_modpath_from_file_1(self):
         self.assertEqual(
             modutils.modpath_from_file(ElementTree.__file__),
             ["xml", "etree", "ElementTree"],
         )
 
-    def test_raise_modpath_from_file_Exception(self):
+    def test_raise_modpath_from_file_exception(self):
         self.assertRaises(Exception, modutils.modpath_from_file, "/turlututu")
 
     def test_import_symlink_with_source_outside_of_path(self):
@@ -297,18 +297,18 @@ class StandardLibModuleTest(resources.SysPathSetup, unittest.TestCase):
 
 
 class IsRelativeTest(unittest.TestCase):
-    def test_knownValues_is_relative_1(self):
+    def test_known_values_is_relative_1(self):
         self.assertTrue(modutils.is_relative("utils", email.__path__[0]))
 
-    def test_knownValues_is_relative_3(self):
+    def test_known_values_is_relative_3(self):
         self.assertFalse(modutils.is_relative("astroid", astroid.__path__[0]))
 
-    def test_knownValues_is_relative_4(self):
+    def test_known_values_is_relative_4(self):
         self.assertTrue(
             modutils.is_relative("util", astroid.interpreter._import.spec.__file__)
         )
 
-    def test_knownValues_is_relative_5(self):
+    def test_known_values_is_relative_5(self):
         self.assertFalse(
             modutils.is_relative(
                 "objectmodel", astroid.interpreter._import.spec.__file__

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -570,7 +570,7 @@ class ConstNodeTest(unittest.TestCase):
 
 
 class NameNodeTest(unittest.TestCase):
-    def test_assign_to_True(self):
+    def test_assign_to_rrue(self):
         """test that True and False assignments don't crash"""
         code = """
             True = False


### PR DESCRIPTION
## Description

Function names should be in snake case. Add a TODO on variable we should remove in 3.0.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


