### PR TITLE
Handle inference fail when calculating lenght of a node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,9 @@ What's New in astroid 2.6.2?
 ============================
 Release date: TBA
 
+* Fix a crash when the inference of the length of a node failed
 
+  Closes PyCQA/pylint#4633
 
 What's New in astroid 2.6.1?
 ============================


### PR DESCRIPTION
## Description

An inference fail was not handled properly.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/4633
