### PR TITLE
Support "is None" constraints from if statements during inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,14 @@ What's New in astroid 2.9.0?
 ============================
 Release date: TBA
 
+* Support "is None" constraints from if statements during inference.
+
+  Closes #791
+  Closes PyCQA/pylint#157
+  Closes PyCQA/pylint#1472
+  Closes PyCQA/pylint#2016
+  Closes PyCQA/pylint#2631
+  Closes PyCQA/pylint#2880
 
 
 What's New in astroid 2.8.1?

--- a/astroid/constraint.py
+++ b/astroid/constraint.py
@@ -1,0 +1,137 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+"""Classes representing different types of constraints on inference values."""
+
+from typing import Any, Dict, Optional
+
+from astroid import nodes, util
+
+
+class Constraint:
+    """Represents a single constraint on a variable."""
+
+    node: nodes.NodeNG
+    negate: bool
+
+    def __init__(self, node: nodes.NodeNG, negate: bool) -> None:
+        self.node = node
+        """The node that this constraint applies to."""
+        self.negate = negate
+        """True if this constraint is negated. E.g., "is not" instead of "is"."""
+
+    def invert(self) -> None:
+        """Invert this constraint."""
+        self.negate = not self.negate
+
+    @classmethod
+    def match(
+        cls, node: nodes.NodeNG, expr: nodes.NodeNG, negate: bool = False
+    ) -> Optional["Constraint"]:
+        """Return a new constraint for node matched from expr, if expr matches
+        the constraint pattern.
+
+        If negate is True, negate the constraint.
+        """
+
+    def satisfied_by(self, inferred: Any) -> bool:
+        """Return True if this constraint is satisfied by the given inferred value."""
+        return True
+
+
+class NoneConstraint(Constraint):
+    """Represents an "is None" or "is not None" constraint."""
+
+    @classmethod
+    def match(
+        cls, node: nodes.NodeNG, expr: nodes.NodeNG, negate: bool = False
+    ) -> Optional[Constraint]:
+        """Return a new constraint for node matched from expr, if expr matches
+        the constraint pattern.
+
+        Negate the constraint based on the value of negate.
+        """
+        if isinstance(expr, nodes.Compare) and len(expr.ops) == 1:
+            left = expr.left
+            op, right = expr.ops[0]
+            const_none = nodes.Const(None)
+            if op in {"is", "is not"} and (
+                matches(left, node)
+                and matches(right, const_none)
+                or matches(left, const_none)
+                and matches(right, node)
+            ):
+                negate = (op == "is" and negate) or (op == "is not" and not negate)
+                return cls(node=node, negate=negate)
+
+        return None
+
+    def satisfied_by(self, inferred: Any) -> bool:
+        """Return True if this constraint is satisfied by the given inferred value."""
+        if inferred is util.Uninferable:
+            return True
+
+        if self.negate and matches(inferred, nodes.Const(None)):
+            return False
+        if not self.negate and not matches(inferred, nodes.Const(None)):
+            return False
+
+        return True
+
+
+def matches(node1: nodes.NodeNG, node2: nodes.NodeNG) -> bool:
+    """Returns True if the two nodes match."""
+    if isinstance(node1, nodes.Name) and isinstance(node2, nodes.Name):
+        return node1.name == node2.name
+    if isinstance(node1, nodes.Attribute) and isinstance(node2, nodes.Attribute):
+        return node1.attrname == node2.attrname and matches(node1.expr, node2.expr)
+    if isinstance(node1, nodes.Const) and isinstance(node2, nodes.Const):
+        return node1.value == node2.value
+
+    return False
+
+
+def get_constraints(
+    expr: nodes.NodeNG, frame: nodes.NodeNG
+) -> Dict[nodes.NodeNG, Constraint]:
+    """Returns the constraints for the given expression.
+
+    The returned dictionary maps the node where the constraint was generated to the
+    corresponding constraint.
+
+    Constraints are computed statically by analysing the code surrounding expr.
+    Currently this only supports constraints generated from if conditions.
+    """
+    current_node = expr
+    constraints = {}
+    while current_node is not None and current_node is not frame:
+        parent = current_node.parent
+        if isinstance(parent, nodes.If):
+            branch, _ = parent.locate_child(current_node)
+            if branch == "body":
+                constraint = match_constraint(expr, parent.test)
+            elif branch == "orelse":
+                constraint = match_constraint(expr, parent.test, invert=True)
+            else:
+                constraint = None
+
+            if constraint:
+                constraints[parent] = constraint
+        current_node = parent
+
+    return constraints
+
+
+ALL_CONSTRAINTS = (NoneConstraint,)
+"""All supported constraint types."""
+
+
+def match_constraint(
+    node: nodes.NodeNG, expr: nodes.NodeNG, invert: bool = False
+) -> Optional[Constraint]:
+    """Returns a constraint pattern for node, if one matches."""
+    for constraint_cls in ALL_CONSTRAINTS:
+        constraint = constraint_cls.match(node, expr, invert)
+        if constraint:
+            return constraint
+
+    return None

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -41,6 +41,7 @@ class InferenceContext:
         "callcontext",
         "boundnode",
         "extra_context",
