### PR TITLE
Remove constraint on numpy for 3.10

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -355,7 +355,7 @@ class NodeNG:
             last_child = self.last_child()
         if last_child is None:
             return self.fromlineno
-        return last_child.tolineno  # pylint: disable=no-member
+        return last_child.tolineno
 
     def _fixed_source_line(self) -> Optional[int]:
         """Attempt to find the line that this node appears on.

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -1,10 +1,7 @@
 attrs
 types-attrs
 nose
-# Don't test numpy with py310
-# Until a wheel is uploaded to pypi, this would require
-# additional dependencies to build it from source
-numpy; python_version < "3.10"
+numpy
 python-dateutil
 types-python-dateutil
 six

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 black==21.7b0
-pylint==2.9.6
+pylint==2.10.0
 isort==5.9.2
 flake8==3.9.2
 mypy==0.910

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -33,7 +33,7 @@ def main() -> None:
     with open(DEFAULT_CHANGELOG_PATH, encoding="utf-8") as f:
         content = f.read()
     content = transform_content(content, args.version)
-    with open(DEFAULT_CHANGELOG_PATH, "w") as f:
+    with open(DEFAULT_CHANGELOG_PATH, "w", encoding="utf8") as f:
         f.write(content)
 
 

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -55,7 +55,6 @@ def get_next_version(version: str, version_type: VersionType) -> str:
 
 
 def get_next_versions(version: str, version_type: VersionType) -> List[str]:
-
     if version_type == VersionType.PATCH:
         # "2.6.1" => ["2.6.2"]
         return [get_next_version(version, VersionType.PATCH)]
@@ -72,9 +71,9 @@ def get_next_versions(version: str, version_type: VersionType) -> List[str]:
 
 
 def get_version_type(version: str) -> VersionType:
-    if version.endswith("0.0"):
+    if version.endswith(".0.0"):
         version_type = VersionType.MAJOR
-    elif version.endswith("0"):
+    elif version.endswith(".0"):
         version_type = VersionType.MINOR
     else:
         version_type = VersionType.PATCH

--- a/script/test_bump_changelog.py
+++ b/script/test_bump_changelog.py
@@ -13,6 +13,8 @@ from bump_changelog import (
     "version,version_type,expected_version,expected_versions",
     [
         ["2.6.1", VersionType.PATCH, "2.6.2", ["2.6.2"]],
+        ["2.10.0", VersionType.MINOR, "2.11.0", ["2.11.0", "2.10.1"]],
+        ["10.1.10", VersionType.PATCH, "10.1.11", ["10.1.11"]],
         [
             "2.6.0",
             VersionType.MINOR,


### PR DESCRIPTION
## Description
The numpy wheels for `3.10` have been uploaded to PyPI. Thus it should be fine to remove the constraint now.