### PR TITLE
Add filter for abc.collections in dataclass inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.7.3?
 ============================
 Release date: TBA
 
+* When processing dataclass attributes, exclude the same type hints from abc.collections
+  as from typing.
+
+  Closes PyCQA/pylint#4895
 
 
 What's New in astroid 2.7.2?

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -399,6 +399,7 @@ def _infer_instance_from_annotation(
         yield Uninferable
     elif klass.root().name in (
         "typing",
+        "_collections_abc",
         "",
     ):  # "" because of synthetic nodes in brain_typing.py
         if klass.name in _INFERABLE_TYPING_TYPES:

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -276,15 +276,16 @@ def test_inference_generic_collection_attribute():
         assert inferred.name == name
 
 
-def test_inference_callable_attribute():
+@pytest.mark.parametrize(("module",), [("typing",), ("collections.abc",)])
+def test_inference_callable_attribute(module: str):
     """Test that an attribute with a Callable annotation is inferred as Uninferable.
 
-    See issue#1129.
+    See issue #1129 and PyCQA/pylint#4895
     """
     instance = astroid.extract_node(
-        """
+        f"""
     from dataclasses import dataclass
-    from typing import Any, Callable
+    from {module} import Any, Callable
 
     @dataclass
     class A:


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Okay, so the filter introduced in #1130 correctly excluded imports from `typing`, but didn't exclude imports from `collections.abc`. Fixed that by adding the module's name to the existing filter. *Note*: the module defines its `__name__` as `'collections.abc'`, but the `.name` node attribute is generated from the file name, `_collections_abc.py`.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes PyCQA/pylint#4895