### PR TITLE
Some fixes for function call inference and inference contexts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,11 @@ Release date: TBA
     Closes #1008
     Closes PyCQA/pylint#4377
 
+* Fixed bug in inference of chained attributes where a subclass
+  had an attribute that was an instance of its superclass.
+
+    Closes PyCQA/pylint#4220
+
 
 What's New in astroid 2.7.3?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@ What's New in astroid 2.8.0?
 ============================
 Release date: TBA
 
+* Fixed bug in attribute inference from inside method calls.
+
+    Closes PyCQA/pylint#400
 
 
 What's New in astroid 2.7.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,12 @@ Release date: TBA
 
     Closes PyCQA/pylint#400
 
+* Fixed bug in inference for superclass instance methods called
+  from the class rather than an instance.
+
+    Closes #1008
+    Closes PyCQA/pylint#4377
+
 
 What's New in astroid 2.7.3?
 ============================

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -169,6 +169,7 @@ def _infer_method_result_truth(instance, method_name, context):
         if not meth.callable():
             return util.Uninferable
         try:
+            context.callcontext = contextmod.CallContext(args=[], callee=meth)
             for value in meth.infer_call_result(instance, context=context):
                 if value is util.Uninferable:
                     return value
@@ -318,7 +319,6 @@ class Instance(BaseInstance):
              all its instances are considered true.
         """
         context = context or contextmod.InferenceContext()
-        context.callcontext = contextmod.CallContext(args=[])
         context.boundnode = self
 
         try:
@@ -336,9 +336,9 @@ class Instance(BaseInstance):
         new_context = contextmod.bind_context_to_node(context, self)
         if not context:
             context = new_context
-        # Create a new CallContext for providing index as an argument.
-        new_context.callcontext = contextmod.CallContext(args=[index])
         method = next(self.igetattr("__getitem__", context=context), None)
+        # Create a new CallContext for providing index as an argument.
+        new_context.callcontext = contextmod.CallContext(args=[index], callee=method)
         if not isinstance(method, BoundMethod):
             raise InferenceError(
                 "Could not find __getitem__ for {node!r}.", node=self, context=context

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -14,10 +14,10 @@
 """Various context related utilities, including inference and call contexts."""
 import contextlib
 import pprint
-from typing import TYPE_CHECKING, MutableMapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, List, MutableMapping, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
-    from astroid.nodes.node_classes import NodeNG
+    from astroid.nodes.node_classes import Keyword, NodeNG
 
 
 _INFERENCE_CACHE = {}
@@ -164,19 +164,21 @@ class InferenceContext:
 class CallContext:
     """Holds information for a call site."""
 
-    __slots__ = ("args", "keywords")
+    __slots__ = ("args", "keywords", "callee")
 
-    def __init__(self, args, keywords=None):
-        """
-        :param List[NodeNG] args: Call positional arguments
-        :param Union[List[nodes.Keyword], None] keywords: Call keywords
-        """
-        self.args = args
+    def __init__(
+        self,
+        args: List["NodeNG"],
+        keywords: Optional[List["Keyword"]] = None,
+        callee: Optional["NodeNG"] = None,
+    ):
+        self.args = args  # Call positional arguments
         if keywords:
             keywords = [(arg.arg, arg.value) for arg in keywords]
         else:
             keywords = []
-        self.keywords = keywords
+        self.keywords = keywords  # Call keyword arguments
+        self.callee = callee  # Function being called
 
 
 def copy_context(context: Optional[InferenceContext]) -> InferenceContext:

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -219,13 +219,14 @@ def class_instance_as_index(node):
     for instance when multiplying or subscripting a list.
     """
     context = contextmod.InferenceContext()
-    context.callcontext = contextmod.CallContext(args=[node])
 
     try:
         for inferred in node.igetattr("__index__", context=context):
             if not isinstance(inferred, bases.BoundMethod):
                 continue
 
+            context.boundnode = node
+            context.callcontext = contextmod.CallContext(args=[], callee=inferred)
             for result in inferred.infer_call_result(node, context=context):
                 if isinstance(result, nodes.Const) and isinstance(result.value, int):
                     return result

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -304,23 +304,7 @@ def infer_attribute(self, context=None):
             yield owner
             continue
 
