### PR TITLE
Rename refs from `master` to `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - 2.*
   pull_request: ~
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: "30 21 * * 2"
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Astroid
 =======
 
-.. image:: https://coveralls.io/repos/github/PyCQA/astroid/badge.svg?branch=master
-    :target: https://coveralls.io/github/PyCQA/astroid?branch=master
+.. image:: https://coveralls.io/repos/github/PyCQA/astroid/badge.svg?branch=main
+    :target: https://coveralls.io/github/PyCQA/astroid?branch=main
 
 .. image:: https://readthedocs.org/projects/astroid/badge/?version=latest
     :target: http://astroid.readthedocs.io/en/latest/?badge=latest
@@ -11,11 +11,11 @@ Astroid
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
-.. image:: https://results.pre-commit.ci/badge/github/PyCQA/astroid/master.svg
-   :target: https://results.pre-commit.ci/latest/github/PyCQA/astroid/master
+.. image:: https://results.pre-commit.ci/badge/github/PyCQA/astroid/main.svg
+   :target: https://results.pre-commit.ci/latest/github/PyCQA/astroid/main
    :alt: pre-commit.ci status
 
-.. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/astroid/master/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
+.. |tideliftlogo| image:: https://raw.githubusercontent.com/PyCQA/astroid/main/doc/media/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White.png
    :width: 75
    :height: 60
    :alt: Tidelift

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-.. Astroid documentation master file, created by
+.. Astroid documentation main file, created by
    sphinx-quickstart on Wed Jun 26 15:00:40 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/doc/release.md
+++ b/doc/release.md
@@ -31,7 +31,7 @@ tbump X.Y+1.Z-dev0 --no-tag --no-push # You can interrupt during copyrite
 git commit -am "Upgrade the version to x.y+1.z-dev0 following x.y.z release"
 ```
 
-Check the result and then upgrade the master branch
+Check the result and then upgrade the main branch
 
 ### Milestone handling
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 deps =
    # We do not use the latest pylint version in CI tests as we want to choose when
    # we fix the warnings
-   git+https://github.com/pycqa/pylint@master
+   git+https://github.com/pycqa/pylint@main
    pre-commit~=2.13
   -r requirements_test_min.txt
 commands = pre-commit run pylint --all-files
@@ -31,7 +31,7 @@ commands =
 basepython = python3
 deps =
     pytest
-    git+https://github.com/pycqa/pylint@master
+    git+https://github.com/pycqa/pylint@main
     pre-commit~=2.13
 commands =
     pre-commit run --all-files


### PR DESCRIPTION
## Description

Rename references from `master` branch to `main`. Should only be applied after the branch has been renamed.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue
https://github.com/PyCQA/pylint/pull/4627