### PR TITLE
Use specific imports instead of importing whole module

### DIFF
--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -9,13 +9,14 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+from typing import Optional
 
-
-from astroid import bases
-from astroid import context as contextmod
-from astroid import nodes, util
-from astroid.context import CallContext
+from astroid import nodes
+from astroid.bases import Instance
+from astroid.const import Context
+from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import InferenceError, NoDefault
+from astroid.util import Uninferable
 
 
 class CallSite:
@@ -48,26 +49,24 @@ class CallSite:
         self._unpacked_kwargs = self._unpack_keywords(keywords, context=context)
 
         self.positional_arguments = [
-            arg for arg in self._unpacked_args if arg is not util.Uninferable
+            arg for arg in self._unpacked_args if arg is not Uninferable
         ]
         self.keyword_arguments = {
             key: value
             for key, value in self._unpacked_kwargs.items()
-            if value is not util.Uninferable
+            if value is not Uninferable
         }
 
     @classmethod
-    def from_call(cls, call_node, context=None):
+    def from_call(cls, call_node, context: Optional[Context] = None):
         """Get a CallSite object from the given Call node.
 
-        :param context:
-            An instance of :class:`astroid.context.Context` that will be used
-            to force a single inference path.
+        context will be used to force a single inference path.
         """
 
         # Determine the callcontext from the given `context` object if any.
-        context = context or contextmod.InferenceContext()
-        callcontext = contextmod.CallContext(call_node.args, call_node.keywords)
+        context = context or InferenceContext()
+        callcontext = CallContext(call_node.args, call_node.keywords)
         return cls(callcontext, context=context)
 
     def has_invalid_arguments(self):
@@ -92,7 +91,7 @@ class CallSite:
 
     def _unpack_keywords(self, keywords, context=None):
         values = {}
-        context = context or contextmod.InferenceContext()
+        context = context or InferenceContext()
         context.extra_context = self.argument_context_map
         for name, value in keywords:
             if name is None:
@@ -100,33 +99,33 @@ class CallSite:
                 try:
                     inferred = next(value.infer(context=context))
                 except InferenceError:
-                    values[name] = util.Uninferable
+                    values[name] = Uninferable
                     continue
                 except StopIteration:
                     continue
 
                 if not isinstance(inferred, nodes.Dict):
                     # Not something we can work with.
-                    values[name] = util.Uninferable
+                    values[name] = Uninferable
                     continue
 
                 for dict_key, dict_value in inferred.items:
                     try:
                         dict_key = next(dict_key.infer(context=context))
                     except InferenceError:
-                        values[name] = util.Uninferable
+                        values[name] = Uninferable
                         continue
                     except StopIteration:
                         continue
                     if not isinstance(dict_key, nodes.Const):
-                        values[name] = util.Uninferable
+                        values[name] = Uninferable
                         continue
                     if not isinstance(dict_key.value, str):
-                        values[name] = util.Uninferable
+                        values[name] = Uninferable
                         continue
                     if dict_key.value in values:
                         # The name is already in the dictionary
-                        values[dict_key.value] = util.Uninferable
+                        values[dict_key.value] = Uninferable
                         self.duplicated_keywords.add(dict_key.value)
                         continue
                     values[dict_key.value] = dict_value
@@ -136,23 +135,23 @@ class CallSite:
 
     def _unpack_args(self, args, context=None):
         values = []
-        context = context or contextmod.InferenceContext()
+        context = context or InferenceContext()
         context.extra_context = self.argument_context_map
         for arg in args:
             if isinstance(arg, nodes.Starred):
                 try:
                     inferred = next(arg.value.infer(context=context))
                 except InferenceError:
-                    values.append(util.Uninferable)
+                    values.append(Uninferable)
                     continue
                 except StopIteration:
                     continue
 
-                if inferred is util.Uninferable:
-                    values.append(util.Uninferable)
+                if inferred is Uninferable:
+                    values.append(Uninferable)
                     continue
                 if not hasattr(inferred, "elts"):
-                    values.append(util.Uninferable)
+                    values.append(Uninferable)
                     continue
                 values.extend(inferred.elts)
             else:
@@ -238,7 +237,7 @@ class CallSite:
                         return iter((boundnode,))
 
                 if funcnode.type == "method":
