### PR TITLE
Removed mutable default value in _inference_tip_cache

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ What's New in astroid 2.7.2?
 Release date: TBA
 
 * ``BaseContainer`` is now public, and will replace ``_BaseContainer`` completely in astroid 3.0.
+* The call cache used by inference functions produced by ``inference_tip``
+  can now be cleared via ``clear_inference_tip_cache``.
 
 
 What's New in astroid 2.7.1?


### PR DESCRIPTION
## Description

The mutable default is problematic when astroid is used as a library,
because it effectively becomes a memory leak, see #792.

This commit moves the cache to the global namespace and adds a public
API entry point to clear it.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|   | :bug: Bug fix          |
|     | :sparkles: New feature |
| ✓    | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

This PR partially addresses #792. More changes are needed to make memory consumption stable. See discussion in the issue.