-        if context and context.boundnode:
-            # This handles the situation where the attribute is accessed through a subclass
-            # of a base class and the attribute is defined at the base class's level,
-            # by taking in consideration a redefinition in the subclass.
-            if isinstance(owner, bases.Instance) and isinstance(
-                context.boundnode, bases.Instance
-            ):
-                try:
-                    if helpers.is_subtype(
-                        helpers.object_type(context.boundnode),
-                        helpers.object_type(owner),
-                    ):
-                        owner = context.boundnode
-                except _NonDeducibleTypeHierarchy:
-                    # Can't determine anything useful.
-                    pass
-        elif not context:
+        if not context:
             context = contextmod.InferenceContext()
 
         old_boundnode = context.boundnode

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -223,9 +223,6 @@ nodes.AssignName.infer_lhs = infer_name  # won't work with a path wrapper
 def infer_call(self, context=None):
     """infer a Call node by trying to guess what the function returns"""
     callcontext = contextmod.copy_context(context)
-    callcontext.callcontext = contextmod.CallContext(
-        args=self.args, keywords=self.keywords
-    )
     callcontext.boundnode = None
     if context is not None:
         callcontext.extra_context = _populate_context_lookup(self, context.clone())
@@ -236,6 +233,9 @@ def infer_call(self, context=None):
             continue
         try:
             if hasattr(callee, "infer_call_result"):
+                callcontext.callcontext = contextmod.CallContext(
+                    args=self.args, keywords=self.keywords, callee=callee
+                )
                 yield from callee.infer_call_result(caller=self, context=callcontext)
         except InferenceError:
             continue
@@ -535,7 +535,10 @@ def _infer_unaryop(self, context=None):
                         continue
 
                     context = contextmod.copy_context(context)
-                    context.callcontext = contextmod.CallContext(args=[operand])
+                    context.boundnode = operand
+                    context.callcontext = contextmod.CallContext(
+                        args=[], callee=inferred
+                    )
                     call_results = inferred.infer_call_result(self, context=context)
                     result = next(call_results, None)
                     if result is None:
@@ -574,6 +577,7 @@ def _invoke_binop_inference(instance, opnode, op, other, context, method_name):
     methods = dunder_lookup.lookup(instance, method_name)
     context = contextmod.bind_context_to_node(context, instance)
     method = methods[0]
+    context.callcontext.callee = method
     try:
         inferred = next(method.infer(context=context))
     except StopIteration as e:

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -2267,6 +2267,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             # Call type.__call__ if not set metaclass
             # (since type is the default metaclass)
             context = contextmod.bind_context_to_node(context, self)
+            context.callcontext.callee = dunder_call
             yield from dunder_call.infer_call_result(caller, context)
         else:
             yield self.instantiate_class()
@@ -2712,7 +2713,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         # Create a new callcontext for providing index as an argument.
         new_context = contextmod.bind_context_to_node(context, self)
-        new_context.callcontext = contextmod.CallContext(args=[index])
+        new_context.callcontext = contextmod.CallContext(args=[index], callee=method)
 
         try:
             return next(method.infer_call_result(self, new_context), util.Uninferable)

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -2384,14 +2384,27 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             __neg__ = lambda self: self.lala + 1
             @property
             def lala(self): return 24
+        class InstanceWithAttr(object):
+            def __init__(self):
+                self.x = 42
+            def __pos__(self):
+                return self.x
+            def __neg__(self):
+                return +self - 41
+            def __invert__(self):
+                return self.x + 1
         instance = GoodInstance()
         lambda_instance = LambdaInstance()
+        instance_with_attr = InstanceWithAttr()
         +instance #@
         -instance #@
         ~instance #@
         --instance #@
         +lambda_instance #@
         -lambda_instance #@
+        +instance_with_attr #@
+        -instance_with_attr #@
+        ~instance_with_attr #@
 
         bad_instance = BadInstance()
         +bad_instance #@
