### PR TITLE
Deprecate some default values for node init calls

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,7 @@ What's New in astroid 2.8.0?
 ============================
 Release date: TBA
 
-* Add additional deprecation warnings in preparation for astroid 3.0.0
+* Add additional deprecation warnings in preparation for astroid 3.0
 
   * Require attributes for some node classes with ``__init__`` call.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,15 @@ What's New in astroid 2.8.0?
 ============================
 Release date: TBA
 
+* Add additional deprecation warnings in preparation for astroid 3.0.0
+
+  * Require attributes for some node classes with ``__init__`` call.
+
+    * ``name`` (``str``) for ``Name``, ``AssignName``, ``DelName``
+    * ``attrname`` (``str``) for ``Attribute``, ``AssignAttr``, ``DelAttr``
+    * ``op`` (``str``) for ``AugAssign``, ``BinOp``, ``BoolOp``, ``UnaryOp``
+    * ``names`` (``list[tuple[str, str | None]]``) for ``Import``
+
 
 What's New in astroid 2.7.4?
 ============================

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3036,6 +3036,12 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         and the alias that the name is assigned to (if any).
         """
 
+        if names is None:
+            warnings.warn(
+                "'names' will be a required attribute of 'nodes.Import' in astroid 3.0.0",
+                DeprecationWarning,
+            )
+
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1401,6 +1401,12 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         self.value: Optional[NodeNG] = None
         """The value being assigned to the variable."""
 
+        if op is None:
+            warnings.warn(
+                "'op' will be a required attribute of 'nodes.AugAssign' in astroid 3.0.0",
+                DeprecationWarning,
+            )
+
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
@@ -1488,6 +1494,12 @@ class BinOp(NodeNG):
         self.right: Optional[NodeNG] = None
         """What is being applied to the operator on the right side."""
 
+        if op is None:
+            warnings.warn(
+                "'op' will be a required attribute of 'nodes.BinOp' in astroid 3.0.0",
+                DeprecationWarning,
+            )
+
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
@@ -1573,6 +1585,12 @@ class BoolOp(NodeNG):
 
         self.values: typing.List[NodeNG] = []
         """The values being applied to the operator."""
+
+        if op is None:
+            warnings.warn(
+                "'op' will be a required attribute of 'nodes.BoolOp' in astroid 3.0.0",
+                DeprecationWarning,
+            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -3792,6 +3810,12 @@ class UnaryOp(NodeNG):
 
         self.operand: Optional[NodeNG] = None
         """What the unary operator is applied to."""
+
+        if op is None:
+            warnings.warn(
+                "'op' will be a required attribute of 'nodes.UnaryOp' in astroid 3.0.0",
+                DeprecationWarning,
+            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1141,6 +1141,12 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         self.attrname: Optional[str] = attrname
         """The name of the attribute being assigned to."""
 
+        if attrname is None:
+            warnings.warn(
+                "'attrname' will be a required attribute of 'nodes.AssignAttr' in astroid 3.0.0",
+                DeprecationWarning,
+            )
+
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(self, expr: Optional[NodeNG] = None) -> None:
@@ -2085,6 +2091,12 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
         self.attrname: Optional[str] = attrname
         """The name of the attribute that is being deleted."""
 
+        if attrname is None:
+            warnings.warn(
+                "'attrname' will be a required attribute of 'nodes.DelAttr' in astroid 3.0.0",
+                DeprecationWarning,
+            )
+
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(self, expr: Optional[NodeNG] = None) -> None:
@@ -2715,6 +2727,12 @@ class Attribute(NodeNG):
 
         self.attrname: Optional[str] = attrname
         """The name of the attribute."""
+
+        if attrname is None:
+            warnings.warn(
+                "'attrname' will be a required attribute of 'nodes.Attribute' in astroid 3.0.0",
+                DeprecationWarning,
+            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -39,7 +39,6 @@ import abc
 import itertools
 import sys
 import typing
-import warnings
 from functools import lru_cache
 from typing import Callable, Generator, Optional
 
@@ -591,6 +590,7 @@ class AssignName(
 
     _other_fields = ("name",)
 
+    @decorators.deprecate_default_argument_values(name="str")
     def __init__(
         self,
         name: Optional[str] = None,
@@ -610,12 +610,6 @@ class AssignName(
         """
         self.name: Optional[str] = name
         """The name that is assigned to."""
