### PR TITLE
Update pylint config and remove useless-suppressions

### DIFF
--- a/astroid/const.py
+++ b/astroid/const.py
@@ -15,8 +15,8 @@ class Context(enum.Enum):
 
 
 # TODO Remove in 3.0 in favor of Context
-Load = Context.Load  # pylint: disable=invalid-name
-Store = Context.Store  # pylint: disable=invalid-name
-Del = Context.Del  # pylint: disable=invalid-name
+Load = Context.Load
+Store = Context.Store
+Del = Context.Del
 
 BUILTINS = builtins.__name__  # Could be just 'builtins' ?

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1386,7 +1386,6 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
     #  - we expose 'annotation', a list with annotations for
     #    for each normal argument. If an argument doesn't have an
     #    annotation, its value will be None.
-    # pylint: disable=too-many-instance-attributes
     _astroid_fields = (
         "args",
         "defaults",

--- a/pylintrc
+++ b/pylintrc
@@ -50,7 +50,7 @@ output-format=text
 files-output=no
 
 # Tells whether to display a full report or only the messages
-reports=yes
+reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which


### PR DESCRIPTION
## Description

Coincidentally, I was also working on the `pylint` update when you opened and merged #1094

Besides removing some `useless-suppression` messages, I would like to set `report=no`. That is also the way it's in the pylint repo: [pylint -> pylintrc](https://github.com/PyCQA/pylint/blob/73089b5a02d11d4a2bb9513d3764aec40b873a4a/pylintrc#L85).

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |