### PR TITLE
Support dataclass inference for pydantic.dataclasses.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.8.1?
 ============================
 Release date: TBA
 
+* Enable inference of dataclass import from pydantic.dataclasses.
+  This allows the dataclasses brain to recognize pydantic dataclasses.
+
+  Closes PyCQA/pylint#4899
 
 
 What's New in astroid 2.8.0?


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Hello, sorry for the delay on this one, it's been a bit hectic at work. Thanks @DanielNoord for the comment https://github.com/PyCQA/pylint/issues/4899#issuecomment-916737641, helped me reliably reproduce the issue. It seems that with `pylint --extension-pkg-allow-list=pydantic`, inference of `dataclass` from `pydantic.dataclasses` succeed (resulting in a `FunctionDef`) rather than yielding `Uninferable`, which is what #1144 handled.

Anyway, I added `pydantic.dataclasses` to an explicit allow-list for dataclass import modules, and this fixed the error. What I'm not sure about is (1) how/why `--extension-pkg-allow-list` affects this inference, and (2) how to update the tests for this, since I'd already added a bunch of tests for `pydantic.dataclasses` in my previous PR, but they already pass. Similarly, the pydantic.dataclasses test in https://github.com/PyCQA/pylint/pull/4919 already passes, but I'd be happy to add another Pylint test with `--extension-pkg-allow-list=pydantic`, with some guidance on setting config options and adding third-party modules for tests. 

Feedback/ideas welcome!

(I also fixed one type annotation, that was an error from earlier.)

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes https://github.com/PyCQA/pylint/issues/4899 (again).