+        "constraints",
         "_nodes_inferred",
     )
 
@@ -89,6 +90,13 @@ class InferenceContext:
 
         Context that needs to be passed down through call stacks
         for call arguments
+        """
+
+        self.constraints = {}
+        """
+        :type: dict
+
+        The constraints on nodes
         """
 
     @property
@@ -145,6 +153,7 @@ class InferenceContext:
         clone.callcontext = self.callcontext
         clone.boundnode = self.boundnode
         clone.extra_context = self.extra_context
+        clone.constraints = self.constraints.copy()
         return clone
 
     @contextlib.contextmanager

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -35,7 +35,9 @@ from typing import Any, Callable, Dict, Iterable, Optional
 
 import wrapt
 
-from astroid import bases, decorators, helpers, nodes, protocols, util
+from astroid import bases
+from astroid import constraint as constraintmod
+from astroid import decorators, helpers, nodes, protocols, util
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -215,6 +217,8 @@ def infer_name(self, context=None):
             )
     context = copy_context(context)
     context.lookupname = self.name
+    context.constraints[self.name] = constraintmod.get_constraints(self, frame)
+
     return bases._infer_stmts(stmts, context, frame)
 
 
@@ -317,6 +321,11 @@ def infer_attribute(self, context=None):
         old_boundnode = context.boundnode
         try:
             context.boundnode = owner
+            if isinstance(owner, (nodes.ClassDef, bases.Instance)):
+                frame = owner if isinstance(owner, nodes.ClassDef) else owner._proxied
+                context.constraints[self.attrname] = constraintmod.get_constraints(
+                    self, frame=frame
+                )
             yield from owner.igetattr(self.attrname, context)
         except (
             AttributeInferenceError,

--- a/tests/unittest_inference_constraints.py
+++ b/tests/unittest_inference_constraints.py
@@ -1,0 +1,569 @@
+"""Tests for inference involving constraints"""
+
+from typing import Any
+
+import pytest
+
+from astroid import builder, nodes
+from astroid.util import Uninferable
+
+
+def common_params(node):
+    return pytest.mark.parametrize(
+        ("condition", "satisfy_val", "fail_val"),
+        (
+            (f"{node} is None", None, 3),
+            (f"{node} is not None", 3, None),
+        ),
+    )
+
+
+@common_params(node="x")
+def test_if_single_statement(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test constraint for a variable that is used in the first statement of an if body."""
+    node1, node2 = builder.extract_node(
+        f"""
+    def f1(x = {fail_val}):
+        if {condition}:  # Filters out default value
+            return (
+                x  #@
+            )
+
+    def f2(x = {satisfy_val}):
+        if {condition}:  # Does not filter out default value
+            return (
+                x  #@
+            )
+    """
+    )
+
+    inferred = node1.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_if_multiple_statements(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test constraint for a variable that is used in an if body with multiple statements."""
+    node1, node2 = builder.extract_node(
+        f"""
+    def f1(x = {fail_val}):
+        if {condition}:  # Filters out default value
+            print(x)
+            return (
+                x  #@
+            )
+
+    def f2(x = {satisfy_val}):
+        if {condition}:  # Does not filter out default value
+            print(x)
+            return (
+                x  #@
+            )
+    """
+    )
+
+    inferred = node1.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_if_irrelevant_condition(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint for a different variable doesn't apply."""
+    nodes_ = builder.extract_node(
+        f"""
+    def f1(x, y = {fail_val}):
+        if {condition}:  # Does not filter out fail_val
+            return (
+                y  #@
+            )
+
+    def f2(x, y = {satisfy_val}):
+        if {condition}:
+            return (
+                y  #@
+            )
+    """
+    )
+    for node, val in zip(nodes_, (fail_val, satisfy_val)):
+        inferred = node.inferred()
+        assert len(inferred) == 2
+        assert isinstance(inferred[0], nodes.Const)
+        assert inferred[0].value == val
+
+        assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_outside_if(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test that constraint in an if condition doesn't apply outside of the if."""
+    nodes_ = builder.extract_node(
+        f"""
+    def f1(x = {fail_val}):
+        if {condition}:
+            pass
+        return (
+            x  #@
+        )
+
+    def f2(x = {satisfy_val}):
+        if {condition}:
+            pass
+
+        return (
+            x  #@
+        )
+    """
+    )
+    for node, val in zip(nodes_, (fail_val, satisfy_val)):
+        inferred = node.inferred()
+        assert len(inferred) == 2
+        assert isinstance(inferred[0], nodes.Const)
+        assert inferred[0].value == val
+
+        assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_nested_if(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test that constraint in an if condition applies within inner if statements."""
+    node1, node2 = builder.extract_node(
+        f"""
+    def f1(y, x = {fail_val}):
+        if {condition}:
+            if y is not None:
+                return (
+                    x  #@
+                )
+
+    def f2(y, x = {satisfy_val}):
+        if {condition}:
+            if y is not None:
+                return (
+                    x  #@
+                )
+    """
+    )
+    inferred = node1.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+
+    assert inferred[1] is Uninferable
+
+
+def test_if_uninferable() -> None:
+    """Test that when no inferred values satisfy all constraints, Uninferable is inferred."""
+    node1, node2 = builder.extract_node(
+        """
+    def f1():
+        x = None
+        if x is not None:
+            x  #@
+
+    def f2():
+        x = 1
+        if x is not None:
+            pass
+        else:
+            x  #@
+    """
+    )
+    inferred = node1.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+@common_params(node="x")
+def test_if_reassignment_in_body(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply when the variable
+    is assigned to a failing value inside the if body.
+    """
+    node = builder.extract_node(
+        f"""
+    def f(x, y):
+        if {condition}:
+            if y:
+                x = {fail_val}
+            return (
+                x  #@
+            )
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 2
+    assert inferred[0] is Uninferable
+
+    assert isinstance(inferred[1], nodes.Const)
+    assert inferred[1].value == fail_val
+
+
+@common_params(node="x")
+def test_if_elif_else_negates(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test that constraint in an if condition is negated when the variable
+    is used in the elif and else branches.
+    """
+    node1, node2, node3, node4 = builder.extract_node(
+        f"""
+    def f1(y, x = {fail_val}):
+        if {condition}:
+            pass
+        elif y:  # Does not filter out default value
+            return (
+                x  #@
+            )
+        else:  # Does not filter out default value
+            return (
+                x  #@
+            )
+
+    def f2(y, x = {satisfy_val}):
+        if {condition}:
+            pass
+        elif y:  # Filters out default value
+            return (
+                x  #@
+            )
+        else:  # Filters out default value
+            return (
+                x  #@
+            )
+    """
+    )
+    for node in (node1, node2):
+        inferred = node.inferred()
+        assert len(inferred) == 2
+        assert isinstance(inferred[0], nodes.Const)
+        assert inferred[0].value == fail_val
+
+        assert inferred[1] is Uninferable
+
+    for node in (node3, node4):
+        inferred = node.inferred()
+        assert len(inferred) == 1
+        assert inferred[0] is Uninferable
+
+
+@common_params(node="x")
+def test_if_reassignment_in_else(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply when the variable
+    is assigned to a failing value inside the else branch.
+    """
+    node = builder.extract_node(
+        f"""
+    def f(x, y):
+        if {condition}:
+            return x
+        else:
+            if y:
+                x = {satisfy_val}
+            return (
+                x  #@
+            )
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 2
+    assert inferred[0] is Uninferable
+
+    assert isinstance(inferred[1], nodes.Const)
+    assert inferred[1].value == satisfy_val
+
+
+@common_params(node="x")
+def test_if_comprehension_shadow(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply when the variable
+    is shadowed by an inner comprehension scope.
+    """
+    node = builder.extract_node(
+        f"""
+    def f(x):
+        if {condition}:
+            return [
+                x  #@
+                for x in [{satisfy_val}, {fail_val}]
+            ]
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 2
+
+    for actual, expected in zip(inferred, (satisfy_val, fail_val)):
+        assert isinstance(actual, nodes.Const)
+        assert actual.value == expected
+
+
+@common_params(node="x")
+def test_if_function_shadow(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test that constraint in an if condition doesn't apply when the variable
+    is shadowed by an inner function scope.
+    """
+    node = builder.extract_node(
+        f"""
+    x = {satisfy_val}
+    if {condition}:
+        def f(x = {fail_val}):
+            return (
+                x  #@
+            )
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="x")
+def test_if_function_call(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test that constraint in an if condition doesn't apply for a parameter
+    a different function call, but with the same name.
+    """
+    node = builder.extract_node(
+        f"""
+    def f(x = {satisfy_val}):
+        if {condition}:
+            g({fail_val})  #@
+
+    def g(x):
+        return x
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+
+
+@common_params(node="self.x")
+def test_if_instance_attr(condition: str, satisfy_val: Any, fail_val: Any) -> None:
+    """Test constraint for an instance attribute in an if statement."""
+    node1, node2 = builder.extract_node(
+        f"""
+    class A1:
+        def __init__(self, x = {fail_val}):
+            self.x = x
+
+        def method(self):
+            if {condition}:
+                self.x  #@
+
+    class A2:
+        def __init__(self, x = {satisfy_val}):
+            self.x = x
+
+        def method(self):
+            if {condition}:
+                self.x  #@
+    """
+    )
+
+    inferred = node1.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == satisfy_val
+
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="self.x")
+def test_if_instance_attr_reassignment_in_body(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply to an instance attribute
+    when it is assigned inside the if body.
+    """
+    node1, node2 = builder.extract_node(
+        f"""
+    class A1:
+        def __init__(self, x):
+            self.x = x
+
+        def method1(self):
+            if {condition}:
+                self.x = {satisfy_val}
+                self.x  #@
+
+        def method2(self):
+            if {condition}:
+                self.x = {fail_val}
+                self.x  #@
+    """
+    )
+
+    inferred = node1.inferred()
+    assert len(inferred) == 2
+    assert inferred[0] is Uninferable
+
+    assert isinstance(inferred[1], nodes.Const)
+    assert inferred[1].value == satisfy_val
+
+    inferred = node2.inferred()
+    assert len(inferred) == 3
+    assert inferred[0] is Uninferable
+
+    assert isinstance(inferred[1], nodes.Const)
+    assert inferred[1].value == satisfy_val
+
+    assert isinstance(inferred[2], nodes.Const)
+    assert inferred[2].value == fail_val
+
+
+@common_params(node="x")
+def test_if_instance_attr_varname_collision1(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply to an instance attribute
+    when the constraint refers to a variable with the same name.
+    """
+    node1, node2 = builder.extract_node(
+        f"""
+    class A1:
+        def __init__(self, x = {fail_val}):
+            self.x = x
+
+        def method(self, x = {fail_val}):
+            if {condition}:
+                x  #@
+                self.x  #@
+    """
+    )
+
+    inferred = node1.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+
+    assert inferred[1] is Uninferable
+
+
+@common_params(node="self.x")
+def test_if_instance_attr_varname_collision2(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply to a variable with the same name."""
+    node1, node2 = builder.extract_node(
+        f"""
+    class A1:
+        def __init__(self, x = {fail_val}):
+            self.x = x
+
+        def method(self, x = {fail_val}):
+            if {condition}:
+                x  #@
+                self.x  #@
+    """
+    )
+
+    inferred = node1.inferred()
+    assert len(inferred) == 2
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+
+    assert inferred[1] is Uninferable
+
+    inferred = node2.inferred()
+    assert len(inferred) == 1
+    assert inferred[0] is Uninferable
+
+
+@common_params(node="self.x")
+def test_if_instance_attr_varname_collision3(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply to an instance attribute
+    for an object of a different class.
+    """
+    node = builder.extract_node(
+        f"""
+    class A1:
+        def __init__(self, x = {fail_val}):
+            self.x = x
+
+        def method(self):
+            obj = A2()
+            if {condition}:
+                obj.x  #@
+
+    class A2:
+        def __init__(self):
+            self.x = {fail_val}
+    """
+    )
+
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == fail_val
+
+
+@common_params(node="self.x")
+def test_if_instance_attr_varname_collision4(
+    condition: str, satisfy_val: Any, fail_val: Any
+) -> None:
+    """Test that constraint in an if condition doesn't apply to a variable of the same name,
+    when that variable is used to infer the value of the instance attribute.
+    """
+    node = builder.extract_node(
+        f"""
+    class A1:
+        def __init__(self, x):
+            self.x = x
+
+        def method(self):
+            x = {fail_val}
+            if {condition}:
+                self.x = x
+                self.x  #@
+    """
+    )
+
+    inferred = node.inferred()
+    assert len(inferred) == 2
+    assert inferred[0] is Uninferable
+
+    assert isinstance(inferred[1], nodes.Const)
+    assert inferred[1].value == fail_val


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Alright, this is a big one so please don't hold back. This PR adds infrastructure to support *constraints* on values during inference. Here's a simple example:

```python
from astroid import extract_node

node = extract_node("""
def f(b):
    if b:
        x = 1
    else:
        x = None
    
    if x is not None:
        x #@
""")
print(node.inferred())
```

This prints `[<Const.int l.4 at 0x14232a6e6d0>, <Const.NoneType l.6 at 0x142329b38b0>]`, using both possible values from the assignment statements. Of course, because of the `x is not None` if condition, only the int is possible, but astroid currently doesn't take this condition into account.

This PR changes how inference works so that only `[<Const.int l.4 at 0x14232a6e6d0>]` is printed.

### Scope

I reviewed the existing pylint issues related to this (they are generally labelled as "topic-control-flow"). There were four types of constraints that were brought up:

1. `x is None`/`x is not None`
2. `x`/`not x` (truthy/falsey value)
3. `isinstance(x, ...)`
4. `x == ...`
5. Combinations of the above with `and`/`or`

There were also three primary locations where these constraints could be inferred (orthogonal to the constraints themselves):

1. if statement (as in above example)
2. `and`/`or` clauses. For example, `x is not None and x[0] == 1`; the second `x` should not be inferred as `None`
3. ternary if expressions. For example, `x[0] if x is not None else 1`; the first `x` should not be inferred as `None`
4. reassignment within an if statement, e.g.

    ```python
    def f():
        a = None
        if a is None:
            a = 1
        return -a
    ```
5. early return/raises within an if statement.
6. assert statements

This pull request addresses just the item 1's in each list. I used an approach that can handle 1-5 of the constraint types, and 1-3 of the locations. If this approach is approved, I think it would be pretty straightforward to make additional PRs for these items. (More on the other constraint locations below.) 

### Implementation overview

I added a new `Constraint` class to represent a constraint on a variable, like `x is not None`.
- This is an abstract class, and can be subclassed for different constraint types.

When a variable is inferred (see `inference.py`, `infer_name`), we search the ancestor chain from the node and look for containing if statements, using these to accumulate constraints on the variable. These constraints are added to the inference context (added a new attribute to `InferenceContext`).

Then, in `_infer_stmts` (`bases.py`), we filter the inferred values based on whether or not they satisfy all constraints for that variable. 
- `Uninferable` is considered to satisfy all constraints.
- ⚠️ If there is at least one inferred value, but *all* inferred values are filtered out, a new `Uninferable` value is yielded, rather than yielding nothing at all. I think this is the conservative approach, to avoid errors from the `raise_if_nothing_inferred` decorator.

The above also applies to attributes (see `infer_attribute`).

### Some comments/questions

1. Because constraints are gathered by searching up the ancestor chain, this PR doesn't handle real control flow issues, e.g. with the reassignment example from above.
2. Because the filtering occurs in `_infer_stmts`, it only applies to variables and attributes. So for example, subscript nodes (e.g. `my_array[0]`) won't have their inferred values filtered.
3. Gathering constraints occurs every time `infer_name`/`infer_attribute` is called, and since this requires going up the ancestor tree, this adds some overhead to inference. In principle constraints can be gathered through an AST visitor, but I thought that would be more complex so didn't choose it. (Thoughts welcome of course!)
4. I think adding the constraints to `InferenceContext` is correct, but to be honest I'm fuzzy on the nuances of this class and how it's used.
5. Do you like the name "constraint" here? I go back on forth on it, but haven't come up with anything better.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes #791
Closes PyCQA/pylint#157
Closes PyCQA/pylint#1472
Closes PyCQA/pylint#2016
Closes PyCQA/pylint#2631
Closes PyCQA/pylint#2880