-                    if not isinstance(boundnode, bases.Instance):
+                    if not isinstance(boundnode, Instance):
                         boundnode = boundnode.instantiate_class()
                     return iter((boundnode,))
                 if funcnode.type == "classmethod":

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -436,7 +436,7 @@ class BoundMethod(UnboundMethod):
         needs to be a tuple of classes
         """
         # pylint: disable=import-outside-toplevel; circular import
-        from astroid.nodes import node_classes
+        from astroid.nodes.node_classes import Pass
 
         # Verify the metaclass
         try:
@@ -507,7 +507,7 @@ class BoundMethod(UnboundMethod):
             col_offset=caller.col_offset,
             parent=caller,
         )
-        empty = node_classes.Pass()
+        empty = Pass()
         cls.postinit(
             bases=bases.elts,
             body=[empty],

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -442,7 +442,7 @@ class BoundMethod(UnboundMethod):
         needs to be a tuple of classes
         """
         # pylint: disable=import-outside-toplevel; circular import
-        from astroid.nodes.node_classes import Pass
+        from astroid.nodes import Pass
 
         # Verify the metaclass
         try:

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -21,8 +21,8 @@ import functools
 
 import wrapt
 
-from astroid import context as contextmod
 from astroid import util
+from astroid.context import InferenceContext
 from astroid.exceptions import InferenceError
 
 
@@ -89,7 +89,7 @@ def path_wrapper(func):
     def wrapped(node, context=None, _func=func, **kwargs):
         """wrapper function handling context"""
         if context is None:
-            context = contextmod.InferenceContext()
+            context = InferenceContext()
         if context.push(node):
             return
 

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -18,9 +18,8 @@ Various helper utilities.
 """
 
 
-from astroid import bases
-from astroid import context as contextmod
-from astroid import manager, nodes, raw_building, util
+from astroid import bases, manager, nodes, raw_building, util
+from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -53,7 +52,7 @@ def _function_type(function, builtins):
 def _object_type(node, context=None):
     astroid_manager = manager.AstroidManager()
     builtins = astroid_manager.builtins_module
-    context = context or contextmod.InferenceContext()
+    context = context or InferenceContext()
 
     for inferred in node.infer(context=context):
         if isinstance(inferred, scoped_nodes.ClassDef):
@@ -218,15 +217,14 @@ def class_instance_as_index(node):
     be used in some scenarios where an integer is expected,
     for instance when multiplying or subscripting a list.
     """
-    context = contextmod.InferenceContext()
-
+    context = InferenceContext()
     try:
         for inferred in node.igetattr("__index__", context=context):
             if not isinstance(inferred, bases.BoundMethod):
                 continue
 
             context.boundnode = node
-            context.callcontext = contextmod.CallContext(args=[], callee=inferred)
+            context.callcontext = CallContext(args=[], callee=inferred)
             for result in inferred.infer_call_result(node, context=context):
                 if isinstance(result, nodes.Const) and isinstance(result.value, int):
                     return result

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -32,9 +32,13 @@ import operator
 
 import wrapt
 
-from astroid import bases
-from astroid import context as contextmod
-from astroid import decorators, helpers, nodes, protocols, util
+from astroid import bases, decorators, helpers, nodes, protocols, util
+from astroid.context import (
+    CallContext,
+    InferenceContext,
+    bind_context_to_node,
+    copy_context,
+)
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidError,
@@ -206,7 +210,7 @@ def infer_name(self, context=None):
             raise NameInferenceError(
                 name=self.name, scope=self.scope(), context=context
             )
-    context = contextmod.copy_context(context)
+    context = copy_context(context)
     context.lookupname = self.name
     return bases._infer_stmts(stmts, context, frame)
 
@@ -222,7 +226,7 @@ nodes.AssignName.infer_lhs = infer_name  # won't work with a path wrapper
 @decorators.path_wrapper
 def infer_call(self, context=None):
     """infer a Call node by trying to guess what the function returns"""
-    callcontext = contextmod.copy_context(context)
+    callcontext = copy_context(context)
     callcontext.boundnode = None
     if context is not None:
         callcontext.extra_context = _populate_context_lookup(self, context.clone())
@@ -233,7 +237,7 @@ def infer_call(self, context=None):
             continue
         try:
             if hasattr(callee, "infer_call_result"):
