### PR TITLE
Guard against missing setuptools

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,8 @@ Release date: TBA
 
   Closes PyCQA/pylint#4715
 
+* Add dependency on setuptools and a guard to prevent related exceptions.
+
 
 What's New in astroid 2.6.2?
 ============================

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -7,4 +7,8 @@ except ImportError:
 
 
 def is_namespace(modname):
-    return pkg_resources is not None and modname in pkg_resources._namespace_packages
+    return (
+        pkg_resources is not None
+        and hasattr(pkg_resources, "_namespace_packages")
+        and modname in pkg_resources._namespace_packages
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ packages = find:
 install_requires =
     lazy_object_proxy>=1.4.0
     wrapt>=1.11,<1.13
+    setuptools>=56.0
     typed-ast>=1.4.0,<1.5;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.7.4;python_version<"3.8"
 python_requires = ~=3.6


### PR DESCRIPTION
Without the dependency on setuptools, poetry won't update setuptools when updating astroid.  And if a user uninstalls setuptools, poetry won't reinstall it when updating.  This causes the cryptic error "'pkg_resources' has no attribute '_namespace_packages' " when running pylint.