### PR TITLE
Make TypedDict instance callable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#4685
 
+* Fix issue that ``TypedDict`` instance wasn't callable.
+
+  Closes PyCQA/pylint#4715
+
 
 What's New in astroid 2.6.2?
 ============================


### PR DESCRIPTION
## Description
Add the `__call__` method to the `TypedDict` class to make sure `TypedDict` instances are callable.

**Note**: In Python 3.8, `TypedDict` was defined as class and not as function.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Ref: https://github.com/PyCQA/pylint/issues/4715