### PR TITLE
Remove default init values Arguments + fix raw_building

### DIFF
--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1428,22 +1428,22 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         self.kwarg: Optional[str] = kwarg  # can be None
         """The name of the variable length keyword arguments."""
 
-        self.args: typing.List[AssignName] = []
+        self.args: typing.List[AssignName]
         """The names of the required arguments."""
 
-        self.defaults: typing.List[NodeNG] = []
+        self.defaults: typing.List[NodeNG]
         """The default values for arguments that can be passed positionally."""
 
-        self.kwonlyargs: typing.List[AssignName] = []
+        self.kwonlyargs: typing.List[AssignName]
         """The keyword arguments that cannot be passed positionally."""
 
         self.posonlyargs: typing.List[AssignName] = []
         """The arguments that can only be passed positionally."""
 
-        self.kw_defaults: typing.List[Optional[NodeNG]] = []
+        self.kw_defaults: typing.List[Optional[NodeNG]]
         """The default values for keyword arguments that cannot be passed positionally."""
 
-        self.annotations: typing.List[Optional[NodeNG]] = []
+        self.annotations: typing.List[Optional[NodeNG]]
         """The type annotations of arguments that can be passed positionally."""
 
         self.posonlyargs_annotations: typing.List[Optional[NodeNG]] = []

--- a/tests/unittest_raw_building.py
+++ b/tests/unittest_raw_building.py
@@ -66,6 +66,10 @@ class RawBuildingTC(unittest.TestCase):
         node = build_function(name="MyFunction", posonlyargs=["a", "b"])
         self.assertEqual(2, len(node.args.posonlyargs))
 
+    def test_build_function_kwonlyargs(self):
+        node = build_function(name="MyFunction", kwonlyargs=["a", "b"])
+        assert len(node.args.kwonlyargs) == 2
+
     def test_build_from_import(self):
         names = ["exceptions, inference, inspector"]
         node = build_from_import("astroid", names)

--- a/tests/unittest_raw_building.py
+++ b/tests/unittest_raw_building.py
@@ -69,6 +69,8 @@ class RawBuildingTC(unittest.TestCase):
     def test_build_function_kwonlyargs(self):
         node = build_function(name="MyFunction", kwonlyargs=["a", "b"])
         assert len(node.args.kwonlyargs) == 2
+        assert node.args.kwonlyargs[0].name == "a"
+        assert node.args.kwonlyargs[1].name == "b"
 
     def test_build_from_import(self):
         names = ["exceptions, inference, inspector"]


### PR DESCRIPTION
## Description
`args`, `default`, `kwonlyargs`, `kw_defaults`, and `annotations` are required parameter for `Arguments.postinit`. With that it's safe to remove the default initialization values for them as long as `postinit` is always called.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |