### PR TITLE
 Replace the constant ``BUILTINS`` by the string 'builtins'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,8 @@ What's New in astroid 2.8.0?
 ============================
 Release date: TBA
 
-
+* ``astroid.const.BUILTINS`` and ``astroid.bases.BUILTINS`` have been removed,
+  simply replace this by the string 'builtins' for better performances.
 
 What's New in astroid 2.7.2?
 ============================

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -29,7 +29,7 @@ import collections
 
 from astroid import context as contextmod
 from astroid import decorators, util
-from astroid.const import BUILTINS, PY310_PLUS
+from astroid.const import PY310_PLUS
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -45,7 +45,7 @@ manager = util.lazy_import("manager")
 # TODO: check if needs special treatment
 BOOL_SPECIAL_METHOD = "__bool__"
 
-PROPERTIES = {BUILTINS + ".property", "abc.abstractproperty"}
+PROPERTIES = {"builtins.property", "abc.abstractproperty"}
 if PY310_PLUS:
     PROPERTIES.add("enum.property")
 
@@ -94,7 +94,7 @@ def _is_property(meth, context=None):
                 if base_class.__class__.__name__ != "Name":
                     continue
                 module, _ = base_class.lookup(base_class.name)
-                if module.name == BUILTINS and base_class.name == "property":
+                if module.name == "builtins" and base_class.name == "property":
                     return True
 
     return False
@@ -394,7 +394,7 @@ class UnboundMethod(Proxy):
         # instance of the class given as first argument.
         if (
             self._proxied.name == "__new__"
-            and self._proxied.parent.frame().qname() == "%s.object" % BUILTINS
+            and self._proxied.parent.frame().qname() == "builtins.object"
         ):
             if caller.args:
                 node_context = context.extra_context.get(caller.args[0])
@@ -445,7 +445,7 @@ class BoundMethod(UnboundMethod):
         if mcs.__class__.__name__ != "ClassDef":
             # Not a valid first argument.
             return None
-        if not mcs.is_subtype_of("%s.type" % BUILTINS):
+        if not mcs.is_subtype_of("builtins.type"):
             # Not a valid metaclass.
             return None
 
@@ -558,7 +558,7 @@ class Generator(BaseInstance):
         return False
 
     def pytype(self):
-        return "%s.generator" % BUILTINS
+        return "builtins.generator"
 
     def display_type(self):
         return "Generator"
@@ -579,7 +579,7 @@ class AsyncGenerator(Generator):
     """Special node representing an async generator"""
 
     def pytype(self):
-        return "%s.async_generator" % BUILTINS
+        return "builtins.async_generator"
 
     def display_type(self):
         return "AsyncGenerator"

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -44,6 +44,7 @@ manager = util.lazy_import("manager")
 
 # TODO: check if needs special treatment
 BOOL_SPECIAL_METHOD = "__bool__"
+BUILTINS = "builtins"  # TODO Remove in 2.8
 
 PROPERTIES = {"builtins.property", "abc.abstractproperty"}
 if PY310_PLUS:

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -5,6 +5,7 @@ PY37_PLUS = sys.version_info >= (3, 7)
 PY38_PLUS = sys.version_info >= (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)
 PY310_PLUS = sys.version_info >= (3, 10)
+BUILTINS = "builtins"  # TODO Remove in 2.8
 
 
 class Context(enum.Enum):

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -1,4 +1,3 @@
-import builtins
 import enum
 import sys
 
@@ -18,5 +17,3 @@ class Context(enum.Enum):
 Load = Context.Load
 Store = Context.Store
 Del = Context.Del
-
-BUILTINS = builtins.__name__  # Could be just 'builtins' ?

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -21,7 +21,6 @@ Various helper utilities.
 from astroid import bases
 from astroid import context as contextmod
 from astroid import manager, nodes, raw_building, util
-from astroid.const import BUILTINS
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -40,7 +39,7 @@ def _build_proxy_class(cls_name, builtins):
 
 def _function_type(function, builtins):
     if isinstance(function, scoped_nodes.Lambda):
-        if function.root().name == BUILTINS:
+        if function.root().name == "builtins":
             cls_name = "builtin_function_or_method"
         else:
             cls_name = "function"

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -45,7 +45,7 @@ from typing import Callable, Generator, Optional
 from astroid import bases
 from astroid import context as contextmod
 from astroid import decorators, mixins, util