-
-        if name is None:
-            warnings.warn(
-                "'name' will be a required attribute of 'nodes.AssignName' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -637,6 +631,7 @@ class DelName(
 
     _other_fields = ("name",)
 
+    @decorators.deprecate_default_argument_values(name="str")
     def __init__(
         self,
         name: Optional[str] = None,
@@ -656,12 +651,6 @@ class DelName(
         """
         self.name: Optional[str] = name
         """The name that is being deleted."""
-
-        if name is None:
-            warnings.warn(
-                "'name' will be a required attribute of 'nodes.DelName' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -684,6 +673,7 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
 
     _other_fields = ("name",)
 
+    @decorators.deprecate_default_argument_values(name="str")
     def __init__(
         self,
         name: Optional[str] = None,
@@ -703,12 +693,6 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
         """
         self.name: Optional[str] = name
         """The name that this node refers to."""
-
-        if name is None:
-            warnings.warn(
-                "'name' will be a required attribute of 'nodes.Name' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -1118,6 +1102,7 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
     _astroid_fields = ("expr",)
     _other_fields = ("attrname",)
 
+    @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
         attrname: Optional[str] = None,
@@ -1140,12 +1125,6 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
 
         self.attrname: Optional[str] = attrname
         """The name of the attribute being assigned to."""
-
-        if attrname is None:
-            warnings.warn(
-                "'attrname' will be a required attribute of 'nodes.AssignAttr' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -1371,6 +1350,7 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
     _astroid_fields = ("target", "value")
     _other_fields = ("op",)
 
+    @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
         op: Optional[str] = None,
@@ -1400,12 +1380,6 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
 
         self.value: Optional[NodeNG] = None
         """The value being assigned to the variable."""
-
-        if op is None:
-            warnings.warn(
-                "'op' will be a required attribute of 'nodes.AugAssign' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -1468,6 +1442,7 @@ class BinOp(NodeNG):
     _astroid_fields = ("left", "right")
     _other_fields = ("op",)
 
+    @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
         op: Optional[str] = None,
@@ -1493,12 +1468,6 @@ class BinOp(NodeNG):
 
         self.right: Optional[NodeNG] = None
         """What is being applied to the operator on the right side."""
-
-        if op is None:
-            warnings.warn(
-                "'op' will be a required attribute of 'nodes.BinOp' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -1563,6 +1532,7 @@ class BoolOp(NodeNG):
     _astroid_fields = ("values",)
     _other_fields = ("op",)
 
+    @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
         op: Optional[str] = None,
@@ -1585,12 +1555,6 @@ class BoolOp(NodeNG):
 
         self.values: typing.List[NodeNG] = []
         """The values being applied to the operator."""
-
-        if op is None:
-            warnings.warn(
-                "'op' will be a required attribute of 'nodes.BoolOp' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -2083,6 +2047,7 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
     _astroid_fields = ("expr",)
     _other_fields = ("attrname",)
 
+    @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
         attrname: Optional[str] = None,
@@ -2108,12 +2073,6 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
 
         self.attrname: Optional[str] = attrname
         """The name of the attribute that is being deleted."""
-
-        if attrname is None:
-            warnings.warn(
-                "'attrname' will be a required attribute of 'nodes.DelAttr' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -2720,6 +2679,7 @@ class Attribute(NodeNG):
     _astroid_fields = ("expr",)
     _other_fields = ("attrname",)
 
+    @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
         attrname: Optional[str] = None,
@@ -2745,12 +2705,6 @@ class Attribute(NodeNG):
 
         self.attrname: Optional[str] = attrname
         """The name of the attribute."""
-
-        if attrname is None:
-            warnings.warn(
-                "'attrname' will be a required attribute of 'nodes.Attribute' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -3012,6 +2966,7 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
 
     _other_fields = ("names",)
 
+    @decorators.deprecate_default_argument_values(names="list[tuple[str, str | None]]")
     def __init__(
         self,
         names: Optional[typing.List[typing.Tuple[str, Optional[str]]]] = None,
@@ -3035,12 +2990,6 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         Each entry is a :class:`tuple` of the name being imported,
         and the alias that the name is assigned to (if any).
         """
-
-        if names is None:
-            warnings.warn(
-                "'names' will be a required attribute of 'nodes.Import' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -3794,6 +3743,7 @@ class UnaryOp(NodeNG):
     _astroid_fields = ("operand",)
     _other_fields = ("op",)
 
+    @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
         op: Optional[str] = None,
@@ -3816,12 +3766,6 @@ class UnaryOp(NodeNG):
 
         self.operand: Optional[NodeNG] = None
         """What the unary operator is applied to."""
-
-        if op is None:
-            warnings.warn(
-                "'op' will be a required attribute of 'nodes.UnaryOp' in astroid 3.0.0",
-                DeprecationWarning,
-            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1249,7 +1249,7 @@ class Assign(mixins.AssignTypeMixin, Statement):
         self.value: Optional[NodeNG] = None
         """The value being assigned to the variables."""
 
-        self.type_annotation: Optional[NodeNG] = None
+        self.type_annotation: Optional[NodeNG] = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -39,6 +39,7 @@ import abc
 import itertools
 import sys
 import typing
+import warnings
 from functools import lru_cache
 from typing import Callable, Generator, Optional
 
@@ -610,6 +611,12 @@ class AssignName(
         self.name: Optional[str] = name
         """The name that is assigned to."""
 
+        if name is None:
+            warnings.warn(
+                "'name' will be a required attribute of 'nodes.AssignName' in astroid 3.0.0",
+                DeprecationWarning,
+            )
+
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
 
@@ -649,6 +656,12 @@ class DelName(
         """
         self.name: Optional[str] = name
         """The name that is being deleted."""
+
+        if name is None:
+            warnings.warn(
+                "'name' will be a required attribute of 'nodes.DelName' in astroid 3.0.0",
+                DeprecationWarning,
+            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -690,6 +703,12 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
         """
         self.name: Optional[str] = name
         """The name that this node refers to."""
+
+        if name is None:
+            warnings.warn(
+                "'name' will be a required attribute of 'nodes.Name' in astroid 3.0.0",
+                DeprecationWarning,
+            )
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -118,8 +118,7 @@ def build_class(name, basenames=(), doc=None):
     """create and initialize an astroid ClassDef node"""
     node = nodes.ClassDef(name, doc)
     for base in basenames:
-        basenode = nodes.Name()
-        basenode.name = base
+        basenode = nodes.Name(name=base)
         node.bases.append(basenode)
         basenode.parent = node
     return node

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     wrapt>=1.11,<1.13
     setuptools>=20.0
     typed-ast>=1.4.0,<1.5;implementation_name=="cpython" and python_version<"3.8"
-    typing-extensions>=3.7.4;python_version<"3.8"
+    typing-extensions>=3.10;python_version<"3.10"
 python_requires = ~=3.6
 
 [options.packages.find]

--- a/tests/unittest_decorators.py
+++ b/tests/unittest_decorators.py
@@ -1,0 +1,99 @@
+import pytest
+from _pytest.recwarn import WarningsRecorder
+
+from astroid.decorators import deprecate_default_argument_values
+
+
+class SomeClass:
+    @deprecate_default_argument_values(name="str")
+    def __init__(self, name=None, lineno=None):
+        ...
+
+    @deprecate_default_argument_values("3.2", name="str", var="int")
+    def func(self, name=None, var=None, type_annotation=None):
+        ...
+
+
+class TestDeprecationDecorators:
+    @staticmethod
+    def test_deprecated_default_argument_values_one_arg() -> None:
+        with pytest.warns(DeprecationWarning) as records:
+            # No argument passed for 'name'
+            SomeClass()
+            assert len(records) == 1
+            assert "name" in records[0].message.args[0]
+            assert "'SomeClass.__init__'" in records[0].message.args[0]
+
+        with pytest.warns(DeprecationWarning) as records:
+            # 'None' passed as argument for 'name'
+            SomeClass(None)
+            assert len(records) == 1
+            assert "name" in records[0].message.args[0]
+
+        with pytest.warns(DeprecationWarning) as records:
+            # 'None' passed as keyword argument for 'name'
+            SomeClass(name=None)
+            assert len(records) == 1
+            assert "name" in records[0].message.args[0]
+
+        with pytest.warns(DeprecationWarning) as records:
+            # No value passed for 'name'
+            SomeClass(lineno=42)
+            assert len(records) == 1
+            assert "name" in records[0].message.args[0]
+
+    @staticmethod
+    def test_deprecated_default_argument_values_two_args() -> None:
+        instance = SomeClass(name="")
+
+        # No value of 'None' passed for both arguments
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func()
+            assert len(records) == 2
+            assert "'SomeClass.func'" in records[0].message.args[0]
+            assert "astroid 3.2" in records[0].message.args[0]
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(None)
+            assert len(records) == 2
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(name=None)
+            assert len(records) == 2
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(var=None)
+            assert len(records) == 2
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(name=None, var=None)
+            assert len(records) == 2
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(type_annotation="")
+            assert len(records) == 2
+
+        # No value of 'None' for one argument
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(42)
+            assert len(records) == 1
+            assert "var" in records[0].message.args[0]
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(name="")
+            assert len(records) == 1
+            assert "var" in records[0].message.args[0]
+
+        with pytest.warns(DeprecationWarning) as records:
+            instance.func(var=42)
+            assert len(records) == 1
+            assert "name" in records[0].message.args[0]
+
+    @staticmethod
+    def test_deprecated_default_argument_values_ok(recwarn: WarningsRecorder) -> None:
+        """No DeprecationWarning should be emitted
+        if all arguments are passed with not None values.
+        """
+        instance = SomeClass(name="some_name")
+        instance.func(name="", var=42)
+        assert len(recwarn) == 0

--- a/tests/unittest_transforms.py
+++ b/tests/unittest_transforms.py
@@ -86,8 +86,7 @@ class TestTransforms(unittest.TestCase):
     def test_transform_patches_locals(self):
         def transform_function(node):
             assign = nodes.Assign()
-            name = nodes.AssignName()
-            name.name = "value"
+            name = nodes.AssignName(name="value")
             assign.targets = [name]
             assign.value = nodes.const_factory(42)
             node.body.append(assign)
@@ -182,8 +181,7 @@ class TestTransforms(unittest.TestCase):
     def test_transforms_are_called_for_builtin_modules(self):
         # Test that transforms are called for builtin modules.
         def transform_function(node):
-            name = nodes.AssignName()
-            name.name = "value"
+            name = nodes.AssignName(name="value")
             node.args.args = [name]
             return node
 


### PR DESCRIPTION
## Description
Some arguments that should always have a value are currently `Optional` with default `None`. This complicates typing them correctly and necessitates additional checks in `pylint`. This PR adds `DeprecationWarnings` if any of these args are `None`.

* `name` (`str`) for `Name`, `AssignName`, `DelName`
* `attrname` (`str`) for `Attribute`, `AssignAttr`, `DelAttr`
* `op` (`str`) for `AugAssign`, `BinOp`, `BoolOp`, `UnaryOp`
* `names` (`list[tuple[str, str | None]]`) for `Import`

--
I plan on adding a few `DeprecationWarnings` in `2.8.0`. Especially for `postinit` methods.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |