### PR TITLE
Support inference of Enum subclasses.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,13 @@ Release date: TBA
 * Import from ``astroid.node_classes`` and ``astroid.scoped_nodes`` has been deprecated in favor of
   ``astroid.nodes``. Only the imports from ``astroid.nodes`` will work in astroid 3.0.0.
 
+* Add support for arbitrary Enum subclass hierachies
+
+  Closes PyCQA/pylint#533
+  Closes PyCQA/pylint#2224
+  Closes PyCQA/pylint#2626
+
+
 What's New in astroid 2.6.7?
 ============================
 Release date: TBA

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -417,9 +417,9 @@ def infer_enum_class(node):
                     # should result in some nice symbolic execution
                     classdef += INT_FLAG_ADDITION_METHODS.format(name=target.name)
 
-                fake = AstroidBuilder(AstroidManager(), apply_transforms=False).string_build(classdef)[
-                    target.name
-                ]
+                fake = AstroidBuilder(
+                    AstroidManager(), apply_transforms=False
+                ).string_build(classdef)[target.name]
                 fake.parent = target.parent
                 for method in node.mymethods():
                     fake.locals[method.name] = [method]
@@ -564,13 +564,15 @@ def _is_enum_subclass(cls: astroid.ClassDef) -> bool:
             attr = 1
     """
     mod_locals = cls.root().locals
-    if ('enum' not in mod_locals and
-            all(base not in mod_locals for base in ENUM_BASE_NAMES)):
+    if "enum" not in mod_locals and all(
+        base not in mod_locals for base in ENUM_BASE_NAMES
+    ):
         return False
 
     try:
         return any(
-            klass.name in ENUM_BASE_NAMES and getattr(klass.root(), "name", None) == "enum"
+            klass.name in ENUM_BASE_NAMES
+            and getattr(klass.root(), "name", None) == "enum"
             for klass in cls.mro()
         )
     except MroError:
@@ -584,9 +586,7 @@ AstroidManager().register_transform(
     nodes.Call, inference_tip(infer_enum), _looks_like_enum
 )
 AstroidManager().register_transform(
-    nodes.ClassDef,
-    infer_enum_class,
-    predicate=_is_enum_subclass
+    nodes.ClassDef, infer_enum_class, predicate=_is_enum_subclass
 )
 AstroidManager().register_transform(
     nodes.ClassDef, inference_tip(infer_typing_namedtuple_class), _has_namedtuple_base

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -28,12 +28,14 @@ import functools
 import keyword
 from textwrap import dedent
 
+import astroid
 from astroid import arguments, inference_tip, nodes, util
 from astroid.builder import AstroidBuilder, extract_node
 from astroid.exceptions import (
     AstroidTypeError,
     AstroidValueError,
     InferenceError,
+    MroError,
     UseInferenceDefault,
 )
 from astroid.manager import AstroidManager
@@ -354,9 +356,7 @@ INT_FLAG_ADDITION_METHODS = """
 
 def infer_enum_class(node):
     """Specific inference for enums."""
-    for basename in node.basenames:
-        # TODO: doesn't handle subclasses yet. This implementation
-        # is a hack to support enums.
+    for basename in (b for cls in node.mro() for b in cls.basenames):
         if basename not in ENUM_BASE_NAMES:
             continue
         if node.root().name == "enum":
@@ -417,7 +417,7 @@ def infer_enum_class(node):
                     # should result in some nice symbolic execution
                     classdef += INT_FLAG_ADDITION_METHODS.format(name=target.name)
 
