### PR TITLE
Prefer using the module loader to get source in builder.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in astroid 2.9.0?
 ============================
 Release date: TBA
 
+* Prefer the module loader get_source() method in AstroidBuilder's
+  module_build() when possible to avoid assumptions about source
+  code being available on a filesystem.  Otherwise the source cannot
+  be found and application behavior changes when running within an
+  embedded hermetic interpreter environment (pyoxidizer, etc.).
 
 
 What's New in astroid 2.8.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -92,6 +92,7 @@ Release date: 2021-10-25
   nodes are now correctly added to the locals of the ``FunctionDef``,
   ``ClassDef``, or ``Comprehension``.
 
+
 What's New in astroid 2.8.3?
 ============================
 Release date: 2021-10-17

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -86,7 +86,15 @@ class AstroidBuilder(raw_building.InspectBuilder):
         """Build an astroid from a living module instance."""
         node = None
         path = getattr(module, "__file__", None)
-        if path is not None:
+        loader = getattr(module, "__loader__", None)
+        # Prefer the loader to get the source rather than assuming we have a
+        # filesystem to read the source file from ourselves.
+        if loader:
+            modname = modname or module.__name__
+            source = loader.get_source(modname)
+            if source:
+                node = self.string_build(source, modname, path=path)
+        if node is None and path is not None:
             path_, ext = os.path.splitext(modutils._path_from_filename(path))
             if ext in {".py", ".pyc", ".pyo"} and os.path.exists(path_ + ".py"):
                 node = self.file_build(path_ + ".py", modname)


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Prefer the module loader get_source() method in AstroidBuilder's module_build() when possible to avoid assumptions about source code being available on a filesystem.  Otherwise the source cannot be found and application behavior changes when running within an embedded hermetic interpreter environment (pyoxidizer, etc.).

Without this change, pylint packaged up as such would fail to infer that functions like `bz2.compress` returned
something other than None, triggering `assignment-from-no-return` when it clearly should not.

At the pylint level, this works as an application integration regression test - _when you run the test build within such a no-filesystem environment._

```python
    def test_safe_infer_on_bz2_compress_return(self):
        src_node = astroid.extract_node('import bz2\nunused = bz2.compress(b"")')
        assignment = next(src_node.nodes_of_class(astroid.Assign))
        inferred = pylint.checkers.utils.safe_infer(assignment.value.func)
        self.assertIsInstance(inferred, astroid.FunctionDef, msg=str(inferred))
        try:
            next(inferred.nodes_of_class(astroid.Return))
        except StopIteration:
            self.fail(f'No return found in body of:\n{str(inferred)}.')
```

I did not try to come up with a smaller targeted astroid unittest faking the "The path in .\_\_file\_\_ does not exist" environment.  That would probably be useful.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
