### PR TITLE
Refactor: Stop adding arbitrary attributes to module obj when building

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -147,17 +147,6 @@ class AstroidBuilder(raw_building.InspectBuilder):
     def _post_build(self, module, encoding):
         """Handles encoding and delayed nodes after a module has been built"""
         module.file_encoding = encoding
-        self._manager.cache_module(module)
-        # post tree building steps after we stored the module in the cache:
-        for from_node in module._import_from_nodes:
-            if from_node.modname == "__future__":
-                for symbol, _ in from_node.names:
-                    module.future_imports.add(symbol)
-            self.add_from_names_to_locals(from_node)
-        # handle delayed assattr nodes
-        for delayed in module._delayed_assattr:
-            self.delayed_assattr(delayed)
-
         # Visit the transforms
         if self._apply_transforms:
             module = self._manager.visit_transforms(module)
@@ -190,8 +179,18 @@ class AstroidBuilder(raw_building.InspectBuilder):
             )
         builder = rebuilder.TreeRebuilder(self._manager, parser_module)
         module = builder.visit_module(node, modname, node_file, package)
-        module._import_from_nodes = builder._import_from_nodes
-        module._delayed_assattr = builder._delayed_assattr
+
+        self._manager.cache_module(module)
+        # post tree building steps after we stored the module in the cache:
+        for from_node in builder._import_from_nodes:
+            if from_node.modname == "__future__":
+                for symbol, _ in from_node.names:
+                    module.future_imports.add(symbol)
+            self.add_from_names_to_locals(from_node)
+        # handle delayed assattr nodes
+        for delayed in builder._delayed_assattr:
+            self.delayed_assattr(delayed)
+
         return module
 
     def add_from_names_to_locals(self, node):

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -28,7 +28,7 @@ import os
 import textwrap
 import types
 from tokenize import detect_encoding
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 from astroid import bases, modutils, nodes, raw_building, rebuilder, util
 from astroid._ast import get_parser_module
@@ -147,25 +147,40 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 except ImportError:
                     modname = os.path.splitext(os.path.basename(path))[0]
             # build astroid representation
-            module = self._data_build(data, modname, path)
-            return self._post_build(module, encoding)
+            module, builder = self._data_build(data, modname, path)
+            return self._post_build(module, builder, encoding)
 
     def string_build(self, data, modname="", path=None):
         """Build astroid from source code string."""
-        module = self._data_build(data, modname, path)
+        module, builder = self._data_build(data, modname, path)
         module.file_bytes = data.encode("utf-8")
-        return self._post_build(module, "utf-8")
+        return self._post_build(module, builder, "utf-8")
 
-    def _post_build(self, module, encoding):
+    def _post_build(
+        self, module: nodes.Module, builder: rebuilder.TreeRebuilder, encoding: str
+    ) -> nodes.Module:
         """Handles encoding and delayed nodes after a module has been built"""
         module.file_encoding = encoding
+        self._manager.cache_module(module)
+        # post tree building steps after we stored the module in the cache:
+        for from_node in builder._import_from_nodes:
+            if from_node.modname == "__future__":
+                for symbol, _ in from_node.names:
+                    module.future_imports.add(symbol)
+            self.add_from_names_to_locals(from_node)
+        # handle delayed assattr nodes
+        for delayed in builder._delayed_assattr:
+            self.delayed_assattr(delayed)
+
         # Visit the transforms
         if self._apply_transforms:
             module = self._manager.visit_transforms(module)
         return module
 
-    def _data_build(self, data: str, modname, path):
-        """Build tree node from data and add some information"""
+    def _data_build(
+        self, data: str, modname, path
+    ) -> Tuple[nodes.Module, rebuilder.TreeRebuilder]:
+        """Build tree node from data and add some informations"""
         try:
             node, parser_module = _parse_string(data, type_comments=True)
         except (TypeError, ValueError, SyntaxError) as exc:
@@ -191,19 +206,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
             )
         builder = rebuilder.TreeRebuilder(self._manager, parser_module, data)
         module = builder.visit_module(node, modname, node_file, package)
-
-        self._manager.cache_module(module)
-        # post tree building steps after we stored the module in the cache:
-        for from_node in builder._import_from_nodes:
-            if from_node.modname == "__future__":
-                for symbol, _ in from_node.names:
-                    module.future_imports.add(symbol)
-            self.add_from_names_to_locals(from_node)
-        # handle delayed assattr nodes
-        for delayed in builder._delayed_assattr:
-            self.delayed_assattr(delayed)
-
-        return module
+        return module, builder
 
     def add_from_names_to_locals(self, node):
         """Store imported names to the locals


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

Moving code from `_post_build` into `_data_build` so that we don't have to attach arbitrary objects to the module (namely `_import_from_nodes`, and `_delayed_assattr`).

Alternatively we could:
- Keep the code in `_post_build` and pass the info along
- Same, but pass the builder

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|   | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
