### PR TITLE
Improve logic of variable lookup (LookupMixin._filter_stmts)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release date: TBA
 
 * Added support to infer return type of ``typing.cast()``
 
+* Fix variable lookup's handling of exclusive statements
+
+  Closes PyCQA/pylint#3711
+
 
 What's New in astroid 2.6.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#3711
 
+* Fix variable lookup's handling of function parameters
+
+  Closes PyCQA/astroid#180
+
 
 What's New in astroid 2.6.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,8 @@ Release date: TBA
 
   Closes PyCQA/astroid#180
 
+* Fix variable lookup's handling of except clause variables
+
 
 What's New in astroid 2.6.5?
 ============================

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1211,17 +1211,26 @@ class LookupMixIn:
                 if not (optional_assign or are_exclusive(_stmts[pindex], node)):
                     del _stmt_parents[pindex]
                     del _stmts[pindex]
+
+            # If self and node are exclusive, then we can ignore node
+            if are_exclusive(self, node):
+                continue
+
             if isinstance(node, AssignName):
+                # Remove all previously stored assignments if:
+                #   1. node's statement always assigns
+                #   2. node has the same parent as self (i.e., they're in the same block)
                 if not optional_assign and stmt.parent is mystmt.parent:
                     _stmts = []
                     _stmt_parents = []
             elif isinstance(node, DelName):
+                # Remove all previously stored assignments
                 _stmts = []
                 _stmt_parents = []
                 continue
-            if not are_exclusive(self, node):
-                _stmts.append(node)
-                _stmt_parents.append(stmt.parent)
+            # Add the new assignment
+            _stmts.append(node)
+            _stmt_parents.append(stmt.parent)
         return _stmts
 
 

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -1220,7 +1220,18 @@ class LookupMixIn:
             #   1. node's statement always assigns
             #   2. node and self are in the same block (i.e., has the same parent as self)
             if isinstance(node, AssignName):
-                if not optional_assign and stmt.parent is mystmt.parent:
+                if isinstance(stmt, ExceptHandler):
+                    # If node's statement is an ExceptHandler, then it is the variable
+                    # bound to the caught exception. If self is not contained within
+                    # the exception handler block, node should override previous assignments;
+                    # otherwise, node should be ignored, as an exception variable
+                    # is local to the handler block.
+                    if stmt.parent_of(self):
+                        _stmts = []
+                        _stmt_parents = []
+                    else:
+                        continue
+                elif not optional_assign and stmt.parent is mystmt.parent:
                     _stmts = []
                     _stmt_parents = []
             elif isinstance(node, DelName):

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4805,6 +4805,24 @@ class ArgumentsTest(unittest.TestCase):
             inferred = next(node.infer())
             self.assertEqual(inferred, util.Uninferable)
 
+    def test_args_overwritten(self):
+        # https://github.com/PyCQA/astroid/issues/180
+        node = extract_node(
+            """
+        next = 42
+        def wrapper(next=next):
+             next = 24
+             def test():
+                 return next
+             return test
+        wrapper()() #@
+        """
+        )
+        inferred = node.inferred()
+        self.assertEqual(len(inferred), 1)
+        self.assertIsInstance(inferred[0], nodes.Const, inferred[0])
+        self.assertEqual(inferred[0].value, 24)
+
 
 class SliceTest(unittest.TestCase):
     def test_slice(self):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

My interest in astroid's lookup algorithm was piqued so I found some outstanding issues to investigate. This PR contains three logical changes, but I decided to submit just one PR because my fixes are all in the same function, `LookupMixin._filter_stmts`, which is the main helper method for determining which assignment/delete statements are "relevant" for a given variable.

To help review, I split up the PR into three different commits, one for each issue. If you'd like, I can also make three separate PRs from them, no big deal. I also added a bunch of test cases for each one---including some test cases for existing correct behaviour, as I wasn't sure whether these cases for `lookup` were being tested indirectly elsewhere in the test suite. Happy to delete some tests I added if they're redundant.