-from astroid.const import BUILTINS, Context
+from astroid.const import Context
 from astroid.exceptions import (
     AstroidIndexError,
     AstroidTypeError,
@@ -2191,7 +2191,7 @@ class Dict(NodeNG, bases.Instance):
         :returns: The name of the type.
         :rtype: str
         """
-        return "%s.dict" % BUILTINS
+        return "builtins.dict"
 
     def get_children(self):
         """Get the key and value nodes below this node.
@@ -3083,7 +3083,7 @@ class List(BaseContainer):
         :returns: The name of the type.
         :rtype: str
         """
-        return "%s.list" % BUILTINS
+        return "builtins.list"
 
     def getitem(self, index, context=None):
         """Get an item from this node.
@@ -3278,7 +3278,7 @@ class Set(BaseContainer):
         :returns: The name of the type.
         :rtype: str
         """
-        return "%s.set" % BUILTINS
+        return "builtins.set"
 
 
 class Slice(NodeNG):
@@ -3356,7 +3356,7 @@ class Slice(NodeNG):
         :returns: The name of the type.
         :rtype: str
         """
-        return "%s.slice" % BUILTINS
+        return "builtins.slice"
 
     def igetattr(self, attrname, context=None):
         """Infer the possible values of the given attribute on the slice.
@@ -3710,7 +3710,7 @@ class Tuple(BaseContainer):
         :returns: The name of the type.
         :rtype: str
         """
-        return "%s.tuple" % BUILTINS
+        return "builtins.tuple"
 
     def getitem(self, index, context=None):
         """Get an item from this node.

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -49,7 +49,7 @@ from astroid import bases
 from astroid import context as contextmod
 from astroid import decorators as decorators_mod
 from astroid import mixins, util
-from astroid.const import BUILTINS, PY39_PLUS
+from astroid.const import PY39_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidTypeError,
@@ -575,7 +575,7 @@ class Module(LocalsDictNodeNG):
         :returns: The name of the type.
         :rtype: str
         """
-        return "%s.module" % BUILTINS
+        return "builtins.module"
 
     def display_type(self):
         """A human readable type of this node.
@@ -1137,9 +1137,9 @@ def _infer_decorator_callchain(node):
     if isinstance(result, bases.Instance):
         result = result._proxied
     if isinstance(result, ClassDef):
-        if result.is_subtype_of("%s.classmethod" % BUILTINS):
+        if result.is_subtype_of("builtins.classmethod"):
             return "classmethod"
-        if result.is_subtype_of("%s.staticmethod" % BUILTINS):
+        if result.is_subtype_of("builtins.staticmethod"):
             return "staticmethod"
     if isinstance(result, FunctionDef):
         if not result.decorators:
@@ -1152,7 +1152,7 @@ def _infer_decorator_callchain(node):
             if (
                 isinstance(decorator, node_classes.Attribute)
                 and isinstance(decorator.expr, node_classes.Name)
-                and decorator.expr.name == BUILTINS
+                and decorator.expr.name == "builtins"
                 and decorator.attrname in BUILTIN_DESCRIPTORS
             ):
                 return decorator.attrname
@@ -1241,8 +1241,8 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         :rtype: str
         """
         if "method" in self.type:
-            return "%s.instancemethod" % BUILTINS
-        return "%s.function" % BUILTINS
+            return "builtins.instancemethod"
+        return "builtins.function"
 
     def display_type(self):
         """A human readable type of this node.
@@ -1541,7 +1541,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
             if (
                 isinstance(node, node_classes.Attribute)
                 and isinstance(node.expr, node_classes.Name)
-                and node.expr.name == BUILTINS
+                and node.expr.name == "builtins"
                 and node.attrname in BUILTIN_DESCRIPTORS
             ):
                 return node.attrname
@@ -1571,9 +1571,9 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                     for ancestor in inferred.ancestors():
                         if not isinstance(ancestor, ClassDef):
                             continue
-                        if ancestor.is_subtype_of("%s.classmethod" % BUILTINS):
+                        if ancestor.is_subtype_of("builtins.classmethod"):
                             return "classmethod"
-                        if ancestor.is_subtype_of("%s.staticmethod" % BUILTINS):
+                        if ancestor.is_subtype_of("builtins.staticmethod"):
                             return "staticmethod"
             except InferenceError:
                 pass
@@ -2162,8 +2162,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         :rtype: str
         """
         if self.newstyle:
-            return "%s.type" % BUILTINS
-        return "%s.classobj" % BUILTINS
+            return "builtins.type"
+        return "builtins.classobj"
 
     def display_type(self):
         """A human readable type of this node.
@@ -2250,7 +2250,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
     def infer_call_result(self, caller, context=None):
         """infer what a class is returning when called"""
-        if self.is_subtype_of(f"{BUILTINS}.type", context) and len(caller.args) == 3:
+        if self.is_subtype_of("builtins.type", context) and len(caller.args) == 3:
             result = self._infer_type_call(caller, context)
             yield result
             return
@@ -2666,7 +2666,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         def _valid_getattr(node):
             root = node.root()
-            return root.name != BUILTINS and getattr(root, "pure_python", None)
+            return root.name != "builtins" and getattr(root, "pure_python", None)
 
         try:
             return _valid_getattr(self.getattr("__getattr__", context)[0])

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -23,7 +23,6 @@ leads to an inferred FrozenSet:
 
 
 from astroid import bases, decorators, util
-from astroid.const import BUILTINS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -40,7 +39,7 @@ class FrozenSet(node_classes.BaseContainer):
     """class representing a FrozenSet composite node"""
 
     def pytype(self):
-        return "%s.frozenset" % BUILTINS
+        return "builtins.frozenset"
 
     def _infer(self, context=None):
         yield self
@@ -120,7 +119,7 @@ class Super(node_classes.NodeNG):
         return ast_builtins.getattr("super")[0]
 
     def pytype(self):
-        return "%s.super" % BUILTINS
+        return "builtins.super"
 
     def display_type(self):
         return "Super of"
@@ -307,7 +306,7 @@ class Property(scoped_nodes.FunctionDef):
     type = "property"
 
     def pytype(self):
-        return "%s.property" % BUILTINS
+        return "builtins.property"
 
     def infer_call_result(self, caller=None, context=None):
         raise InferenceError("Properties are not callable")

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -15,7 +15,6 @@ import os
 import sys
 
 from astroid import builder
-from astroid.bases import BUILTINS
 from astroid.manager import AstroidManager
 
 DATA_DIR = os.path.join("testdata", "python3")
@@ -58,9 +57,9 @@ class AstroidCacheSetupMixin:
 
     @classmethod
     def setup_class(cls):
-        cls._builtins = AstroidManager().astroid_cache.get(BUILTINS)
+        cls._builtins = AstroidManager().astroid_cache.get("builtins")
 
     @classmethod
     def teardown_class(cls):
         if cls._builtins:
-            AstroidManager().astroid_cache[BUILTINS] = cls._builtins
+            AstroidManager().astroid_cache["builtins"] = cls._builtins

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -695,7 +695,7 @@ class MultiprocessingBrainTest(unittest.TestCase):
 
         for attr in ("list", "dict"):
             obj = next(module[attr].infer())
-            self.assertEqual(obj.qname(), f"{bases.BUILTINS}.{attr}")
+            self.assertEqual(obj.qname(), f"builtins.{attr}")
 
         # pypy's implementation of array.__spec__ return None. This causes problems for this inference.
         if not hasattr(sys, "pypy_version_info"):
@@ -771,10 +771,9 @@ class EnumBrainTest(unittest.TestCase):
         one = enumeration["one"]
         self.assertEqual(one.pytype(), ".MyEnum.one")
 
-        property_type = f"{bases.BUILTINS}.property"
         for propname in ("name", "value"):
             prop = next(iter(one.getattr(propname)))
-            self.assertIn(property_type, prop.decoratornames())
+            self.assertIn("builtins.property", prop.decoratornames())
 
         meth = one.getattr("mymethod")[0]
         self.assertIsInstance(meth, astroid.FunctionDef)
@@ -861,9 +860,8 @@ class EnumBrainTest(unittest.TestCase):
         one = enumeration["one"]
 
         clazz = one.getattr("__class__")[0]
-        int_type = f"{bases.BUILTINS}.int"
         self.assertTrue(
-            clazz.is_subtype_of(int_type),
+            clazz.is_subtype_of("builtins.int"),
             "IntEnum based enums should be a subtype of int",
         )
 

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -31,7 +31,7 @@ import unittest
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import BUILTINS, PY38_PLUS
+from astroid.const import PY38_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -287,7 +287,7 @@ class BuilderTest(unittest.TestCase):
 
     def test_inspect_build0(self):
         """test astroid tree build from a living object"""
-        builtin_ast = self.manager.ast_from_module_name(BUILTINS)
+        builtin_ast = self.manager.ast_from_module_name("builtins")
         # just check type and object are there
         builtin_ast.getattr("type")
         objectastroid = builtin_ast.getattr("object")[0]
@@ -314,7 +314,7 @@ class BuilderTest(unittest.TestCase):
         self.builder.inspect_build(unittest)
 
     def test_inspect_build_type_object(self):
-        builtin_ast = self.manager.ast_from_module_name(BUILTINS)
+        builtin_ast = self.manager.ast_from_module_name("builtins")
 
         inferred = list(builtin_ast.igetattr("object"))
         self.assertEqual(len(inferred), 1)

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -48,7 +48,7 @@ import pytest
 from astroid import Slice, arguments
 from astroid import decorators as decoratorsmod
 from astroid import helpers, nodes, objects, test_utils, util
-from astroid.bases import BUILTINS, BoundMethod, Instance, UnboundMethod
+from astroid.bases import BoundMethod, Instance, UnboundMethod
 from astroid.builder import AstroidBuilder, extract_node, parse
 from astroid.const import PY38_PLUS, PY39_PLUS
 from astroid.exceptions import (
@@ -76,7 +76,7 @@ def get_node_of_class(start_from, klass):
 
 builder = AstroidBuilder()
 
-EXC_MODULE = BUILTINS
+EXC_MODULE = "builtins"
 BOOL_SPECIAL_METHOD = "__bool__"
 
 
@@ -202,7 +202,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         inferred = self.ast["C"]["meth1"]["var"].infer()
         var = next(inferred)
         self.assertEqual(var.name, "object")
-        self.assertEqual(var.root().name, BUILTINS)
+        self.assertEqual(var.root().name, "builtins")
         self.assertRaises(StopIteration, partial(next, inferred))
 
     def test_tupleassign_name_inference(self):
@@ -249,7 +249,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         inferred = self.ast["h"].infer()
         var = next(inferred)
         self.assertEqual(var.name, "object")
-        self.assertEqual(var.root().name, BUILTINS)
+        self.assertEqual(var.root().name, "builtins")
         self.assertRaises(StopIteration, partial(next, inferred))
 
     def test_advanced_tupleassign_name_inference2(self):
@@ -266,7 +266,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         inferred = self.ast["k"].infer()
         var = next(inferred)
         self.assertEqual(var.name, "object")
-        self.assertEqual(var.root().name, BUILTINS)
+        self.assertEqual(var.root().name, "builtins")
         self.assertRaises(StopIteration, partial(next, inferred))
 
     def test_swap_assign_inference(self):
@@ -316,7 +316,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         meth1 = next(inferred)
         self.assertIsInstance(meth1, Instance)
         self.assertEqual(meth1.name, "object")
-        self.assertEqual(meth1.root().name, BUILTINS)
+        self.assertEqual(meth1.root().name, "builtins")
         self.assertRaises(StopIteration, partial(next, inferred))
 
     def test_unbound_method_inference(self):
@@ -554,7 +554,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(ancestor.root().name, EXC_MODULE)
         ancestor = next(ancestors)
         self.assertEqual(ancestor.name, "object")
-        self.assertEqual(ancestor.root().name, BUILTINS)
+        self.assertEqual(ancestor.root().name, "builtins")
         self.assertRaises(StopIteration, partial(next, ancestors))
 
     def test_method_argument(self):
@@ -1336,7 +1336,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             my_smtp = SendMailController().smtp
             my_me = SendMailController().me
             """
-        decorators = {"%s.property" % BUILTINS}
+        decorators = {"builtins.property"}
         ast = parse(code, __name__)
         self.assertEqual(ast["SendMailController"]["smtp"].decoratornames(), decorators)
         propinferred = list(ast.body[2].value.infer())
@@ -1735,7 +1735,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         for node in ast[8:]:
             inferred = next(node.infer())
             self.assertIsInstance(inferred, Instance)
-            self.assertEqual(inferred.qname(), f"{BUILTINS}.tuple")
+            self.assertEqual(inferred.qname(), "builtins.tuple")
 
     def test_starred_in_tuple_literal(self):
         code = """
@@ -1888,7 +1888,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         for node in ast[7:]:
             inferred = next(node.infer())
             self.assertIsInstance(inferred, Instance)
-            self.assertEqual(inferred.qname(), f"{BUILTINS}.frozenset")
+            self.assertEqual(inferred.qname(), "builtins.frozenset")
 
     def test_set_builtin_inference(self):
         code = """
@@ -1919,7 +1919,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         for node in ast[7:]:
             inferred = next(node.infer())
             self.assertIsInstance(inferred, Instance)
-            self.assertEqual(inferred.qname(), f"{BUILTINS}.set")
+            self.assertEqual(inferred.qname(), "builtins.set")
 
     def test_list_builtin_inference(self):
         code = """
@@ -1949,7 +1949,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         for node in ast[7:]:
             inferred = next(node.infer())
             self.assertIsInstance(inferred, Instance)
-            self.assertEqual(inferred.qname(), f"{BUILTINS}.list")
+            self.assertEqual(inferred.qname(), "builtins.list")
 
     def test_conversion_of_dict_methods(self):
         ast_nodes = extract_node(
@@ -2020,7 +2020,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         for node in ast[10:]:
             inferred = next(node.infer())
             self.assertIsInstance(inferred, Instance)
-            self.assertEqual(inferred.qname(), f"{BUILTINS}.dict")
+            self.assertEqual(inferred.qname(), "builtins.dict")
 
     def test_dict_inference_kwargs(self):
         ast_node = extract_node("""dict(a=1, b=2, **{'c': 3})""")
@@ -2060,7 +2060,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             ast_node = extract_node(invalid)
             inferred = next(ast_node.infer())
             self.assertIsInstance(inferred, Instance)
-            self.assertEqual(inferred.qname(), f"{BUILTINS}.dict")
+            self.assertEqual(inferred.qname(), "builtins.dict")
 
     def test_str_methods(self):
         code = """
@@ -4204,7 +4204,7 @@ class GetattrTest(unittest.TestCase):
 
         second = next(ast_nodes[1].infer())
         self.assertIsInstance(second, nodes.ClassDef)
-        self.assertEqual(second.qname(), "%s.int" % BUILTINS)
+        self.assertEqual(second.qname(), "builtins.int")
 
         third = next(ast_nodes[2].infer())
         self.assertIsInstance(third, nodes.Const)
@@ -4878,7 +4878,7 @@ class SliceTest(unittest.TestCase):
             step_value = next(inferred.igetattr("step"))
             self.assertIsInstance(step_value, nodes.Const)
             self.assertEqual(step_value.value, step)
-            self.assertEqual(inferred.pytype(), "%s.slice" % BUILTINS)
+            self.assertEqual(inferred.pytype(), "builtins.slice")
 
     def test_slice_type(self):
         ast_node = extract_node("type(slice(None, None, None))")

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -32,7 +32,6 @@ import pkg_resources
 
 import astroid
 from astroid import manager, test_utils
-from astroid.const import BUILTINS
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 
 from . import resources
@@ -263,22 +262,22 @@ class AstroidManagerTest(
     def test_ast_from_class(self):
         ast = self.manager.ast_from_class(int)
         self.assertEqual(ast.name, "int")
-        self.assertEqual(ast.parent.frame().name, BUILTINS)
+        self.assertEqual(ast.parent.frame().name, "builtins")
 
         ast = self.manager.ast_from_class(object)
         self.assertEqual(ast.name, "object")
-        self.assertEqual(ast.parent.frame().name, BUILTINS)
+        self.assertEqual(ast.parent.frame().name, "builtins")
         self.assertIn("__setattr__", ast)
 
     def test_ast_from_class_with_module(self):
         """check if the method works with the module name"""
         ast = self.manager.ast_from_class(int, int.__module__)
         self.assertEqual(ast.name, "int")
-        self.assertEqual(ast.parent.frame().name, BUILTINS)
+        self.assertEqual(ast.parent.frame().name, "builtins")
 
         ast = self.manager.ast_from_class(object, object.__module__)
         self.assertEqual(ast.name, "object")
-        self.assertEqual(ast.parent.frame().name, BUILTINS)
+        self.assertEqual(ast.parent.frame().name, "builtins")
         self.assertIn("__setattr__", ast)
 
     def test_ast_from_class_attr_error(self):
@@ -307,10 +306,10 @@ class BorgAstroidManagerTC(unittest.TestCase):
         """test that the AstroidManager is really a borg, i.e. that two different
         instances has same cache"""
         first_manager = manager.AstroidManager()
-        built = first_manager.ast_from_module_name(BUILTINS)
+        built = first_manager.ast_from_module_name("builtins")
 
         second_manager = manager.AstroidManager()
-        second_built = second_manager.ast_from_module_name(BUILTINS)
+        second_built = second_manager.ast_from_module_name("builtins")
         self.assertIs(built, second_built)
 
 

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -40,7 +40,7 @@ import astroid
 from astroid import Uninferable, bases, builder
 from astroid import context as contextmod
 from astroid import nodes, parse, test_utils, transforms, util
-from astroid.const import BUILTINS, PY38_PLUS, PY310_PLUS, Context
+from astroid.const import PY38_PLUS, PY310_PLUS, Context
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -473,18 +473,18 @@ class ImportNodeTest(resources.SysPathSetup, unittest.TestCase):
         self.assertTrue(isinstance(myos, nodes.Module), myos)
         self.assertEqual(myos.name, "os")
         self.assertEqual(myos.qname(), "os")
-        self.assertEqual(myos.pytype(), "%s.module" % BUILTINS)
+        self.assertEqual(myos.pytype(), "builtins.module")
 
     def test_from_self_resolve(self):
         namenode = next(self.module.igetattr("NameNode"))
         self.assertTrue(isinstance(namenode, nodes.ClassDef), namenode)
         self.assertEqual(namenode.root().name, "astroid.nodes.node_classes")
         self.assertEqual(namenode.qname(), "astroid.nodes.node_classes.Name")
-        self.assertEqual(namenode.pytype(), "%s.type" % BUILTINS)
+        self.assertEqual(namenode.pytype(), "builtins.type")
         abspath = next(self.module2.igetattr("abspath"))
         self.assertTrue(isinstance(abspath, nodes.FunctionDef), abspath)
         self.assertEqual(abspath.root().name, "os.path")
-        self.assertEqual(abspath.pytype(), "%s.function" % BUILTINS)
+        self.assertEqual(abspath.pytype(), "builtins.function")
         if sys.platform != "win32":
             # Not sure what is causing this check to fail on Windows.
             # For some reason the abspath() inference returns a different

--- a/tests/unittest_objects.py
+++ b/tests/unittest_objects.py
@@ -27,7 +27,7 @@ class ObjectsTest(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIsInstance(inferred, objects.FrozenSet)
 
-        self.assertEqual(inferred.pytype(), "%s.frozenset" % bases.BUILTINS)
+        self.assertEqual(inferred.pytype(), "builtins.frozenset")
 
         itered = inferred.itered()
         self.assertEqual(len(itered), 2)
@@ -35,7 +35,7 @@ class ObjectsTest(unittest.TestCase):
         self.assertEqual([const.value for const in itered], [1, 2])
 
         proxied = inferred._proxied
-        self.assertEqual(inferred.qname(), "%s.frozenset" % bases.BUILTINS)
+        self.assertEqual(inferred.qname(), "builtins.frozenset")
         self.assertIsInstance(proxied, nodes.ClassDef)
 
 
@@ -58,15 +58,15 @@ class SuperTests(unittest.TestCase):
         )
         in_static = next(ast_nodes[0].value.infer())
         self.assertIsInstance(in_static, bases.Instance)
-        self.assertEqual(in_static.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(in_static.qname(), "builtins.super")
 
         module_level = next(ast_nodes[1].infer())
         self.assertIsInstance(module_level, bases.Instance)
-        self.assertEqual(in_static.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(in_static.qname(), "builtins.super")
 
         no_arguments = next(ast_nodes[2].infer())
         self.assertIsInstance(no_arguments, bases.Instance)
-        self.assertEqual(no_arguments.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(no_arguments.qname(), "builtins.super")
 
     def test_inferring_unbound_super_doesnt_work(self):
         node = builder.extract_node(
@@ -78,7 +78,7 @@ class SuperTests(unittest.TestCase):
         )
         unbounded = next(node.infer())
         self.assertIsInstance(unbounded, bases.Instance)
-        self.assertEqual(unbounded.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(unbounded.qname(), "builtins.super")
 
     def test_use_default_inference_on_not_inferring_args(self):
         ast_nodes = builder.extract_node(
@@ -91,11 +91,11 @@ class SuperTests(unittest.TestCase):
         )
         first = next(ast_nodes[0].infer())
         self.assertIsInstance(first, bases.Instance)
-        self.assertEqual(first.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(first.qname(), "builtins.super")
 
         second = next(ast_nodes[1].infer())
         self.assertIsInstance(second, bases.Instance)
-        self.assertEqual(second.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(second.qname(), "builtins.super")
 
     def test_no_arguments_super(self):
         ast_nodes = builder.extract_node(
@@ -239,7 +239,7 @@ class SuperTests(unittest.TestCase):
         )
         inferred = next(node.infer())
         proxied = inferred._proxied
-        self.assertEqual(proxied.qname(), "%s.super" % bases.BUILTINS)
+        self.assertEqual(proxied.qname(), "builtins.super")
         self.assertIsInstance(proxied, nodes.ClassDef)
 
     def test_super_bound_model(self):

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -22,7 +22,6 @@ import textwrap
 import unittest
 
 from astroid import MANAGER, Instance, nodes, test_utils
-from astroid.bases import BUILTINS
 from astroid.builder import AstroidBuilder, extract_node
 from astroid.exceptions import InferenceError
 from astroid.raw_building import build_module
@@ -201,7 +200,7 @@ def test():
         )
         ancestors = list(node.ancestors())
         self.assertEqual(len(ancestors), 1)
-        self.assertEqual(ancestors[0].qname(), f"{BUILTINS}.object")
+        self.assertEqual(ancestors[0].qname(), "builtins.object")
 
     def test_ancestors_missing_from_function(self):
         # Test for https://www.logilab.org/ticket/122793

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -41,7 +41,7 @@ from functools import partial
 import pytest
 
 from astroid import MANAGER, builder, nodes, objects, test_utils, util
-from astroid.bases import BUILTINS, BoundMethod, Generator, Instance, UnboundMethod
+from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod
 from astroid.exceptions import (
     AttributeInferenceError,
     DuplicateBasesError,
@@ -368,7 +368,7 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         method = self.module2["AbstractClass"]["to_override"]
         self.assertTrue(method.is_abstract(pass_is_abstract=False))
         self.assertEqual(method.qname(), "data.module2.AbstractClass.to_override")
-        self.assertEqual(method.pytype(), "%s.instancemethod" % BUILTINS)
+        self.assertEqual(method.pytype(), "builtins.instancemethod")
         method = self.module2["AbstractClass"]["return_something"]
         self.assertFalse(method.is_abstract(pass_is_abstract=False))
         # non regression : test raise "string" doesn't cause an exception in is_abstract
@@ -417,7 +417,7 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         """
         astroid = builder.parse(data)
         g = list(astroid["f"].ilookup("g"))[0]
-        self.assertEqual(g.pytype(), "%s.function" % BUILTINS)
+        self.assertEqual(g.pytype(), "builtins.function")
 
     def test_lambda_qname(self):
         astroid = builder.parse("lmbd = lambda: None", __name__)
@@ -1391,7 +1391,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         A1 = astroid.getattr("A1")[0]
         B1 = astroid.getattr("B1")[0]
         C1 = astroid.getattr("C1")[0]
-        object_ = MANAGER.astroid_cache[BUILTINS].getattr("object")[0]
+        object_ = MANAGER.astroid_cache["builtins"].getattr("object")[0]
         self.assertEqual(
             cm.exception.mros, [[B1, C1, A1, object_], [C1, B1, A1, object_]]
         )


### PR DESCRIPTION
## Description

 This make for clearer and also slightly faster code (means time
 seems to decrease by 0.68% with this change alone (astroid/pylint)
 in the pylint tests benchmarks). Done because we were using an
 import from astroid from astroid.bases for one of those, which is
 kinda messy.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Require https://github.com/PyCQA/pylint/pull/4868 to be merged in pylint, pylint 2.10.0 being released and the pylint version used in pre-commit to be updated in astroid to work.

It's a little one, but it's a breaking change, I don't know if we can put that in 2.7.2 or should wait for 2.8 or even 3.0.  (Edit : as we need pylint 2.10 to be released it will go in 2.8.0 most likely, maybe astroid 2.7.x)
