### PR TITLE
Infer the type of the result of calling typing.cast()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,8 @@ What's New in astroid 2.6.6?
 ============================
 Release date: TBA
 
-* Added support to infer return type of typing.cast()
+* Added support to infer return type of ``typing.cast()``
+
 
 What's New in astroid 2.6.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,7 +11,7 @@ What's New in astroid 2.6.6?
 ============================
 Release date: TBA
 
-
+* Added support to infer return type of typing.cast()
 
 What's New in astroid 2.6.5?
 ============================

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -370,11 +370,18 @@ def infer_typing_cast(
     node: Call, ctx: context.InferenceContext = None
 ) -> typing.Iterator[NodeNG]:
     """Infer call to cast() returning same type as casted-from var"""
+    if not isinstance(node.func, (Name, Attribute)):
+        raise UseInferenceDefault
+
     try:
         func = next(node.func.infer(context=ctx))
     except InferenceError as exc:
         raise UseInferenceDefault from exc
-    if func.qname() != "typing.cast" or len(node.args) != 2:
+    if (
+        not isinstance(func, FunctionDef)
+        or func.qname() != "typing.cast"
+        or len(node.args) != 2
+    ):
         raise UseInferenceDefault
 
     return node.args[1].infer(context=ctx)

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1810,6 +1810,38 @@ class TypingBrain(unittest.TestCase):
             self.assertIsInstance(inferred, nodes.ClassDef)
             self.assertIsInstance(inferred.getattr("__iter__")[0], nodes.FunctionDef)
 
+    def test_typing_cast(self):
+        node = builder.extract_node(
+            """
+        from typing import cast
+        class A:
+            pass
+
+        b = list()
+        a = cast(A, b)
+        a
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, bases.Instance)
+        assert inferred.name == "list"
+
+    def test_typing_cast_attribute(self):
+        node = builder.extract_node(
+            """
+        import typing
+        class A:
+            pass
+
+        b = list()
+        a = typing.cast(A, b)
+        a
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, bases.Instance)
+        assert inferred.name == "list"
+
 
 class ReBrainTest(unittest.TestCase):
     def test_regex_flags(self):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1817,14 +1817,14 @@ class TypingBrain(unittest.TestCase):
         class A:
             pass
 
-        b = list()
+        b = 42
         a = cast(A, b)
         a
         """
         )
         inferred = next(node.infer())
-        assert isinstance(inferred, bases.Instance)
-        assert inferred.name == "list"
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 42
 
     def test_typing_cast_attribute(self):
         node = builder.extract_node(
@@ -1833,14 +1833,14 @@ class TypingBrain(unittest.TestCase):
         class A:
             pass
 
-        b = list()
+        b = 42
         a = typing.cast(A, b)
         a
         """
         )
         inferred = next(node.infer())
-        assert isinstance(inferred, bases.Instance)
-        assert inferred.name == "list"
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 42
 
 
 class ReBrainTest(unittest.TestCase):


### PR DESCRIPTION
## Description

Added an inference rule in `brain_typing.py` to infer the return type of `typing.cast`. So that:

```py
from typing import cast

class A:
    pass

b = cast(A, x)  # Can infer that b is an instance of A
```

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
