### PR TITLE
Fix wrong exception raised in infer_import_from

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,11 @@ Release date: TBA
 
   Closes PyCQA/pylint#4439
 
+* Fix a crash when a AttributeInferenceError was raised when
+ failing to find the real name in infer_import_from.
+
+  Closes PyCQA/pylint#4692
+
 
 What's New in astroid 2.6.4?
 ============================

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -273,8 +273,11 @@ def infer_import_from(self, context=None, asname=True):
     if name is None:
         raise InferenceError(node=self, context=context)
     if asname:
-        name = self.real_name(name)
-
+        try:
+            name = self.real_name(name)
+        except AttributeInferenceError as exc:
+            # See https://github.com/PyCQA/pylint/issues/4692
+            raise InferenceError(node=self, context=context) from exc
     try:
         module = self.do_import_module()
     except AstroidBuildingError as exc:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6155,6 +6155,20 @@ def test_issue926_binop_referencing_same_name_is_not_uninferable():
     assert inferred[0].value == 3
 
 
+def test_pylint_issue_4692_attribute_inference_error_in_infer_import_from():
+    """https://github.com/PyCQA/pylint/issues/4692"""
+    code = """
+import click
+
+
+for name, item in click.__dict__.items():
+    _ = isinstance(item, click.Command) and item != 'foo'
+    """
+    node = extract_node(code)
+    with pytest.raises(InferenceError):
+        list(node.infer())
+
+
 def test_issue_1090_infer_yield_type_base_class():
     code = """
 import contextlib


### PR DESCRIPTION
## Description

We expect to raise InferenceError not AttributeInferenceError in this function.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/4692
