### PR TITLE
Recognize nested classes in classes inherited from NamedTuple

### DIFF
--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -484,13 +484,13 @@ def infer_typing_namedtuple_class(class_node, context=None):
     for method in class_node.mymethods():
         generated_class_node.locals[method.name] = [method]
 
-    for assign in class_node.body:
-        if not isinstance(assign, nodes.Assign):
-            continue
-
-        for target in assign.targets:
-            attr = target.name
-            generated_class_node.locals[attr] = class_node.locals[attr]
+    for body_node in class_node.body:
+        if isinstance(body_node, nodes.Assign):
+            for target in body_node.targets:
+                attr = target.name
+                generated_class_node.locals[attr] = class_node.locals[attr]
+        elif isinstance(body_node, nodes.ClassDef):
+            generated_class_node.locals[body_node.name] = [body_node]
 
     return iter((generated_class_node,))
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1629,6 +1629,27 @@ class TypingBrain(unittest.TestCase):
             inferred = next(node.infer())
             self.assertIsInstance(inferred, nodes.ClassDef, node.as_string())
 
+    def test_namedtuple_nested_class(self):
+        result = builder.extract_node(
+            """
+        from typing import NamedTuple
+
+        class Example(NamedTuple):
+            class Foo:
+                bar = "bar"
+
+        Example
+        """
+        )
+        inferred = next(result.infer())
+        self.assertIsInstance(inferred, astroid.ClassDef)
+
+        class_def_attr = inferred.getattr("Foo")[0]
+        self.assertIsInstance(class_def_attr, astroid.ClassDef)
+        attr_def = class_def_attr.getattr("bar")[0]
+        attr = next(attr_def.infer())
+        self.assertEqual(attr.value, "bar")
+
     @test_utils.require_version(minver="3.7")
     def test_tuple_type(self):
         node = builder.extract_node(


### PR DESCRIPTION
## Description

This PR adds recognition of nested class defintions to classes inherited from `typing.NamedTuple`. It also adds a unittest for new functionality. The old functionality is still checked by a few existing unittests.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Fixes PyCQA/pylint#4370.