### PR TITLE
Fix incorrect scope for functools partials

### DIFF
--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -103,7 +103,7 @@ def _functools_partial_inference(node, context=None):
         doc=inferred_wrapped_function.doc,
         lineno=inferred_wrapped_function.lineno,
         col_offset=inferred_wrapped_function.col_offset,
-        parent=inferred_wrapped_function.parent,
+        parent=node.parent,
     )
     partial_function.postinit(
         args=inferred_wrapped_function.args,

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1209,16 +1209,8 @@ class LookupMixIn:
                 # want to clear previous assignments if any (hence the test on
                 # optional_assign)
                 if not (optional_assign or are_exclusive(_stmts[pindex], node)):
-                    if (
-                        # In case of partial function node, if the statement is different
-                        # from the origin function then it can be deleted otherwise it should
-                        # remain to be able to correctly infer the call to origin function.
-                        not node.is_function
-                        or node.qname() != "PartialFunction"
-                        or node.name != _stmts[pindex].name
-                    ):
-                        del _stmt_parents[pindex]
-                        del _stmts[pindex]
+                    del _stmt_parents[pindex]
+                    del _stmts[pindex]
             if isinstance(node, AssignName):
                 if not optional_assign and stmt.parent is mystmt.parent:
                     _stmts = []

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -260,7 +260,10 @@ class PartialFunction(scoped_nodes.FunctionDef):
     def __init__(
         self, call, name=None, doc=None, lineno=None, col_offset=None, parent=None
     ):
-        super().__init__(name, doc, lineno, col_offset, parent)
+        super().__init__(name, doc, lineno, col_offset, parent=None)
+        # A typical FunctionDef automatically adds its name to the parent scope,
+        # but a partial should not, so defer setting parent until after init
+        self.parent = parent
         self.filled_positionals = len(call.positional_arguments[1:])
         self.filled_args = call.positional_arguments[1:]
         self.filled_keywords = call.keyword_arguments

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -2742,6 +2742,24 @@ class TestFunctoolsPartial:
         scope = partial_func3.parent.scope()
         assert scope.name == "test3_scope", "parented by closure"
 
+    def test_partial_does_not_affect_scope(self):
+        """Make sure partials are not automatically assigned."""
+        ast_nodes = astroid.extract_node(
+            """
+        from functools import partial
+        def test(a, b):
+            return a + b
+        def scope():
+            test2 = partial(test, 1)
+            test2 #@
+        """
+        )
+        test2 = next(ast_nodes.infer())
+        mod_scope = test2.root()
+        scope = test2.parent.scope()
+        assert set(mod_scope) == {"test", "scope", "partial"}
+        assert set(scope) == {"test2"}
+
 
 def test_http_client_brain():
     node = astroid.extract_node(


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

While working on https://github.com/PyCQA/pylint/pull/4357, I happened to notice an issue with partial functions where a given scope had both the original function and some remote partial usage returned by the same inference call.

I tracked the underlying issue to partials having their parents set the original function parent.

So in the [abbreviated] code from pylint/checkers/utils.py below, `func` (`partial(error_of_type, ...)`) gets Module as the parent (and since it has the same name, PartialFunction(name=error_of_type)), both of these values are locals in Module with the same name. This lead to the extremely strange case of `error_of_type(handler, exception)` inferred as both `error_of_type` and `partial(error_of_type, ...)`.
The proper parent for `partial(error_of_type, ...)` should just be the normal assignment to `func`.

```py
def error_of_type(handler: astroid.ExceptHandler, error_type) -> bool:
    pass

def _except_handlers_ignores_exception(
    handlers: astroid.ExceptHandler, exception
) -> bool:
    func = partial(error_of_type, error_type=(exception,))
    return any(func(handler) for handler in handlers)

def get_exception_handlers(
    node: astroid.node_classes.NodeNG, exception=Exception
) -> Optional[List[astroid.ExceptHandler]]:
    context = find_try_except_wrapper_node(node)
    if isinstance(context, astroid.TryExcept):
        return [
            handler for handler in context.handlers if error_of_type(handler, exception)
        ]
    return []
```

This also fixes the underlying issue seen in https://github.com/PyCQA/pylint/issues/2588 / https://github.com/PyCQA/astroid/commit/87b55a6e without a special case.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

https://github.com/PyCQA/pylint/pull/4357
