### PR TITLE
Catch the StopIteration that result from PEP-479 or add default value in ``next``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,12 @@ Release date: TBA
 
   Closes PyCQA/pylint#4633
 
+* Fix unhandled StopIteration during inference, following the implementation
+  of PEP479 in python 3.7+
+
+  Closes PyCQA/pylint#4631
+  Closes #1080
+
 What's New in astroid 2.6.1?
 ============================
 Release date: 2021-06-29

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -101,6 +101,8 @@ class CallSite:
                 except InferenceError:
                     values[name] = util.Uninferable
                     continue
+                except StopIteration:
+                    continue
 
                 if not isinstance(inferred, nodes.Dict):
                     # Not something we can work with.
@@ -112,6 +114,8 @@ class CallSite:
                         dict_key = next(dict_key.infer(context=context))
                     except InferenceError:
                         values[name] = util.Uninferable
+                        continue
+                    except StopIteration:
                         continue
                     if not isinstance(dict_key, nodes.Const):
                         values[name] = util.Uninferable
@@ -139,6 +143,8 @@ class CallSite:
                     inferred = next(arg.value.infer(context=context))
                 except InferenceError:
                     values.append(util.Uninferable)
+                    continue
+                except StopIteration:
                     continue
 
                 if inferred is util.Uninferable:

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -74,7 +74,7 @@ def _functools_partial_inference(node, context=None):
     partial_function = call.positional_arguments[0]
     try:
         inferred_wrapped_function = next(partial_function.infer(context=context))
-    except InferenceError as exc:
+    except (InferenceError, StopIteration) as exc:
         raise UseInferenceDefault from exc
     if inferred_wrapped_function is Uninferable:
         raise UseInferenceDefault("Cannot infer the wrapped function")

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -36,7 +36,7 @@ def _multiprocessing_transform():
     try:
         context = next(node["default"].infer())
         base = next(node["base"].infer())
-    except InferenceError:
+    except (InferenceError, StopIteration):
         return module
 
     for node in (context, base):

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -42,7 +42,7 @@ def _nose_tools_functions():
     )
     try:
         case = next(module["a"].infer())
-    except InferenceError:
+    except (InferenceError, StopIteration):
         return
     for method in case.methods():
         if method.name.startswith("assert") and "_" not in method.name:

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -189,7 +189,7 @@ def transform_six_add_metaclass(node):  # pylint: disable=inconsistent-return-st
 
         try:
             func = next(decorator.func.infer())
-        except InferenceError:
+        except (InferenceError, StopIteration):
             continue
         if func.qname() == SIX_ADD_METACLASS and decorator.args:
             metaclass = decorator.args[0]

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -95,21 +95,22 @@ def path_wrapper(func):
 
         yielded = set()
         generator = _func(node, context, **kwargs)
-        try:
-            while True:
+        while True:
+            try:
                 res = next(generator)
-                # unproxy only true instance, not const, tuple, dict...
-                if res.__class__.__name__ == "Instance":
-                    ares = res._proxied
-                else:
-                    ares = res
-                if ares not in yielded:
-                    yield res
-                    yielded.add(ares)
-        except StopIteration as error:
-            if error.args:
-                return error.args[0]
-            return None
+            except StopIteration as error:
+                if error.args:
+                    return error.args[0]
+                return None
+
+            # unproxy only true instance, not const, tuple, dict...
+            if res.__class__.__name__ == "Instance":
+                ares = res._proxied
+            else:
+                ares = res
+            if ares not in yielded:
+                yield res
+                yielded.add(ares)
 
     return wrapped
 
@@ -131,7 +132,6 @@ def yes_if_nothing_inferred(func, instance, args, kwargs):
 @wrapt.decorator
 def raise_if_nothing_inferred(func, instance, args, kwargs):
     generator = func(*args, **kwargs)
-
     try:
         yield next(generator)
     except StopIteration as error:

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -285,6 +285,8 @@ def object_len(node, context=None):
 
     try:
         len_call = next(node_type.igetattr("__len__", context=context))
+    except StopIteration as e:
+        raise AstroidTypeError(str(e)) from e
     except AttributeInferenceError as e:
         raise AstroidTypeError(
             f"object of type '{node_type.pytype()}' has no len()"

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -308,7 +308,10 @@ class FunctionModel(ObjectModel):
                     )
 
                 context = contextmod.copy_context(context)
-                cls = next(caller.args[0].infer(context=context))
+                try:
+                    cls = next(caller.args[0].infer(context=context))
+                except StopIteration as e:
+                    raise InferenceError(context=context, node=caller.args[0]) from e
 
                 if cls is astroid.Uninferable:
                     raise InferenceError(
@@ -705,7 +708,7 @@ class DictModel(ObjectModel):
             def infer_call_result(self, caller, context=None):
                 yield obj
 
-        meth = next(self._instance._proxied.igetattr(name))
+        meth = next(self._instance._proxied.igetattr(name), None)
         return DictMethodBoundMethod(proxy=meth, bound=self._instance)
 
     @property

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -79,7 +79,7 @@ def unpack_infer(stmt, context=None):
             yield from unpack_infer(elt, context)
         return dict(node=stmt, context=context)
     # if inferred is a final node, return it and stop
-    inferred = next(stmt.infer(context))
+    inferred = next(stmt.infer(context), util.Uninferable)
     if inferred is stmt:
         yield inferred
         return dict(node=stmt, context=context)
@@ -185,7 +185,7 @@ def _slice_value(index, context=None):
         # we'll stop at the first possible value.
         try:
             inferred = next(index.infer(context=context))
-        except InferenceError:
+        except (InferenceError, StopIteration):
             pass
         else:
             if isinstance(inferred, Const):


### PR DESCRIPTION
StopIteration exceptions raised directly or indirectly in coroutines
and generators are transformed into RuntimeError exceptions for python
3.7+.

## Description

Handle all the StopIteration and not just the one that caused https://github.com/PyCQA/pylint/issues/4631

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/4631
Closes #1080 