1. https://github.com/PyCQA/pylint/issues/3711. The issue here was that an assignment statement to a variable in one branch of an if statement overrode statements associated with a use of that variable in another branch:

    ```py
    >>> import astroid
    >>> ast = astroid.parse("""
    ...     x = 10
    ...     if x > 10:
    ...         x = 100
    ...     elif x > 0:
    ...         x = 200
    ... """)
    >>> node = [n for n in ast.nodes_of_class(astroid.Name) if n.name == 'x'][1]  # the x in x > 0
    >>> node.lookup('x')  # This should return the `x` from `x = 10`
    (<Module.builtins l.0 at 0x1f3b2e1fdf0>, ())
    ```

    Fixed it by explicitly ignoring statements that "`are_exclusive`" with the variable in `_filter_stmts`. Note that there had previously been a check for this, I just moved the check up a bit.

2. https://github.com/PyCQA/astroid/issues/180. The issue here was that `AssignName` nodes representing function parameters didn't have a "`_parent_stmts`" value consistent with the other nodes in the function's body: doing `node.statement().parent` returns the parent of the `FunctionDef`, which won't result in a "match" at this check in `_filter_stmts`:

    https://github.com/PyCQA/astroid/blob/22e0cdcfcdff3ea80142ba6b90758b42a85ed8e0/astroid/node_classes.py#L1178-L1179

    This results in the following error:

    ```py
    >>> ast = astroid.parse("""
    ...     def f(x):
    ...         x = 100
    ...         if True:
    ...             print(x)
    ... """)
    >>> name = [n for n in ast.nodes_of_class(astroid.Name) if n.name == 'x'][0]
    >>> name.lookup('x')  # should only be the x = 100
    (<FunctionDef.f2 l.1 at 0x1f3b39b4dc0>, [<AssignName.x l.2 at 0x1f3b39b45b0>, <AssignName.x l.3 at 0x1f3b39b4b80>])
    ```

    One subtlety: because of this check,

    https://github.com/PyCQA/astroid/blob/22e0cdcfcdff3ea80142ba6b90758b42a85ed8e0/astroid/node_classes.py#L1222-L1225

    the bug only occurs when the variable being used does *not* have the same parent as the assignment statement overwriting the function parameter, which is why I included the strange `if True:` above. (*Comment: I wonder if this check was actually an attempt to fix this same problem?*)

    The fix I added was to have a special case for `Arguments` nodes when updating `_stmt_parents`. Not a big fan of having special cases like this, but not sure if there's a cleaner way. 

3. (**Edit: the change is inspired by, but does not fix, the issue**) https://github.com/PyCQA/pylint/issues/626. The issue here is pretty straightforward, `ExceptHandler`s have their own local scope for the exception variable, as of [Python 3](https://www.python.org/dev/peps/pep-3110/). From the [Python spec](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement):

    > When an exception has been assigned using as target, it is cleared at the end of the except clause.

    Here's an example:

    ```py
    >>> ast = astroid.parse("""
    ...     try:
    ...         1 / 0
    ...     except ZeroDivisionError as e:
    ...         pass
    ...     print(e)
    ... """)
    >>> name = [n for n in ast.nodes_of_class(astroid.Name) if n.name == 'e'][0]
    >>> name.lookup('e')  # Should be empty
    (<Module l.0 at 0x1f3b39bbc70>, [<AssignName.e l.4 at 0x1f3b39bbd00>])
    ```

    My fix here was a bit clunky, adding a special case to reset the accumulated assignments in `_filter_stmts` if the variable being was was inside the `ExceptHandler` that bound that variable, and otherwise to skip that `AssignName`.  I think it would be possible (preferred?) to make `ExceptHandler` its own scope (and subclass `LocalsDictNodeNG`), but this was a bigger change and so didn't want to make that change without discussion.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes PyCQA/pylint#3711
Closes PyCQA/astroid#180
~~Closes~~ Ref PyCQA/pylint#626. The issue still occurs in pylint, see https://github.com/PyCQA/astroid/pull/1111#issuecomment-890250023.