-                callcontext.callcontext = contextmod.CallContext(
+                callcontext.callcontext = CallContext(
                     args=self.args, keywords=self.keywords, callee=callee
                 )
                 yield from callee.infer_call_result(caller=self, context=callcontext)
@@ -284,7 +288,7 @@ def infer_import_from(self, context=None, asname=True):
         raise InferenceError(node=self, context=context) from exc
 
     try:
-        context = contextmod.copy_context(context)
+        context = copy_context(context)
         context.lookupname = name
         stmts = module.getattr(name, ignore_locals=module is self.root())
         return bases._infer_stmts(stmts, context)
@@ -305,7 +309,7 @@ def infer_attribute(self, context=None):
             continue
 
         if not context:
-            context = contextmod.InferenceContext()
+            context = InferenceContext()
 
         old_boundnode = context.boundnode
         try:
@@ -518,11 +522,10 @@ def _infer_unaryop(self, context=None):
                     if inferred is util.Uninferable or not inferred.callable():
                         continue
 
-                    context = contextmod.copy_context(context)
+                    context = copy_context(context)
                     context.boundnode = operand
-                    context.callcontext = contextmod.CallContext(
-                        args=[], callee=inferred
-                    )
+                    context.callcontext = CallContext(args=[], callee=inferred)
+
                     call_results = inferred.infer_call_result(self, context=context)
                     result = next(call_results, None)
                     if result is None:
@@ -559,7 +562,7 @@ def _is_not_implemented(const):
 def _invoke_binop_inference(instance, opnode, op, other, context, method_name):
     """Invoke binary operation inference on the given instance."""
     methods = dunder_lookup.lookup(instance, method_name)
-    context = contextmod.bind_context_to_node(context, instance)
+    context = bind_context_to_node(context, instance)
     method = methods[0]
     context.callcontext.callee = method
     try:
@@ -616,7 +619,7 @@ def _get_binop_contexts(context, left, right):
     # left.__op__(right).
     for arg in (right, left):
         new_context = context.clone()
-        new_context.callcontext = contextmod.CallContext(args=[arg])
+        new_context.callcontext = CallContext(args=[arg])
         new_context.boundnode = None
         yield new_context
 
@@ -758,9 +761,9 @@ def _infer_binop(self, context):
     # we use two separate contexts for evaluating lhs and rhs because
     # 1. evaluating lhs may leave some undesired entries in context.path
     #    which may not let us infer right value of rhs
-    context = context or contextmod.InferenceContext()
-    lhs_context = contextmod.copy_context(context)
-    rhs_context = contextmod.copy_context(context)
+    context = context or InferenceContext()
+    lhs_context = copy_context(context)
+    rhs_context = copy_context(context)
     lhs_iter = left.infer(context=lhs_context)
     rhs_iter = right.infer(context=rhs_context)
     for lhs, rhs in itertools.product(lhs_iter, rhs_iter):
@@ -790,7 +793,7 @@ nodes.BinOp._infer = infer_binop
 def _infer_augassign(self, context=None):
     """Inference logic for augmented binary operations."""
     if context is None:
-        context = contextmod.InferenceContext()
+        context = InferenceContext()
 
     rhs_context = context.clone()
 
@@ -911,9 +914,9 @@ def infer_ifexp(self, context=None):
     # evaluating lhs may leave some undesired entries in context.path
     # which may not let us infer right value of rhs.
 
-    context = context or contextmod.InferenceContext()
-    lhs_context = contextmod.copy_context(context)
-    rhs_context = contextmod.copy_context(context)
+    context = context or InferenceContext()
+    lhs_context = copy_context(context)
+    rhs_context = copy_context(context)
     try:
         test = next(self.test.infer(context=context.clone()))
     except (InferenceError, StopIteration):

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -34,7 +34,7 @@ import os
 import pprint
 import types
 from functools import lru_cache
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import astroid
 from astroid import util
@@ -45,6 +45,8 @@ from astroid.nodes import node_classes
 
 objects = util.lazy_import("objects")
 
+if TYPE_CHECKING:
+    from astroid.objects import Property
 
 IMPL_PREFIX = "attr_"
 
@@ -799,7 +801,7 @@ class PropertyModel(ObjectModel):
 
         func = self._instance
 
-        def find_setter(func: objects.Property) -> Optional[astroid.FunctionDef]:
+        def find_setter(func: "Property") -> Optional[astroid.FunctionDef]:
             """
             Given a property, find the corresponding setter function and returns it.
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -37,8 +37,8 @@ from functools import lru_cache
 from typing import Optional
 
 import astroid
-from astroid import context as contextmod
 from astroid import util
+from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
@@ -308,7 +308,7 @@ class FunctionModel(ObjectModel):
                         context=context,
                     )
 
-                context = contextmod.copy_context(context)
+                context = copy_context(context)
                 try:
                     cls = next(caller.args[0].infer(context=context))
                 except StopIteration as e:
@@ -450,7 +450,7 @@ class ClassModel(ObjectModel):
     @property
     def attr___bases__(self):
         obj = node_classes.Tuple()
-        context = contextmod.InferenceContext()
+        context = InferenceContext()
         elts = list(self._instance._inferred_bases(context))
         obj.postinit(elts=elts)
         return obj

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -42,9 +42,9 @@ import typing
 from functools import lru_cache
 from typing import Callable, Generator, Optional
 
-from astroid import bases
 from astroid import context as contextmod
 from astroid import decorators, mixins, util
+from astroid.bases import Instance, _infer_stmts
 from astroid.const import Context
 from astroid.exceptions import (
     AstroidIndexError,
@@ -272,7 +272,7 @@ class Statement(NodeNG):
 
 
 class BaseContainer(
-    mixins.ParentAssignTypeMixin, NodeNG, bases.Instance, metaclass=abc.ABCMeta
+    mixins.ParentAssignTypeMixin, NodeNG, Instance, metaclass=abc.ABCMeta
 ):
     """Base class for Set, FrozenSet, Tuple and List."""
 
@@ -382,7 +382,7 @@ class LookupMixIn:
         """
         frame, stmts = self.lookup(name)
         context = contextmod.InferenceContext()
-        return bases._infer_stmts(stmts, context, frame)
+        return _infer_stmts(stmts, context, frame)
 
     def _get_filtered_node_statements(self, nodes):
         statements = [(node, node.statement()) for node in nodes]
@@ -1822,7 +1822,7 @@ class Comprehension(NodeNG):
         yield from self.ifs
 
 
-class Const(mixins.NoChildrenMixin, NodeNG, bases.Instance):
+class Const(mixins.NoChildrenMixin, NodeNG, Instance):
     """Class representing any constant including num, str, bool, None, bytes.
 
     >>> import astroid
@@ -2124,7 +2124,7 @@ class Delete(mixins.AssignTypeMixin, Statement):
         yield from self.targets
 
 
-class Dict(NodeNG, bases.Instance):
+class Dict(NodeNG, Instance):
     """Class representing an :class:`ast.Dict` node.
 
     A :class:`Dict` is a dictionary that is created with ``{}`` syntax.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -42,10 +42,10 @@ import typing
 from functools import lru_cache
 from typing import Callable, Generator, Optional
 
-from astroid import context as contextmod
 from astroid import decorators, mixins, util
 from astroid.bases import Instance, _infer_stmts
 from astroid.const import Context
+from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidIndexError,
     AstroidTypeError,
@@ -381,7 +381,7 @@ class LookupMixIn:
         :rtype: iterable
         """
         frame, stmts = self.lookup(name)
-        context = contextmod.InferenceContext()
+        context = InferenceContext()
         return _infer_stmts(stmts, context, frame)
 
     def _get_filtered_node_statements(self, nodes):
@@ -4458,7 +4458,7 @@ class MatchMapping(mixins.AssignTypeMixin, Pattern):
         [
             "MatchMapping",
             AssignName,
-            Optional[contextmod.InferenceContext],
+            Optional[InferenceContext],
             Literal[None],
         ],
         Generator[NodeNG, None, None],
@@ -4542,7 +4542,7 @@ class MatchStar(mixins.AssignTypeMixin, Pattern):
         [
             "MatchStar",
             AssignName,
-            Optional[contextmod.InferenceContext],
+            Optional[InferenceContext],
             Literal[None],
         ],
         Generator[NodeNG, None, None],
@@ -4599,7 +4599,7 @@ class MatchAs(mixins.AssignTypeMixin, Pattern):
         [
             "MatchAs",
             AssignName,
-            Optional[contextmod.InferenceContext],
+            Optional[InferenceContext],
             Literal[None],
         ],
         Generator[NodeNG, None, None],

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -33,10 +33,9 @@ import operator as operator_mod
 import sys
 from typing import Generator, Optional
 
-from astroid import arguments, bases
-from astroid import context as contextmod
-from astroid import decorators, helpers, nodes, util
+from astroid import arguments, bases, decorators, helpers, nodes, util
 from astroid.const import Context
+from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import (
     AstroidIndexError,
     AstroidTypeError,
@@ -374,7 +373,7 @@ def _arguments_infer_argname(self, name, context):
     # if there is a default value, yield it. And then yield Uninferable to reflect
     # we can't guess given argument value
     try:
-        context = contextmod.copy_context(context)
+        context = copy_context(context)
         yield from self.default_value(name).infer(context)
         yield util.Uninferable
     except NoDefault:
@@ -395,7 +394,7 @@ def arguments_assigned_stmts(self, node=None, context=None, assign_path=None):
     ):
         # reset call context/name
         callcontext = context.callcontext
-        context = contextmod.copy_context(context)
+        context = copy_context(context)
         context.callcontext = None
         args = arguments.CallSite(callcontext, context=context)
         return args.infer_argument(self.parent, node.name, context)
@@ -648,7 +647,7 @@ def starred_assigned_stmts(self, node=None, context=None, assign_path=None):
         )
 
     if context is None:
-        context = contextmod.InferenceContext()
+        context = InferenceContext()
 
     if isinstance(stmt, nodes.Assign):
         value = stmt.value
@@ -803,7 +802,7 @@ nodes.Starred.assigned_stmts = starred_assigned_stmts
 def match_mapping_assigned_stmts(
     self: nodes.MatchMapping,
     node: nodes.AssignName,
-    context: Optional[contextmod.InferenceContext] = None,
+    context: Optional[InferenceContext] = None,
     assign_path: Literal[None] = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Return empty generator (return -> raises StopIteration) so inferred value
@@ -820,7 +819,7 @@ nodes.MatchMapping.assigned_stmts = match_mapping_assigned_stmts
 def match_star_assigned_stmts(
     self: nodes.MatchStar,
     node: nodes.AssignName,
-    context: Optional[contextmod.InferenceContext] = None,
+    context: Optional[InferenceContext] = None,
     assign_path: Literal[None] = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Return empty generator (return -> raises StopIteration) so inferred value
@@ -837,7 +836,7 @@ nodes.MatchStar.assigned_stmts = match_star_assigned_stmts
 def match_as_assigned_stmts(
     self: nodes.MatchAs,
     node: nodes.AssignName,
-    context: Optional[contextmod.InferenceContext] = None,
+    context: Optional[InferenceContext] = None,
     assign_path: Literal[None] = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Infer MatchAs as the Match subject if it's the only MatchCase pattern

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -13,7 +13,7 @@
 import collections
 from functools import lru_cache
 
-from astroid import context as contextmod
+from astroid.context import _invalidate_cache
 
 
 class TransformVisitor:
@@ -47,7 +47,7 @@ class TransformVisitor:
                 # if the transformation function returns something, it's
                 # expected to be a replacement for the node
                 if ret is not None:
-                    contextmod._invalidate_cache()
+                    _invalidate_cache()
                     node = ret
                 if ret.__class__ != cls:
                     # Can no longer apply the rest of the transforms.

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -37,10 +37,18 @@ import unittest
 import pytest
 
 import astroid
-from astroid import Uninferable, bases, builder
-from astroid import context as contextmod
-from astroid import nodes, parse, test_utils, transforms, util
+from astroid import (
+    Uninferable,
+    bases,
+    builder,
+    nodes,
+    parse,
+    test_utils,
+    transforms,
+    util,
+)
 from astroid.const import PY38_PLUS, PY310_PLUS, Context
+from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -555,7 +563,7 @@ from ..cave import wine\n\n"""
 
     def test_absolute_import(self):
         module = resources.build_file("data/absimport.py")
-        ctx = contextmod.InferenceContext()
+        ctx = InferenceContext()
         # will fail if absolute import failed
         ctx.lookupname = "message"
         next(module["message"].infer(ctx))
@@ -571,7 +579,7 @@ from ..cave import wine\n\n"""
 
     def test_conditional(self):
         module = resources.build_file("data/conditional_import/__init__.py")
-        ctx = contextmod.InferenceContext()
+        ctx = InferenceContext()
 
         for name in self._pickle_names:
             ctx.lookupname = name
@@ -580,7 +588,7 @@ from ..cave import wine\n\n"""
 
     def test_conditional_import(self):
         module = resources.build_file("data/conditional.py")
-        ctx = contextmod.InferenceContext()
+        ctx = InferenceContext()
 
         for name in self._pickle_names:
             ctx.lookupname = name


### PR DESCRIPTION
## Description

In order to fight circular import more effectively and speed up astroid import time, we need be specific in what we need to import so we can realize a new architecture can be made.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
