### PR TITLE
Bug pylint 4960

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -58,7 +58,7 @@ Release date: 2021-09-14
   modules. (Revert the "The transforms related to a module are applied only if this
   module has not been explicitly authorized to be imported" of version 2.7.3)
 
-* Adds a brain to infer the `numpy.ma.masked_where` function.
+* Adds a brain to infer the ``numpy.ma.masked_where`` function.
 
   Closes PyCQA/pylint#3342
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -52,7 +52,16 @@ Release date: 2021-09-14
 
 * Fixed bug in inference of dataclass field calls.
 
-    Closes PyCQA/pylint#4963
+  Closes PyCQA/pylint#4963
+
+* Suppress the conditional between applied brains and dynamic import authorized
+modules. (Revert the "The transforms related to a module are applied only if
+		this module has not been explicitly authorized to be imported" of version
+		2.7.3)
+
+* Adds a brain to infer the `numpy.ma.masked_where` function.
+
+  Closes PyCQA/pylint#3342
 
 
 What's New in astroid 2.7.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -55,9 +55,8 @@ Release date: 2021-09-14
   Closes PyCQA/pylint#4963
 
 * Suppress the conditional between applied brains and dynamic import authorized
-modules. (Revert the "The transforms related to a module are applied only if
-		this module has not been explicitly authorized to be imported" of version
-		2.7.3)
+  modules. (Revert the "The transforms related to a module are applied only if this
+  module has not been explicitly authorized to be imported" of version 2.7.3)
 
 * Adds a brain to infer the `numpy.ma.masked_where` function.
 

--- a/astroid/brain/brain_numpy_ma.py
+++ b/astroid/brain/brain_numpy_ma.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
+
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+"""Astroid hooks for numpy ma module"""
+import functools
+
+from astroid.builder import parse
+from astroid.manager import AstroidManager
+from astroid.brain.helpers import register_module_extender
+
+
+def numpy_ma_transform():
+    """
+    Infer the call of the masked_where function
+
+    :param node: node to infer
+    :param context: inference context
+    """
+    return parse("""
+    import numpy.ma
+    def masked_where(condition, a, copy=True):
+        return numpy.ma.masked_array(a, mask=[])
+    """)
+
+
+register_module_extender(
+    AstroidManager(), "numpy.ma", numpy_ma_transform
+)
+

--- a/astroid/brain/brain_numpy_ma.py
+++ b/astroid/brain/brain_numpy_ma.py
@@ -3,11 +3,10 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 """Astroid hooks for numpy ma module"""
-import functools
 
+from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
 from astroid.manager import AstroidManager
-from astroid.brain.helpers import register_module_extender
 
 
 def numpy_ma_transform():
@@ -17,14 +16,13 @@ def numpy_ma_transform():
     :param node: node to infer
     :param context: inference context
     """
-    return parse("""
+    return parse(
+        """
     import numpy.ma
     def masked_where(condition, a, copy=True):
         return numpy.ma.masked_array(a, mask=[])
-    """)
+    """
+    )
 
 
-register_module_extender(
-    AstroidManager(), "numpy.ma", numpy_ma_transform
-)
-
+register_module_extender(AstroidManager(), "numpy.ma", numpy_ma_transform)

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -160,10 +160,6 @@ class AstroidBuilder(raw_building.InspectBuilder):
 
         # Visit the transforms
         if self._apply_transforms:
-            if modutils.is_module_name_part_of_extension_package_whitelist(
-                module.name, self._manager.extension_package_whitelist
-            ):
-                return module
             module = self._manager.visit_transforms(module)
         return module
 

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 hippo91 <guillaume.peillex@gmail.com>
+
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+import unittest
+
+try:
+    import numpy  # pylint: disable=unused-import
+
+    HAS_NUMPY = True
+except ImportError:
+    HAS_NUMPY = False
+
+from astroid import builder
+
+
+@unittest.skipUnless(HAS_NUMPY, "This test requires the numpy library.")
+class BrainNumpyMaTest(unittest.TestCase):
+    """
+    Test the numpy ma brain module
+    """
+
+    def test_numpy_ma_masked_where_returns_maskedarray(self):
+        """
+        Test that calls to numpy ma masked_where returns a MaskedArray object.
+
+        The "masked_where" node is an Attribute
+        """
+        src = """
+        import numpy as np
+        data = np.ndarray((1,2))
+        np.ma.masked_where([1, 0, 0], data)
+        """
+        node=builder.extract_node(src)
+        cls_node = node.inferred()[0]
+        self.assertEqual(cls_node.pytype(), "numpy.ma.core.MaskedArray")
+
+    def test_numpy_ma_masked_where_returns_maskedarray_bis(self):
+        """
+        Test that calls to numpy ma masked_where returns a MaskedArray object
+
+        The "masked_where" node is a Name
+        """
+        src = """
+        from numpy.ma import masked_where
+        data = np.ndarray((1,2))
+        masked_where([1, 0, 0], data)
+        """
+        node=builder.extract_node(src)
+        cls_node = node.inferred()[0]
+        self.assertEqual(cls_node.pytype(), "numpy.ma.core.MaskedArray")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -6,7 +6,6 @@ import pytest
 
 try:
     import numpy  # pylint: disable=unused-import
-
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False
@@ -19,7 +18,6 @@ class TestBrainNumpyMa:
     """
     Test the numpy ma brain module
     """
-
     @staticmethod
     def test_numpy_ma_masked_where_returns_maskedarray():
         """

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -19,6 +19,7 @@ class TestBrainNumpyMa:
     """
     Test the numpy ma brain module
     """
+
     @staticmethod
     def test_numpy_ma_masked_where_returns_maskedarray():
         """

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -19,6 +19,7 @@ class TestBrainNumpyMa:
     """
     Test the numpy ma brain module
     """
+
     @staticmethod
     def test_numpy_ma_masked_where_returns_maskedarray():
         """
@@ -50,4 +51,3 @@ class TestBrainNumpyMa:
         node = builder.extract_node(src)
         cls_node = node.inferred()[0]
         assert cls_node.pytype() == "numpy.ma.core.MaskedArray"
-

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -2,7 +2,7 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
-import unittest
+import pytest
 
 try:
     import numpy  # pylint: disable=unused-import
@@ -14,13 +14,13 @@ except ImportError:
 from astroid import builder
 
 
-@unittest.skipUnless(HAS_NUMPY, "This test requires the numpy library.")
-class BrainNumpyMaTest(unittest.TestCase):
+@pytest.mark.skipif(not HAS_NUMPY, reason="This test requires the numpy library.")
+class TestBrainNumpyMa:
     """
     Test the numpy ma brain module
     """
-
-    def test_numpy_ma_masked_where_returns_maskedarray(self):
+    @staticmethod
+    def test_numpy_ma_masked_where_returns_maskedarray():
         """
         Test that calls to numpy ma masked_where returns a MaskedArray object.
 
@@ -33,9 +33,10 @@ class BrainNumpyMaTest(unittest.TestCase):
         """
         node = builder.extract_node(src)
         cls_node = node.inferred()[0]
-        self.assertEqual(cls_node.pytype(), "numpy.ma.core.MaskedArray")
+        assert cls_node.pytype() == "numpy.ma.core.MaskedArray"
 
-    def test_numpy_ma_masked_where_returns_maskedarray_bis(self):
+    @staticmethod
+    def test_numpy_ma_masked_where_returns_maskedarray_bis():
         """
         Test that calls to numpy ma masked_where returns a MaskedArray object
 
@@ -48,8 +49,5 @@ class BrainNumpyMaTest(unittest.TestCase):
         """
         node = builder.extract_node(src)
         cls_node = node.inferred()[0]
-        self.assertEqual(cls_node.pytype(), "numpy.ma.core.MaskedArray")
+        assert cls_node.pytype() == "numpy.ma.core.MaskedArray"
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -14,7 +14,7 @@ except ImportError:
 from astroid import builder
 
 
-@pytest.mark.skipif(not HAS_NUMPY, reason="This test requires the numpy library.")
+@pytest.mark.skipif(HAS_NUMPY is False, reason="This test requires the numpy library.")
 class TestBrainNumpyMa:
     """
     Test the numpy ma brain module

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -31,7 +31,7 @@ class BrainNumpyMaTest(unittest.TestCase):
         data = np.ndarray((1,2))
         np.ma.masked_where([1, 0, 0], data)
         """
-        node=builder.extract_node(src)
+        node = builder.extract_node(src)
         cls_node = node.inferred()[0]
         self.assertEqual(cls_node.pytype(), "numpy.ma.core.MaskedArray")
 
@@ -46,7 +46,7 @@ class BrainNumpyMaTest(unittest.TestCase):
         data = np.ndarray((1,2))
         masked_where([1, 0, 0], data)
         """
-        node=builder.extract_node(src)
+        node = builder.extract_node(src)
         cls_node = node.inferred()[0]
         self.assertEqual(cls_node.pytype(), "numpy.ma.core.MaskedArray")
 

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -6,6 +6,7 @@ import pytest
 
 try:
     import numpy  # pylint: disable=unused-import
+
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False
@@ -18,6 +19,7 @@ class TestBrainNumpyMa:
     """
     Test the numpy ma brain module
     """
+
     @staticmethod
     def test_numpy_ma_masked_where_returns_maskedarray():
         """

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -19,7 +19,6 @@ class TestBrainNumpyMa:
     """
     Test the numpy ma brain module
     """
-
     @staticmethod
     def test_numpy_ma_masked_where_returns_maskedarray():
         """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [*] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [*] Write a good description on what the PR does.

## Description
The PR #1148 introduced a regression that causes PyCQA/pylint#4960. 
While the idea behind #1148 may be a good idea, its implementation was faulty and prevent the use of brains even if the node that are modified inside those brains are not part of a potentially dynamically loaded module.
I didn't find a correct implementation that prevent the modification of nodes that are defined inside a dynamically loaded module.
That's why this PR is a partial revert of #1148. (revert concerns only the `builder` module).
I also added a `numpy` brain that allows `pylint` to infer correctly the call to `numpy.ma.masked_where` function so that PyCQA/pylint#3342 will be definitely closed.  


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes PyCQA/pylint#3342
Closes PyCQA/pylint#4960

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
