### PR TITLE
Improve brain for typing.Callable + typing.Type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,11 @@ Release date: TBA
 
 * Astroid does not trigger it's own deprecation warning anymore.
 
+* Improve inference of ``typing.Callable``.
+  Fix pylint false-positive when used in ``isinstance``.
+
+  Closes PyCQA/pylint#3507
+
 
 What's New in astroid 2.8.0?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,10 +30,7 @@ Release date: TBA
 
 * Astroid does not trigger it's own deprecation warning anymore.
 
-* Improve inference of ``typing.Callable``.
-  Fix pylint false-positive when used in ``isinstance``.
-
-  Closes PyCQA/pylint#3507
+* Improve brain for ``typing.Callable`` and ``typing.Type``.
 
 
 What's New in astroid 2.8.0?

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -232,9 +232,7 @@ def _looks_like_typing_alias(node: Call) -> bool:
         and node.func.name == "_alias"
         and (
             # _alias function works also for builtins object such as list and dict
-            isinstance(node.args[0], Attribute)
-            or isinstance(node.args[0], Name)
-            and node.args[0].name != "type"
+            isinstance(node.args[0], (Attribute, Name))
         )
     )
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -280,7 +280,7 @@ def infer_typing_alias(
         or not len(node.parent.targets) == 1
         or not isinstance(node.parent.targets[0], AssignName)
     ):
-        return None
+        raise UseInferenceDefault
     try:
         res = next(node.args[0].infer(context=ctx))
     except StopIteration as e:
@@ -318,37 +318,58 @@ def infer_typing_alias(
     return iter([class_def])
 
 
-def _looks_like_tuple_alias(node: Call) -> bool:
-    """Return True if call is for Tuple alias.
+def _looks_like_special_alias(node: Call) -> bool:
+    """Return True if call is for Tuple or Callable alias.
 
     In PY37 and PY38 the call is to '_VariadicGenericAlias' with 'tuple' as
     first argument. In PY39+ it is replaced by a call to '_TupleType'.
 
     PY37: Tuple = _VariadicGenericAlias(tuple, (), inst=False, special=True)
     PY39: Tuple = _TupleType(tuple, -1, inst=False, name='Tuple')
+
+
+    PY37: Callable = _VariadicGenericAlias(collections.abc.Callable, (), special=True)
+    PY39: Callable = _CallableType(collections.abc.Callable, 2)
     """
     return isinstance(node.func, Name) and (
         not PY39_PLUS
         and node.func.name == "_VariadicGenericAlias"
-        and isinstance(node.args[0], Name)
-        and node.args[0].name == "tuple"
+        and (
+            isinstance(node.args[0], Name)
+            and node.args[0].name == "tuple"
+            or isinstance(node.args[0], Attribute)
+            and node.args[0].as_string() == "collections.abc.Callable"
+        )
         or PY39_PLUS
-        and node.func.name == "_TupleType"
-        and isinstance(node.args[0], Name)
-        and node.args[0].name == "tuple"
+        and (
+            node.func.name == "_TupleType"
+            and isinstance(node.args[0], Name)
+            and node.args[0].name == "tuple"
+            or node.func.name == "_CallableType"
+            and isinstance(node.args[0], Attribute)
+            and node.args[0].as_string() == "collections.abc.Callable"
+        )
     )
 
 
-def infer_tuple_alias(
+def infer_special_alias(
     node: Call, ctx: context.InferenceContext = None
 ) -> typing.Iterator[ClassDef]:
     """Infer call to tuple alias as new subscriptable class typing.Tuple."""
+    if not (
+        isinstance(node.parent, Assign)
+        and len(node.parent.targets) == 1
+        and isinstance(node.parent.targets[0], AssignName)
+    ):
+        raise UseInferenceDefault
     try:
         res = next(node.args[0].infer(context=ctx))
     except StopIteration as e:
         raise InferenceError(node=node.args[0], context=context) from e
+
+    assign_name = node.parent.targets[0]
     class_def = ClassDef(
-        name="Tuple",
+        name=assign_name.name,
         parent=node.parent,
     )
     class_def.postinit(bases=[res], body=[], decorators=None)
@@ -413,5 +434,5 @@ if PY37_PLUS:
         Call, inference_tip(infer_typing_alias), _looks_like_typing_alias
     )
     AstroidManager().register_transform(
-        Call, inference_tip(infer_tuple_alias), _looks_like_tuple_alias
+        Call, inference_tip(infer_special_alias), _looks_like_special_alias
     )

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1678,6 +1678,19 @@ class TypingBrain(unittest.TestCase):
         assert inferred.qname() == "typing.Tuple"
 
     @test_utils.require_version(minver="3.7")
+    def test_callable_type(self):
+        node = builder.extract_node(
+            """
+        from typing import Callable, Any
+        Callable[..., Any]
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)
+        assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
+        assert inferred.qname() == "typing.Callable"
+
+    @test_utils.require_version(minver="3.7")
     def test_typing_generic_subscriptable(self):
         """Test typing.Generic is subscriptable with __class_getitem__ (added in PY37)"""
         node = builder.extract_node(


### PR DESCRIPTION
## Description
Similar to `typing.Tuple` - `typing.Callable` is a special alias as well. Added some brain logic to help infer it correctly.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Ref: https://github.com/PyCQA/pylint/issues/3507#issuecomment-929502627
Ref: https://github.com/PyCQA/pylint/issues/5087
Pylint PR with additional tests: https://github.com/PyCQA/pylint/pull/5089
Pylint PR for additional typing tests: https://github.com/PyCQA/pylint/pull/5090