### PR TITLE
Deprecate ``is_typing_guard`` and ``is_sys_guard``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,9 +40,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#5059
 
-* The ``is_typing_guard`` and ``is_sys_guard`` functions were deprecated and will
-  be removed in 3.0.0. They are complex meta-inference functions that are not
-  suitable for astroid.
+* The ``is_typing_guard`` and ``is_sys_guard`` functions are deprecated and will
+  be removed in 3.0.0. They are complex meta-inference functions that are better
+  suited for pylint. Import them from ``pylint.checkers.utils`` instead
+  (requires pylint ``2.12``).
 
 
 What's New in astroid 2.8.0?

--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#5059
 
+* The ``is_typing_guard`` and ``is_sys_guard`` functions were deprecated and will
+  be removed in 3.0.0. They are complex meta-inference functions that are not
+  suitable for astroid.
+
 
 What's New in astroid 2.8.0?
 ============================

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -39,6 +39,7 @@ import abc
 import itertools
 import sys
 import typing
+import warnings
 from functools import lru_cache
 from typing import TYPE_CHECKING, Callable, Generator, Optional
 
@@ -2870,6 +2871,10 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         >>> node.is_sys_guard()
         True
         """
+        warnings.warn(
+            "The 'is_sys_guard' function is deprecated and will be removed in astroid 3.0.0",
+            DeprecationWarning,
+        )
         if isinstance(self.test, Compare):
             value = self.test.left
             if isinstance(value, Subscript):
@@ -2891,6 +2896,10 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         >>> node.is_typing_guard()
         True
         """
+        warnings.warn(
+            "The 'is_typing_guard' function is deprecated and will be removed in astroid 3.0.0",
+            DeprecationWarning,
+        )
         return isinstance(
             self.test, (Name, Attribute)
         ) and self.test.as_string().endswith("TYPE_CHECKING")


### PR DESCRIPTION
## Description

See https://github.com/PyCQA/pylint/pull/5107#discussion_r720916886 for context.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue

References #1199