@@ -2405,13 +2418,13 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         +BadInstance #@
         """
         )
-        expected = [42, 1, 42, -1, 24, 25]
-        for node, value in zip(ast_nodes[:6], expected):
+        expected = [42, 1, 42, -1, 24, 25, 42, 1, 43]
+        for node, value in zip(ast_nodes[:9], expected):
             inferred = next(node.infer())
             self.assertIsInstance(inferred, nodes.Const)
             self.assertEqual(inferred.value, value)
 
-        for bad_node in ast_nodes[6:]:
+        for bad_node in ast_nodes[9:]:
             inferred = next(bad_node.infer())
             self.assertEqual(inferred, util.Uninferable)
 

--- a/tests/unittest_inference_calls.py
+++ b/tests/unittest_inference_calls.py
@@ -1,0 +1,411 @@
+"""Tests for function call inference"""
+
+from astroid import builder, nodes
+from astroid.util import Uninferable
+
+
+def test_no_return():
+    """Test function with no return statements"""
+    node = builder.extract_node(
+        """
+    def f():
+        pass
+
+    f()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+def test_one_return():
+    """Test function with a single return that always executes"""
+    node = builder.extract_node(
+        """
+    def f():
+        return 1
+
+    f()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+
+def test_one_return_possible():
+    """Test function with a single return that only sometimes executes
+
+    Note: currently, inference doesn't handle this type of control flow
+    """
+    node = builder.extract_node(
+        """
+    def f(x):
+        if x:
+            return 1
+
+    f(1)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+
+def test_multiple_returns():
+    """Test function with multiple returns"""
+    node = builder.extract_node(
+        """
+    def f(x):
+        if x > 10:
+            return 1
+        elif x > 20:
+            return 2
+        else:
+            return 3
+
+    f(100)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 3
+    assert all(isinstance(node, nodes.Const) for node in inferred)
+    assert {node.value for node in inferred} == {1, 2, 3}
+
+
+def test_argument():
+    """Test function whose return value uses its arguments"""
+    node = builder.extract_node(
+        """
+    def f(x, y):
+        return x + y
+
+    f(1, 2)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+
+
+def test_inner_call():
+    """Test function where return value is the result of a separate function call"""
+    node = builder.extract_node(
+        """
+    def f():
+        return g()
+
+    def g():
+        return 1
+
+    f()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+
+def test_inner_call_with_const_argument():
+    """Test function where return value is the result of a separate function call,
+    with a constant value passed to the inner function.
+    """
+    node = builder.extract_node(
+        """
+    def f():
+        return g(1)
+
+    def g(y):
+        return y + 2
+
+    f()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
+
+
+def test_inner_call_with_dynamic_argument():
+    """Test function where return value is the result of a separate function call,
+    with a dynamic value passed to the inner function.
+
+    Currently, this is Uninferable.
+    """
+    node = builder.extract_node(
+        """
+    def f(x):
+        return g(x)
+
+    def g(y):
+        return y + 2
+
+    f(1)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+def test_method_const_instance_attr():
+    """Test method where the return value is based on an instance attribute with a
+    constant value.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def __init__(self):
+            self.x = 1
+
+        def get_x(self):
+            return self.x
+
+    A().get_x()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+
+def test_method_const_instance_attr_multiple():
+    """Test method where the return value is based on an instance attribute with
+    multiple possible constant values, across different methods.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def __init__(self, x):
+            if x:
+                self.x = 1
+            else:
+                self.x = 2
+
+        def set_x(self):
+            self.x = 3
+
+        def get_x(self):
+            return self.x
+
+    A().get_x()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 3
+    assert all(isinstance(node, nodes.Const) for node in inferred)
+    assert {node.value for node in inferred} == {1, 2, 3}
+
+
+def test_method_const_instance_attr_same_method():
+    """Test method where the return value is based on an instance attribute with
+    multiple possible constant values, including in the method being called.
+
+    Note that even with a simple control flow where the assignment in the method body
+    is guaranteed to override any previous assignments, all possible constant values
+    are returned.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def __init__(self, x):
+            if x:
+                self.x = 1
+            else:
+                self.x = 2
+
+        def set_x(self):
+            self.x = 3
+
+        def get_x(self):
+            self.x = 4
+            return self.x
+
+    A().get_x()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 4
+    assert all(isinstance(node, nodes.Const) for node in inferred)
+    assert {node.value for node in inferred} == {1, 2, 3, 4}
+
+
+def test_method_dynamic_instance_attr_1():
+    """Test method where the return value is based on an instance attribute with
+    a dynamically-set value in a different method.
+
+    In this case, the return value is Uninferable.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def __init__(self, x):
+            self.x = x
+
+        def get_x(self):
+            return self.x
+
+    A(1).get_x()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+def test_method_dynamic_instance_attr_2():
+    """Test method where the return value is based on an instance attribute with
+    a dynamically-set value in the same method.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        # Note: no initializer, so the only assignment happens in get_x
+
+        def get_x(self, x):
+            self.x = x
+            return self.x
+
+    A().get_x(1)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 1
+
+
+def test_method_dynamic_instance_attr_3():
+    """Test method where the return value is based on an instance attribute with
+    a dynamically-set value in a different method.
+
+    This is currently Uninferable.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def get_x(self, x):  # x is unused
+            return self.x
+
+        def set_x(self, x):
+            self.x = x
+
+    A().get_x(10)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable  # not 10!
+
+
+def test_method_dynamic_instance_attr_4():
+    """Test method where the return value is based on an instance attribute with
+    a dynamically-set value in a different method, and is passed a constant value.
+
+    This is currently Uninferable.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        # Note: no initializer, so the only assignment happens in get_x
+
+        def get_x(self):
+            self.set_x(10)
+            return self.x
+
+        def set_x(self, x):
+            self.x = x
+
+    A().get_x()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+def test_method_dynamic_instance_attr_5():
+    """Test method where the return value is based on an instance attribute with
+    a dynamically-set value in a different method, and is passed a constant value.
+
+    But, where the outer and inner functions have the same signature.
+
+    Inspired by https://github.com/PyCQA/pylint/issues/400
+
+    This is currently Uninferable.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        # Note: no initializer, so the only assignment happens in get_x
+
+        def get_x(self, x):
+            self.set_x(10)
+            return self.x
+
+        def set_x(self, x):
+            self.x = x
+
+    A().get_x(1)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+def test_method_dynamic_instance_attr_6():
+    """Test method where the return value is based on an instance attribute with
+    a dynamically-set value in a different method, and is passed a dynamic value.
+
+    This is currently Uninferable.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        # Note: no initializer, so the only assignment happens in get_x
+
+        def get_x(self, x):
+            self.set_x(x + 1)
+            return self.x
+
+        def set_x(self, x):
+            self.x = x
+
+    A().get_x(1)  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+def test_dunder_getitem():
+    """Test for the special method __getitem__ (used by Instance.getitem).
+
+    This is currently Uninferable, until we can infer instance attribute values through
+    constructor calls.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def __init__(self, x):
+            self.x = x
+
+        def __getitem__(self, i):
+            return self.x + i
+
+    A(1)[2]  #@
+    """
+    )
+
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable

--- a/tests/unittest_inference_calls.py
+++ b/tests/unittest_inference_calls.py
@@ -534,3 +534,33 @@ def test_class_method_inherited():
         assert len(inferred) == 1
         assert isinstance(inferred[0], nodes.ClassDef)
         assert inferred[0].name == expected
+
+
+def test_chained_attribute_inherited():
+    """Tests for class methods that are inherited from a superclass.
+
+    Based on https://github.com/PyCQA/pylint/issues/4220.
+    """
+    node = builder.extract_node(
+        """
+    class A:
+        def f(self):
+            return 42
+
+
+    class B(A):
+        def __init__(self):
+            self.a = A()
+            result = self.a.f()
+
+        def f(self):
+            pass
+
+
+    B().a.f()  #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 42


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This PR addresses three issues for the inference of function calls. Again I went deep on this segment of the code and put the changes all in one branch, but I've split up the changes into three logically independent commits, and would be happy to split up into separate PRs if you want. (Honestly I think I got a bit carried away.)

I added tests for each change; as is my style, there are some new tests that pass on main, but I included them anyway to be thorough. I also put the Changelog entries under 2.8.0 since it affects some core algorithms.

1. https://github.com/PyCQA/pylint/issues/400. The issue here is an interesting interaction between `infer_call`, which sets a `CallContext` for inference, and calling `igetattr` in [`infer_attribute`](https://github.com/PyCQA/astroid/blob/main/astroid/inference.py#L300-L338), which statically scans all class methods for assignments to an instance attribute. The issue was that the `CallContext` was passed to `igetattr`, which caused attributes to be incorrectly inferred based on argument values for a completely different call! Here's an example from one of the test cases I added (`test_method_dynamic_instance_attr_3`):

    ```python
        node = builder.extract_node(
        """
    class A:
        def get_x(self, x):  # x is unused
            return self.x

        def set_x(self, x):
            self.x = x

    A().get_x(10)  #@
    """
    )
    inferred = node.inferred()
    assert len(inferred) == 1
    assert inferred[0] is Uninferable  # not 10!
    """
    ```

    Currently astroid uses the argument `10` to infer the `x` in `set_x`, which isn't even called at all in this simple program.

    The straightforward solution would be to clear the call context before calling `igetattr`, but this had the unintended consequence of removing some inference astroid currently does support, when an instance attribute is set in the method being called, e.g.

    ```python
    class A:
        def get_x(self, x):
            self.x = x
            return self.x

    A().get_x(10)  # Should infer to 10
    ```
    
    Without keeping the call context in this case, we'd get `Uninferable` for the call result. So to try to keep this behaviour but remove the invalid inference, I added a new `callee` attribute to the call context to store what function is actually being called in the context, and modified the way we infer argument `AssignName`s to only use the call context if the argument is for the callee. The other changes in the commit are just setting this new attribute and tidying up slightly.

2. https://github.com/PyCQA/astroid/issues/1008. This one is pretty straightforward: when we call an instance method from the class rather than an instance, e.g. `MyClass.method(obj, 10)`, the `MyClass.method` is inferred as an `UnboundMethod`, and inference context's `boundnode` attribute is `None`. I think this is the correct and intended behaviour. The problem is that when `self` is inferred in `CallSite.infer_arguments`, the current code tries to "fill in" a `boundnode` that's `None`.

    https://github.com/PyCQA/astroid/blob/0a697736138703c37571ac92d274e4ab0ee7adc3/astroid/arguments.py#L218-L241

    I added a special case to this method for when dealing with an instance method where `boundnode is None`, and at least one positional argument is passed. Since `BoundMethod.infer_call_result` [sets boundnode already](https://github.com/PyCQA/astroid/blob/0a697736138703c37571ac92d274e4ab0ee7adc3/astroid/bases.py#L522-L523), I think this is a safe change, as I don't think there are cases where `boundnode` should be `None`.

3. https://github.com/PyCQA/pylint/issues/4220. This one's a bit strange. Basically, given these classes:

    ```python
    
    class A:
        def f(self):
            return 42

    class B(A):
        def __init__(self):
            self.a = A()
            result = self.a.f()
        
        def f(self):
            pass
    ```

    In the expression `B().a.f()`, the `B().a` is an instance of `A`, but the `boundnode` of the context is set to `B`, which causes an inference error on the call to `f()`, since the `B.f` version is used rather than `A.f`. It seems the root cause is https://github.com/PyCQA/astroid/commit/d272438213e6235f642d864085b10768b501cade, which added a check in `infer_attribute` that essentially converts an inferred superclass instance (`Instance of A`) into a subclass instance, that that subclass instance is already the boundnode.

    I'm actually not sure if `boundnode` should be set in `infer_attribute` at all, since it's set appropriately in `infer_call_result` already, and I think only used in resulving method calls (`infer_attribute` itself just uses `igetattr`). But anyway I removed this check and verified that the tests that the commit added still pass, probably because `igetattr` has gotten better at dealing with inheritance since that commit was made.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

First commit:

Closes https://github.com/PyCQA/pylint/issues/400

Second commit:

Closes #1008
Closes https://github.com/PyCQA/pylint/issues/4377

Third commit:

Closes https://github.com/PyCQA/pylint/issues/4220
