### PR TITLE
Add new If guard helper methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,12 +6,12 @@ What's New in astroid 2.7.0?
 ============================
 Release date: TBA
 
+* Added ``If.is_sys_guard`` and ``If.is_typing_guard`` helper methods
 
 
 What's New in astroid 2.6.3?
 ============================
 Release date: TBA
-
 
 * Fix a bad inferenece type for yield values inside of a derived class.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,12 +6,12 @@ What's New in astroid 2.7.0?
 ============================
 Release date: TBA
 
-* Added ``If.is_sys_guard`` and ``If.is_typing_guard`` helper methods
-
 
 What's New in astroid 2.6.3?
 ============================
 Release date: TBA
+
+* Added ``If.is_sys_guard`` and ``If.is_typing_guard`` helper methods
 
 * Fix a bad inferenece type for yield values inside of a derived class.
 


### PR DESCRIPTION
## Description
Add `If.is_sys_guard` and `If.is_typing_guard` helper methods. Most useful to check if analysis of the `if` body should be skipped, e.g. because module are not available for the checked python version.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue
https://github.com/PyCQA/pylint/pull/4702
https://github.com/PyCQA/pylint/pull/4703
