### PR TITLE
Handle the case where node is a Module in ``brain_builtin_inference``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,9 @@ What's New in astroid 2.6.3?
 ============================
 Release date: TBA
 
+* Fix a crash when the node is a 'Module' in the brain builtin inference
 
+  Closes PyCQA/pylint#4671
 
 What's New in astroid 2.6.2?
 ============================

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -200,7 +200,9 @@ def register_builtin_transform(transform, builtin_name):
 
             if result.lineno is None:
                 result.lineno = node.lineno
-            if result.col_offset is None:
+            # Can be a 'Module' see https://github.com/PyCQA/pylint/issues/4671
+            # We don't have a regression test on this one: tread carefully
+            if hasattr(result, "col_offset") and result.col_offset is None:
                 result.col_offset = node.col_offset
         return iter([result])
 


### PR DESCRIPTION
## Description

This is a blind fix, see the original issue.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes https://github.com/PyCQA/pylint/issues/4671
