### PR TITLE
Add dict as base for TypedDict

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ What's New in astroid 2.6.1?
 ============================
 Release Date: TBA
 
+* Fix issue with ``TypedDict`` for Python 3.9+
+
+  Closes PyCQA/pylint#4610
 
 
 What's New in astroid 2.6.0?

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -201,6 +201,7 @@ def infer_typedDict(  # pylint: disable=invalid-name
         col_offset=node.col_offset,
         parent=node.parent,
     )
+    class_def.postinit(bases=[extract_node("dict")], body=[], decorators=None)
     return iter([class_def])
 
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1623,6 +1623,8 @@ class TypingBrain(unittest.TestCase):
         inferred_base = next(node.bases[0].infer())
         assert isinstance(inferred_base, nodes.ClassDef)
         assert inferred_base.qname() == "typing.TypedDict"
+        typedDict_base = next(inferred_base.bases[0].infer())
+        assert typedDict_base.qname() == "builtins.dict"
 
     @test_utils.require_version(minver="3.7")
     def test_typing_alias_type(self):


### PR DESCRIPTION
## Description

`TypedDict` should inherit from `dict` to be subscriptable.


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Pylint issue: https://github.com/PyCQA/pylint/issues/4610
Regression test: https://github.com/PyCQA/pylint/pull/4611