### PR TITLE
Fix copyright links

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Python Abstract Syntax Tree New Generation
 

--- a/astroid/__pkginfo__.py
+++ b/astroid/__pkginfo__.py
@@ -22,7 +22,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 __version__ = "2.6.3-dev0"
 version = __version__

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 from astroid import bases

--- a/astroid/as_string.py
+++ b/astroid/as_string.py
@@ -18,7 +18,7 @@
 # Copyright (c) 2021 pre-commit-ci[bot] <bot@noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """This module renders Astroid nodes as string:
 

--- a/astroid/astroid_manager.py
+++ b/astroid/astroid_manager.py
@@ -7,7 +7,7 @@ AstroidManager() directly.
 """
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 from astroid.manager import AstroidManager

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -17,7 +17,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """This module contains base classes and functions for the nodes and some
 inference utils.

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 """
 Astroid hook for the attrs library
 

--- a/astroid/brain/brain_boto3.py
+++ b/astroid/brain/brain_boto3.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for understanding boto3.ServiceRequest()"""
 from astroid import extract_node

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -15,7 +15,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for various builtins."""
 

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.const import PY37_PLUS

--- a/astroid/brain/brain_curses.py
+++ b/astroid/brain/brain_curses.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.manager import AstroidManager

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 """
 Astroid hook for the dataclasses library
 """

--- a/astroid/brain/brain_dateutil.py
+++ b/astroid/brain/brain_dateutil.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for dateutil"""
 

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import collections.abc
 
 from astroid.manager import AstroidManager

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for the Python 2 GObject introspection bindings.
 

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid brain hints for some of the `http` module."""
 import textwrap

--- a/astroid/brain/brain_hypothesis.py
+++ b/astroid/brain/brain_hypothesis.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 """
 Astroid hook for the Hypothesis library.
 

--- a/astroid/brain/brain_io.py
+++ b/astroid/brain/brain_io.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid brain hints for some of the _io C objects."""
 from astroid import ClassDef

--- a/astroid/brain/brain_mechanize.py
+++ b/astroid/brain/brain_mechanize.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import AstroidBuilder

--- a/astroid/brain/brain_multiprocessing.py
+++ b/astroid/brain/brain_multiprocessing.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 from astroid.bases import BoundMethod
 from astroid.brain.helpers import register_module_extender

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -20,7 +20,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for the Python standard library."""
 

--- a/astroid/brain/brain_nose.py
+++ b/astroid/brain/brain_nose.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Hooks for nose library."""

--- a/astroid/brain/brain_numpy_core_fromnumeric.py
+++ b/astroid/brain/brain_numpy_core_fromnumeric.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for numpy.core.fromnumeric module."""

--- a/astroid/brain/brain_numpy_core_function_base.py
+++ b/astroid/brain/brain_numpy_core_function_base.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for numpy.core.function_base module."""

--- a/astroid/brain/brain_numpy_core_multiarray.py
+++ b/astroid/brain/brain_numpy_core_multiarray.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for numpy.core.multiarray module."""

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for numpy.core.numeric module."""

--- a/astroid/brain/brain_numpy_core_numerictypes.py
+++ b/astroid/brain/brain_numpy_core_numerictypes.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 # TODO(hippo91) : correct the methods signature.
 

--- a/astroid/brain/brain_numpy_core_umath.py
+++ b/astroid/brain/brain_numpy_core_umath.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 # Note: starting with version 1.18 numpy module has `__getattr__` method which prevent
 # `pylint` to emit `no-member` message for all numpy's attributes. (see pylint's module

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for numpy ndarray class."""

--- a/astroid/brain/brain_numpy_random_mtrand.py
+++ b/astroid/brain/brain_numpy_random_mtrand.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 # TODO(hippo91) : correct the functions return types
 """Astroid hooks for numpy.random.mtrand module."""

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Different utilities for the numpy brains"""

--- a/astroid/brain/brain_pkg_resources.py
+++ b/astroid/brain/brain_pkg_resources.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 from astroid import parse

--- a/astroid/brain/brain_pytest.py
+++ b/astroid/brain/brain_pytest.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for pytest."""
 from astroid.brain.helpers import register_module_extender

--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for the PyQT library."""
 

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import random
 
 from astroid import helpers

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 from astroid import context, inference_tip, nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse

--- a/astroid/brain/brain_scipy_signal.py
+++ b/astroid/brain/brain_scipy_signal.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for scipy.signal module."""

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2021 Francis Charette Migneault <francis.charette.migneault@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """Astroid hooks for six module."""

