### PR TITLE
Restrict type inference of dataclass attributes.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,10 @@ What's New in astroid 2.7.1?
 ============================
 Release date: TBA
 
+* When processing dataclass attributes, only do typing inference on collection types.
+  Support for instantiating other typing types is left for the future, if desired.
 
+  Closes #1129
 
 What's New in astroid 2.7.0?
 ============================


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

The change in #1126 used type annotations to infer `Instance` values for instance attributes of dataclasses:

https://github.com/PyCQA/astroid/blob/f5f1125e31b85f2c2002189c8ad95a691fd56c83/astroid/brain/brain_dataclasses.py#L82-L111

This works well for most types, but type annotations from `typing` are different: they don't exactly represent new classes themselves, but really are "hints" about what the type of a variable should be. But the current code isn't aware of this, and so creates `Instance`s of these type annotation classes.

For generic collection types like `typing.List`, this isn't an issue, since astroid proxies these to the corresponding built-in collection (like `list`), see `astroid/brain/brain_typing.py` (I think, haven't looked into the details). But for other types this is an issue, since 1-to-1 proxying doesn't always make sense.

In #1129, an attribute is inferred to be an `Instance of typing.Callable`, but that class doesn't have a `__call__` method, leading to a `not-callable` pylint error. This caused a regression because the previously-inferred value, `Uninferable`, was more permissive and caused pylint to skip these kinds of typechecks.

So for now I've **created an allowed list of typing types for which astroid support inference**, and currently included only the generic collection types. All other type annotations from `typing` will revert to yielding `Uninferable`.

You'll also note that I've pulled out the type annotation inference code into a separate protected function, but left it in `brain_dataclasses.py`. It could be made public, extended, and used more generically, but... I didn't want to rock the boat, so leaving that discussion to later. 😅 

### More testing

On the pylint side, all of the typecheck checkers should include a new cases for dataclass attributes, which are using this new approach. Hopefully to prevent new regressions like #1129 in the future. I can work on this later, but I think I'm going to take some time off astroid/pylint after this immediate issue gets resolved.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Closes #1129 