### PR TITLE
Add mypy configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         exclude: tests/testdata
         args: [--py36-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.9.1
     hooks:
       - id: isort
         exclude: tests/testdata
@@ -61,6 +61,18 @@ repos:
             # "--load-plugins=pylint.extensions.docparams", We're not ready for that
           ]
         exclude: tests/testdata|conf.py
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.902
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: python
+        types: [python]
+        args: []
+        require_serial: true
+        additional_dependencies: ["types-pkg_resources==0.1.2"]
+        exclude: tests/testdata| # exclude everything, we're not ready
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.1
     hooks:

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -2,3 +2,4 @@ black==21.6b0
 pylint==2.8.2
 isort==5.8.0
 flake8==3.9.2
+mypy==0.902

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,3 +61,27 @@ known_third_party = sphinx, pytest, six, nose, numpy, attr
 known_first_party = astroid
 include_trailing_comma = True
 skip_glob = tests/testdata
+
+[mypy]
+scripts_are_modules = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-nose.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-_io.*]
+ignore_missing_imports = True
+
+[mypy-wrapt.*]
+ignore_missing_imports = True
+
+[mypy-lazy_object_proxy.*]
+ignore_missing_imports = True
+
+[mypy-gi.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,21 @@ skip_glob = tests/testdata
 [mypy]
 scripts_are_modules = True
 
+[mypy-setuptools]
+ignore_missing_imports = True
+
+[mypy-typed_ast]
+ignore_missing_imports = True
+
+[mypy-dateutil]
+ignore_missing_imports = True
+
+[mypy-attr]
+ignore_missing_imports = True
+
+[mypy-six]
+ignore_missing_imports = True
+
 [mypy-pytest]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Description

This add a configuration for mypy in the pre-commit configuration, but not activated yet.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

Required to test #1062 more easily
