### PR TITLE
Support lookup in nested non-FunctionDef scopes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Release date: TBA
 
   Closes PyCQA/pylint#4685
 
+* Fix lookup for nested non-function scopes
 
 What's New in astroid 2.6.2?
 ============================


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Currently astroid's lookup algorithm does not correctly handle nested non-function scopes in some cases. For example:

```python
[[i + j for j in range(20)] for i in range(10)]
```

Calling lookup on the `Name` node for `i` in the inner comprehension doesn't return the `i` from the outer comprehension.

```pyconsole
>>> import astroid
>>> ast = astroid.extract_node('[[i + j for j in range(20)] for i in range(10)]')
>>> i_name = [name for name in ast.nodes_of_class(astroid.Name) if name.name == 'i'][0]
>>> i_name.lookup('i')
(<Module.builtins l.0 at 0x213fe117b50>, ())
```

I believe the same issue is the cause of https://github.com/PyCQA/pylint/issues/3711#issuecomment-692649149.

Currently, `LocalsDictNodeNG._scope_lookup` has this block:

```python
        if self.parent:  # i.e. not Module
            # nested scope: if parent scope is a function, that's fine
            # else jump to the module
            pscope = self.parent.scope()
            if not pscope.is_function:
                pscope = pscope.root()
            return pscope.scope_lookup(node, name)
```

This is used during lookup to determine the next enclosing scope to search for, if the search in the current scope didn't find any results. Currently, all non-function scopes are skipped over (`if not pscope.is_function`), and the algorithm goes straight to the top-level. I believe this was written because of this part of the [Python spec](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding):

> Class definition blocks and arguments to exec() and eval() are special in the context of name resolution. A class definition is an executable statement that may use and define names. These references follow the normal rules for name resolution with an exception that unbound local variables are looked up in the global namespace. The namespace of the class definition becomes the attribute dictionary of the class. The scope of names defined in a class block is limited to the class block; it does not extend to the code blocks of methods – this includes comprehensions and generator expressions since they are implemented using a function scope. This means that the following will fail:
>
> ```python
> class A:
>     a = 42
>     b = list(a + i for i in range(10))

So `ClassDef`s should be skipped in the lookup, but other possible enclosing scope types (`ComprehensionScope`, `Lambda`) shouldn't be.

I've changed the code to search for the nearest enclosing non-`ClassDef` scope instead, and added additional tests to illustrate what I mean. Note that `test_function_nested` and `test_class_variables` also pass with the current implementation, but I added them for completeness.

Using my above example, after this change we get the following result:

```pyconsole
>>> import astroid
>>> ast = astroid.extract_node('[[i + j for j in range(20)] for i in range(10)]')
>>> i_name = [name for name in ast.nodes_of_class(astroid.Name) if name.name == 'i'][0]
>>> i_name.lookup('i')
(<ListComp l.1 at 0x2a95c196580>, [<AssignName.i l.1 at 0x2a95c196940>])
```

*Comment*: Given that the lookup algorithm is pretty central to astroid/pylint, I'm sure you want to be conservative in making changes to it! Please let me know if there are other tests you'd like me to include, or other cases I'm not aware of. 😄 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
