### PR TITLE
Relax dataclass filter for Uninferable nodes.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#4895
 
+* Apply dataclass inference to pydantic's dataclasses.
+
+  Closes PyCQA/pylint#4899
+
 
 What's New in astroid 2.7.2?
 ============================


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

The filtering introduced in #1130 excluded pydantic's [dataclasses](https://pydantic-docs.helpmanual.io/usage/dataclasses/), which are a drop-in replacement for built-in dataclasses.

One twist when fixing this was that inference doesn't seem to work for pydantic's code:

```python
import astroid
node = astroid.extract_node(
    """
from pydantic.dataclasses import dataclass

dataclass
"""
)

print(node.inferred())  # prints [Uninferable]
```

So I modified the filter so that any Uninferable node that looks like "dataclass" or "<expr>.dataclass" will be treated as a dataclass decorator. Probably should have done this to begin with, as it better aligns with the astroid/pylint philosophy of treating `Uninferable` as a permissive wildcard (e.g., `no-member` isn't raised for `Uninferable` values).

If inference improves and `pydantic.dataclasses` can be inferred, we'll need to add `pydantic.dataclasses` to the `DATACLASS_MODULE` variable. I didn't do that in this PR since it doesn't currently fix the problem, but I did parametrize the tests to use both `dataclasses` and `pydantic.dataclasses`, so we should be able to catch a regression if `pydantic.dataclasses` becomes inferable.

*Comment*: the code change is bigger than the actual logical change, since I refactored the two places that the change is relevant into a single helper, `_looks_like_dataclass_decorator`.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes https://github.com/PyCQA/pylint/issues/4899