-                fake = AstroidBuilder(AstroidManager()).string_build(classdef)[
+                fake = AstroidBuilder(AstroidManager(), apply_transforms=False).string_build(classdef)[
                     target.name
                 ]
                 fake.parent = target.parent
@@ -544,6 +544,39 @@ def infer_typing_namedtuple(node, context=None):
     return infer_named_tuple(node, context)
 
 
+def _is_enum_subclass(cls: astroid.ClassDef) -> bool:
+    """Return whether cls is a subclass of an Enum.
+
+    Warning: For efficiency purposes, this function immediately returns False if enum hasn't
+    been imported in the module of the ClassDef. This means it fails to detect an Enum
+    subclass that is imported from a new module and subclassed, e.g.
+
+        # a.py
+        import enum
+
+        class A(enum.Enum):
+            pass
+
+        # b.py
+        from a import A
+
+        class B(A):  # is_enum_subclass returns False
+            attr = 1
+    """
+    mod_locals = cls.root().locals
+    if ('enum' not in mod_locals and
+            all(base not in mod_locals for base in ENUM_BASE_NAMES)):
+        return False
+
+    try:
+        return any(
+            klass.name in ENUM_BASE_NAMES and getattr(klass.root(), "name", None) == "enum"
+            for klass in cls.mro()
+        )
+    except MroError:
+        return False
+
+
 AstroidManager().register_transform(
     nodes.Call, inference_tip(infer_named_tuple), _looks_like_namedtuple
 )
@@ -553,9 +586,7 @@ AstroidManager().register_transform(
 AstroidManager().register_transform(
     nodes.ClassDef,
     infer_enum_class,
-    predicate=lambda cls: any(
-        basename for basename in cls.basenames if basename in ENUM_BASE_NAMES
-    ),
+    predicate=_is_enum_subclass
 )
 AstroidManager().register_transform(
     nodes.ClassDef, inference_tip(infer_typing_namedtuple_class), _has_namedtuple_base

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -545,30 +545,7 @@ def infer_typing_namedtuple(node, context=None):
 
 
 def _is_enum_subclass(cls: astroid.ClassDef) -> bool:
-    """Return whether cls is a subclass of an Enum.
-
-    Warning: For efficiency purposes, this function immediately returns False if enum hasn't
-    been imported in the module of the ClassDef. This means it fails to detect an Enum
-    subclass that is imported from a new module and subclassed, e.g.
-
-        # a.py
-        import enum
-
-        class A(enum.Enum):
-            pass
-
-        # b.py
-        from a import A
-
-        class B(A):  # is_enum_subclass returns False
-            attr = 1
-    """
-    mod_locals = cls.root().locals
-    if "enum" not in mod_locals and all(
-        base not in mod_locals for base in ENUM_BASE_NAMES
-    ):
-        return False
-
+    """Return whether cls is a subclass of an Enum."""
     try:
         return any(
             klass.name in ENUM_BASE_NAMES

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -2963,8 +2963,11 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         for stmt in self.bases:
             try:
                 # Find the first non-None inferred base value
-                baseobj = next(b for b in stmt.infer(context=context.clone())
-                               if not (isinstance(b, Const) and b.value is None))
+                baseobj = next(
+                    b
+                    for b in stmt.infer(context=context.clone())
+                    if not (isinstance(b, Const) and b.value is None)
+                )
             except (InferenceError, StopIteration):
                 continue
             if isinstance(baseobj, bases.Instance):

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -63,7 +63,7 @@ from astroid.exceptions import (
 from astroid.interpreter.dunder_lookup import lookup
 from astroid.interpreter.objectmodel import ClassModel, FunctionModel, ModuleModel
 from astroid.manager import AstroidManager
-from astroid.nodes import node_classes
+from astroid.nodes import Const, node_classes
 
 ITER_METHODS = ("__iter__", "__getitem__")
 EXCEPTION_BASE_CLASSES = frozenset({"Exception", "BaseException"})
@@ -2962,7 +2962,9 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         for stmt in self.bases:
             try:
-                baseobj = next(stmt.infer(context=context.clone()))
+                # Find the first non-None inferred base value
+                baseobj = next(b for b in stmt.infer(context=context.clone())
+                               if not (isinstance(b, Const) and b.value is None))
             except (InferenceError, StopIteration):
                 continue
             if isinstance(baseobj, bases.Instance):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1137,7 +1137,7 @@ class EnumBrainTest(unittest.TestCase):
         class EnumSubclass(Enum):
             pass
         """,
-            "a"
+            "a",
         )
         ast_node = astroid.extract_node(
             """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Currently, the `infer_enum_class` inference tip is only applies to classes that have `Enum`/`IntEnum`/`IntFlag` as direct bases, but not when they have one of these classes higher up in an inheritance hierarchy, like

```python
from enum import Enum

class A(Enum):
    pass

class B(A):  # Is an Enum, but doesn't have infer_enum_class activated
    attr = 1
```

I addressed this by:

1. Ensuring `Enum` would correctly appear when `ClassDef.mro` is called on a subclass of `Enum`.
    
    This required a change in `ClassDef._inferred_bases` to ignore any `Const.None` inference values, because `Enum` is first initialized to `None` in `enum.py`:

https://github.com/python/cpython/blob/0eec6276fdcdde5221370d92b50ea95851760c72/Lib/enum.py#L18-L21

2. Setting `infer_enum_class` to be called whenever one of the `Enum` built-in classes appear the mro. However, this required calling `ClassDef.mro` on every `ClassDef` node, which was a pretty significant change and potentially performance hit, compared to the previous (constant-time) check. So I put in a guard to only do this when we detect that `enum` of one of the built-in enum types has been imported, though this causes a false negative (see docstring of the new predicate function).

    I'm not sure there's a better way to solve this problem than searching through the mro, at least using what `astroid` already provides, but definitely open to ideas.

### Additional comments

1. I also added a check for the module name, so that a user-defined `Enum`/`IntEnum`/`IntFlag` class won't trigger this inference tip. In principle this causes a false negative if the user writes their own `Enum` class based on the `EnumMeta` metaclass, but I figured this would be very rare.
2. This change causes an existing test in pylint to fail, on this line:

    https://github.com/PyCQA/pylint/blob/a379cc4df1ad303021628eca90e34b98c36c1b2b/tests/functional/a/arguments_renamed.py#L20

    The reason is `Condiments()` should just be `Condiments`; since `Condiments` is defined as an `Enum`, its constructor requires a value argument. To be honest I'm not sure why this error wasn't caught before, but it failed now when I tested these changes out locally.
3. I put the Changelog entry under 2.7.0 since the mro check seemed like a more substantial change. But I could easily move this to 2.6.7.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Closes PyCQA/pylint#533
Closes PyCQA/pylint#2224
Closes PyCQA/pylint#2626

As an aside, I found two related issues that I think no longer reproduce on master: PyCQA/pylint#2263 and PyCQA/pylint#3649. You might want to check those out and close the issues if you can't reproduce them either?