### PR TITLE
Fixed import of LookupMixIn from astroid.node_classes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ What's New in astroid 2.7.1?
 ============================
 Release date: TBA
 
+* Fixed LookupMixIn missing from ``astroid.node_classes``.
+
 
 
 What's New in astroid 2.7.0?

--- a/astroid/node_classes.py
+++ b/astroid/node_classes.py
@@ -46,6 +46,7 @@ from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (E
     JoinedStr,
     Keyword,
     List,
+    LookupMixIn,
     Match,
     MatchAs,
     MatchCase,


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This change reinstates being able to import LookupMixIn from `astroid.node_classes`, which went missing since the contents of `astroid.node_classes` was moved to `astroid.nodes.node_classes`.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

See https://github.com/readthedocs/sphinx-autoapi/issues/301