### PR TITLE
Remove deprecation warning raised by own astroid code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Release date: TBA
 
   Closes PyCQA/pylint#5048
 
+* Astroid does not trigger it's own deprecation warning anymore.
 
 What's New in astroid 2.8.0?
 ============================

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -48,11 +48,10 @@ from pathlib import Path
 # the version before the dependencies are installed (in particular 'wrapt'
 # that is imported in astroid.inference)
 from astroid.__pkginfo__ import __version__, version
+from astroid.nodes import node_classes, scoped_nodes
 
 # isort: on
 
-from astroid import node_classes  # Deprecated, to remove later
-from astroid import scoped_nodes  # Deprecated, to remove later
 from astroid import inference, raw_building
 from astroid.astroid_manager import MANAGER
 from astroid.bases import BaseInstance, BoundMethod, Instance, UnboundMethod


### PR DESCRIPTION
## Description

Following comment here: https://github.com/PyCQA/astroid/issues/1072\#issuecomment-925471310

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

#1072 