--- a/astroid/brain/brain_ssl.py
+++ b/astroid/brain/brain_ssl.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for the ssl library."""
 

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2021 Damien Baty <damien@damienbaty.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import textwrap
 

--- a/astroid/brain/brain_threading.py
+++ b/astroid/brain/brain_threading.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -6,7 +6,7 @@ However it was not possible to simply add this method inside type's body, otherw
 all types would also have this method. In this case it would have been possible
 to write str[int].
 Guido Van Rossum proposed a hack to handle this in the interpreter:
-https://github.com/python/cpython/blob/master/Objects/abstract.c#L186-L189
+https://github.com/python/cpython/blob/67e394562d67cbcd0ac8114e5439494e7645b8f5/Objects/abstract.c#L181-L184
 
 This brain follows the same logic. It is no wise to add permanently the __class_getitem__ method
 to the type object. Instead we choose to add it only in the case of a subscript node

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 # Copyright (c) 2017-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2017 Łukasz Rogalski <rogalski.91@gmail.com>

--- a/astroid/brain/brain_uuid.py
+++ b/astroid/brain/brain_uuid.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Astroid hooks for the UUID module."""
 from astroid.manager import AstroidManager

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """The AstroidBuilder makes astroid from living object and / or from _ast
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Various context related utilities, including inference and call contexts."""
 import contextlib

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -13,7 +13,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """ A few useful function/method decorators."""
 

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """this module contains exceptions used in the astroid library
 """

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -21,7 +21,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """this module contains a set of functions to handle inference on astroid trees
 """

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -1,5 +1,5 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Transform utilities (filters and decorator)"""
 

--- a/astroid/interpreter/dunder_lookup.py
+++ b/astroid/interpreter/dunder_lookup.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018 Claudiu Popa <pcmanticore@gmail.com>
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Contains logic for retrieving special methods.
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 """
 Data object model, as per https://docs.python.org/3/reference/datamodel.html.
 

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -19,7 +19,7 @@
 # Copyright (c) 2021 pre-commit-ci[bot] <bot@noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """astroid manager: avoid multiple astroid build of a same module when
 possible by providing a class responsible to get astroid representation

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -11,7 +11,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """This module contains some mixins for the different nodes.
 """

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -21,7 +21,7 @@
 # Copyright (c) 2021 DudeNr33 <3929834+DudeNr33@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Python modules manipulation utility functions.
 

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -29,7 +29,7 @@
 # Copyright (c) 2021 Federico Bond <federicobond@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Module for some node classes. More nodes in scoped_nodes.py"""
 

--- a/astroid/nodes.py
+++ b/astroid/nodes.py
@@ -11,7 +11,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Every available node class.
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -19,7 +19,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """this module contains a set of functions to handle python protocols for nodes
 where it makes sense.

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -18,7 +18,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """this module contains a set of functions to create astroid trees from scratch
 (build_* functions) or from living object (object_build_* functions)

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -23,7 +23,7 @@
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """this module contains utilities for rebuilding an _ast tree in
 order to get a single Astroid representation

--- a/astroid/scoped_nodes.py
+++ b/astroid/scoped_nodes.py
@@ -29,7 +29,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 """

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -10,7 +10,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Utility functions for test code that uses astroid ASTs as input."""
 import contextlib

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 import collections

--- a/astroid/util.py
+++ b/astroid/util.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import importlib
 import warnings

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import os
 import sys

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -31,7 +31,7 @@
 # Copyright (c) 2021 Damien Baty <damien@damienbaty.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Tests for basic functionality in astroid.brain."""
 import io

--- a/tests/unittest_brain_numpy_core_fromnumeric.py
+++ b/tests/unittest_brain_numpy_core_fromnumeric.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_core_function_base.py
+++ b/tests/unittest_brain_numpy_core_function_base.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_core_multiarray.py
+++ b/tests/unittest_brain_numpy_core_multiarray.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_core_numerictypes.py
+++ b/tests/unittest_brain_numpy_core_numerictypes.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_core_umath.py
+++ b/tests/unittest_brain_numpy_core_umath.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_ndarray.py
+++ b/tests/unittest_brain_numpy_ndarray.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_brain_numpy_random_mtrand.py
+++ b/tests/unittest_brain_numpy_random_mtrand.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import unittest
 
 try:

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -17,7 +17,7 @@
 # Copyright (c) 2021 pre-commit-ci[bot] <bot@noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """tests for the astroid builder and rebuilder module"""
 

--- a/tests/unittest_helpers.py
+++ b/tests/unittest_helpers.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 import builtins

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -32,7 +32,7 @@
 # Copyright (c) 2021 Francis Charette Migneault <francis.charette.migneault@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """Tests for the astroid inference capabilities"""
 

--- a/tests/unittest_lookup.py
+++ b/tests/unittest_lookup.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """tests for the astroid variable lookup capabilities
 """

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -17,7 +17,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import os
 import platform

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -17,7 +17,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """
 unit tests for module modutils (module manipulation utilities)

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -22,7 +22,7 @@
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """tests for specific behaviour of astroid nodes
 """

--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import unittest
 import xml

--- a/tests/unittest_objects.py
+++ b/tests/unittest_objects.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 import unittest

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 import contextlib

--- a/tests/unittest_python3.py
+++ b/tests/unittest_python3.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import unittest
 from textwrap import dedent

--- a/tests/unittest_raw_building.py
+++ b/tests/unittest_raw_building.py
@@ -11,7 +11,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import platform
 import unittest

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -14,7 +14,7 @@
 # Copyright (c) 2021 Andrew Haigh <hello@nelf.in>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import sys
 import textwrap

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -25,7 +25,7 @@
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """tests for specific behaviour of astroid scoped nodes (i.e. module, class and
 function)

--- a/tests/unittest_transforms.py
+++ b/tests/unittest_transforms.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 
 import contextlib

--- a/tests/unittest_utils.py
+++ b/tests/unittest_utils.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-# For details: https://github.com/PyCQA/astroid/blob/master/LICENSE
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import unittest
 


### PR DESCRIPTION
## Description
Changed the copyright links to `main`. Fixed invalid link to `cpython`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue
Followup to #1079
Pylint PR: https://github.com/PyCQA/pylint/pull/4647
