### PR TITLE
Ensure the `*_fields` attributes of `__init__`/`postinit` are cohesive

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.8.4?
 ============================
 Release date: TBA
 
+* Fix incosistency between ``NodeNG`` subclass ``*_field`` definitions and
+  ``__init__``/``postinit``. A ``DeprecationWarning`` will be emitted for code
+  which provides an argument to the now-incorrect method (generally the
+  parameters have been moved from ``postinit`` to ``__init__``).
 
 
 What's New in astroid 2.8.3?

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -212,7 +212,7 @@ def deprecate_default_argument_values(
 def deprecate_arguments(
     *arguments: str, hint: str
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    """Decorator which emitts a DeprecationWarning if any arguments specified
+    """Decorator which emits a DeprecationWarning if any arguments specified
     are provided.
     """
 

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -208,19 +208,21 @@ def deprecate_default_argument_values(
 
     return deco
 
-def deprecate_arguments(*arguments: str, hint: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+
+def deprecate_arguments(
+    *arguments: str, hint: str
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator which emitts a DeprecationWarning if any arguments specified
     are provided.
     """
+
     def deco(func: Callable[P, R]) -> Callable[P, R]:
         """Decorator function."""
 
         parameter_names = inspect.signature(func).parameters.keys()
         for arg in arguments:
             if arg not in parameter_names:
-                raise Exception(
-                    f"Can't find argument '{arg}'"
-                )
+                raise Exception(f"Can't find argument '{arg}'")
         params = list(parameter_names)
         func.deprecated_args = arguments
 
@@ -230,10 +232,7 @@ def deprecate_arguments(*arguments: str, hint: str) -> Callable[[Callable[P, R]]
 
             for arg in arguments:
                 index = params.index(arg)
-                if (
-                    arg in kwargs
-                    or len(args) > index
-                ):
+                if arg in kwargs or len(args) > index:
                     warnings.warn(
                         f"'{arg}' is a deprecated argument for "
                         f"'{args[0].__class__.__qualname__}.{func.__name__}' "

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -222,7 +222,7 @@ def deprecate_arguments(
         parameter_names = inspect.signature(func).parameters.keys()
         for arg in arguments:
             if arg not in parameter_names:
-                raise Exception(f"Can't find argument '{arg}'")
+                raise ValueError(f"Can't find argument '{arg}'")
         params = list(parameter_names)
         func.deprecated_args = arguments
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1310,6 +1310,7 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
 
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
+    @decorators.deprecate_arguments("simple", hint="Pass it to __init__ instead")
     def postinit(
         self,
         target: NodeNG,
@@ -1787,6 +1788,7 @@ class Comprehension(NodeNG):
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     # pylint: disable=redefined-builtin; same name as builtin ast module.
+    @decorators.deprecate_arguments("is_async", hint="Pass to __init__ instead")
     def postinit(
         self,
         target: Optional[NodeNG] = None,
@@ -4537,21 +4539,22 @@ class MatchClass(Pattern):
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
         *,
-        kwd_attrs: typing.List[str] = [],
+        kwd_attrs: typing.List[str] = None,
     ) -> None:
         self.cls: NodeNG
         self.patterns: typing.List[Pattern]
-        self.kwd_attrs = kwd_attrs
+        self.kwd_attrs = kwd_attrs or []
         self.kwd_patterns: typing.List[Pattern]
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
+    @decorators.deprecate_arguments("kwd_attrs", hint="Pass it to __init__ instead")
     def postinit(
         self,
         *,
         cls: NodeNG,
         patterns: typing.List[Pattern],
         kwd_patterns: typing.List[Pattern],
-        kwd_attrs: typing.List[str] = [],  # @TODO: Handle deprecation (moved to __init__)
+        kwd_attrs: typing.List[str] = [],
     ) -> None:
         self.cls = cls
         self.patterns = patterns

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4539,7 +4539,7 @@ class MatchClass(Pattern):
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
         *,
-        kwd_attrs: typing.List[str] = None,
+        kwd_attrs: typing.Optional[typing.List[str]] = None,
     ) -> None:
         self.cls: NodeNG
         self.patterns: typing.List[Pattern]
@@ -4554,11 +4554,11 @@ class MatchClass(Pattern):
         cls: NodeNG,
         patterns: typing.List[Pattern],
         kwd_patterns: typing.List[Pattern],
-        kwd_attrs: typing.List[str] = [],
+        kwd_attrs: typing.Optional[typing.List[str]] = None,
     ) -> None:
         self.cls = cls
         self.patterns = patterns
-        self.kwd_attrs = kwd_attrs or self.kwd_attrs
+        self.kwd_attrs = kwd_attrs or self.kwd_attrs or []
         self.kwd_patterns = kwd_patterns
 
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2667,7 +2667,7 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         :param parent: The parent node in the syntax tree.
         """
         self.fromname: Optional[str] = fromname  # can be None
-        self.modname = self.fromname  # For backwards
+        self.modname = self.fromname  # For backwards compatibility
         """The module that is being imported from.
 
         This is ``None`` for relative imports.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4351,7 +4351,7 @@ class MatchCase(mixins.MultiLineBlockMixin, NodeNG):
         *,
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None
+        parent: Optional[NodeNG] = None,
     ) -> None:
         self.pattern: Pattern
         self.guard: Optional[NodeNG]

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1315,7 +1315,7 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         self,
         target: NodeNG,
         annotation: NodeNG,
-        simple: int = None,
+        simple: Optional[int] = None,
         value: Optional[NodeNG] = None,
     ) -> None:
         """Do some setup after initialisation.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4263,7 +4263,7 @@ class EvaluatedObject(NodeNG):
 
     name = "EvaluatedObject"
     _astroid_fields = ("original",)
-    _other_fields = ("value",)
+    _other_other_fields = ("value",)
 
     def __init__(
         self, original: NodeNG, value: typing.Union[NodeNG, util.Uninferable]
@@ -4344,11 +4344,17 @@ class MatchCase(mixins.MultiLineBlockMixin, NodeNG):
     _astroid_fields = ("pattern", "guard", "body")
     _multi_line_block_fields = ("body",)
 
-    def __init__(self, *, parent: Optional[NodeNG] = None) -> None:
+    def __init__(
+        self,
+        *,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
+        parent: Optional[NodeNG] = None
+    ) -> None:
         self.pattern: Pattern
         self.guard: Optional[NodeNG]
         self.body: typing.List[NodeNG]
-        super().__init__(parent=parent)
+        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
     def postinit(
         self,
@@ -4530,10 +4536,12 @@ class MatchClass(Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        kwd_attrs: typing.List[str] = [],
     ) -> None:
         self.cls: NodeNG
         self.patterns: typing.List[Pattern]
-        self.kwd_attrs: typing.List[str]
+        self.kwd_attrs = kwd_attrs
         self.kwd_patterns: typing.List[Pattern]
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
@@ -4542,12 +4550,12 @@ class MatchClass(Pattern):
         *,
         cls: NodeNG,
         patterns: typing.List[Pattern],
-        kwd_attrs: typing.List[str],
         kwd_patterns: typing.List[Pattern],
+        kwd_attrs: typing.List[str] = [],  # @TODO: Handle deprecation (moved to __init__)
     ) -> None:
         self.cls = cls
         self.patterns = patterns
-        self.kwd_attrs = kwd_attrs
+        self.kwd_attrs = kwd_attrs or self.kwd_attrs
         self.kwd_patterns = kwd_patterns
 
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -171,6 +171,8 @@ class NodeNG:
         result = []
         for field in self._other_fields + self._astroid_fields:
             value = getattr(self, field)
+            if value is None:
+                continue
             width = 80 - len(field) - alignment
             lines = pprint.pformat(value, indent=2, width=width).splitlines(True)
 

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -2057,7 +2057,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         ),
     )
     _other_fields = ("name", "doc")
-    _other_other_fields = ("locals", "_newstyle")
+    _other_other_fields = ("locals", "_newstyle", "_metaclass")
     _newstyle = None
 
     def __init__(self, name=None, doc=None, lineno=None, col_offset=None, parent=None):

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -385,10 +385,10 @@ class Module(LocalsDictNodeNG):
 
     :type: int or None
     """
-    lineno = None
+    lineno = 0
     """The line that this node appears on in the source code.
 
-    :type: int or None"
+    :type: int or None
     """
 
     # attributes below are set by the builder module or by raw factories

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -43,6 +43,7 @@ Lambda, GeneratorExp, DictComp and SetComp to some extent).
 import builtins
 import io
 import itertools
+import json
 import os
 import typing
 from typing import List, Optional, TypeVar
@@ -366,6 +367,27 @@ class LocalsDictNodeNG(node_classes.LookupMixIn, node_classes.NodeNG):
         """
         return name in self.locals
 
+    def __load__(self, data, loader):
+        """Load the node from the data dict."""
+        self.__init__(
+            **{
+                key: loader(data[key])
+                for key in {"lineno", "col_offset", "parent"}
+                if key in data
+            },
+            **{key: loader(data[key]) for key in self._other_fields},
+        )
+
+        postinit_fields = set(self._astroid_fields + self._other_other_fields) - {
+            "locals",
+            "globals",
+        }
+        self.postinit(
+            **{key: loader(data[key]) for key in postinit_fields if key in data}
+        )
+        # Use update so Module's globals get updated too
+        self.locals.update(loader(data["locals"]))
+
 
 class Module(LocalsDictNodeNG):
     """Class representing an :class:`ast.Module` node.
@@ -385,7 +407,7 @@ class Module(LocalsDictNodeNG):
 
     :type: int or None
     """
-    lineno = 0
+    lineno = None
     """The line that this node appears on in the source code.
 
     :type: int or None
@@ -474,6 +496,7 @@ class Module(LocalsDictNodeNG):
         package=None,
         parent=None,
         pure_python=True,
+        future_imports=None,
     ):
         """
         :param name: The name of the module.
@@ -496,6 +519,9 @@ class Module(LocalsDictNodeNG):
 
         :param pure_python: Whether the ast was built from source.
         :type pure_python: bool or None
+
+        :param future_imports: The imports from ``__future__``.
+        :type future_imports: Optional[Set[str]]
         """
         self.name = name
         self.doc = doc
@@ -514,7 +540,7 @@ class Module(LocalsDictNodeNG):
 
         :type: list(NodeNG) or None
         """
-        self.future_imports = set()
+        self.future_imports = future_imports or set()
 
     # pylint: enable=redefined-builtin
 
@@ -825,6 +851,28 @@ class Module(LocalsDictNodeNG):
 
     def get_children(self):
         yield from self.body
+
+    def __dump__(self, dumper):
+        """Dump the node as a JSON-serializable dict."""
+        # Don't serialize globals since globals is locals
+        assert self.locals is self.globals
+        data = super().__dump__(dumper)
+        data.pop("globals")
+        return data
+
+    def dump(self):
+        """Dump the node as a JSON-serializable dict."""
+        import astroid._persistence
+
+        refmap = {}
+        data = astroid._persistence.dump(self, refmap)
+        return json.dumps(dict(refmap=refmap, data=data))
+
+    @classmethod
+    def load(cls, data):
+        import astroid._persistence
+
+        return astroid._persistence.load(**json.loads(data))
 
 
 class ComprehensionScope(LocalsDictNodeNG):
@@ -1393,7 +1441,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
     _other_fields = ("name", "doc")
     _other_other_fields = (
         "locals",
-        "_type",
+        # "_type",
         "type_comment_returns",
         "type_comment_args",
     )
@@ -1839,6 +1887,15 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                 return self, [frame]
         return super().scope_lookup(node, name, offset)
 
+    def __dump__(self, dumper):
+        data = super().__dump__(dumper)
+        data["instance_attrs"] = dumper(self.instance_attrs)
+        return data
+
+    def __load__(self, data, loader):
+        super().__load__(data, loader)
+        self.instance_attrs = loader(data["instance_attrs"])
+
 
 class AsyncFunctionDef(FunctionDef):
     """Class representing an :class:`ast.FunctionDef` node.
@@ -2054,6 +2111,14 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         :type name: str or None
         """
 
+        if not isinstance(doc, (str, type(None))):
+            # This can happen for C-implemented types, like `wrapper_descriptor`
+            # `type(str.__dict__['__add__'])` is a `wrapper_descriptor`
+            # `__doc__` on that object is a `getset_descriptor`, I assume
+            # because `wrapper_descriptor` has no doc.
+            # https://github.com/python/cpython/blob/f25f2e2e8c8e48490d22b0cdf67f575608701f6f/Objects/descrobject.c#L865
+            doc = None
+
         self.doc = doc
         """The class' docstring.
 
@@ -2105,8 +2170,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         :param keywords: The keywords given to the class definition.
         :type keywords: list(Keyword) or None
         """
-        if keywords is not None:
-            self.keywords = keywords
+        self.keywords = keywords
         self.bases = bases
         self.body = body
         self.decorators = decorators
@@ -3054,3 +3118,16 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             child_node._get_assign_nodes() for child_node in self.body
         )
         return list(itertools.chain.from_iterable(children_assign_nodes))
+
+    def __dump__(self, dumper):
+        data = super().__dump__(dumper)
+        data["instance_attrs"] = dumper(self.instance_attrs)
+        data["metaclass"] = dumper(self._metaclass)
+        return data
+
+    def __load__(self, data, loader):
+        newstyle = data.pop("_newstyle")
+        super().__load__(data, loader)
+        self.instance_attrs = loader(data["instance_attrs"])
+        self._metaclass = loader(data["metaclass"])
+        self._newstyle = newstyle

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -389,7 +389,7 @@ class Module(LocalsDictNodeNG):
     """The line that this node appears on in the source code.
 
     :type: int or None"
-    """"
+    """
 
     # attributes below are set by the builder module or by raw factories
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -306,6 +306,8 @@ node_classes.Dict.__bases__ = (node_classes.NodeNG, DictInstance)
 class Property(scoped_nodes.FunctionDef):
     """Class representing a Python property"""
 
+    _other_fields = scoped_nodes.FunctionDef._other_fields + ("function",)
+
     def __init__(
         self, function, name=None, doc=None, lineno=None, col_offset=None, parent=None
     ):

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -973,11 +973,10 @@ class TreeRebuilder:
 
     def visit_annassign(self, node: "ast.AnnAssign", parent: NodeNG) -> nodes.AnnAssign:
         """visit an AnnAssign node by returning a fresh instance of it"""
-        newnode = nodes.AnnAssign(node.lineno, node.col_offset, parent)
+        newnode = nodes.AnnAssign(node.lineno, node.col_offset, parent, simple=node.simple)
         newnode.postinit(
             target=self.visit(node.target, newnode),
             annotation=self.visit(node.annotation, newnode),
-            simple=node.simple,
             value=self.visit(node.value, newnode),
         )
         return newnode
@@ -1112,12 +1111,11 @@ class TreeRebuilder:
         self, node: "ast.comprehension", parent: NodeNG
     ) -> nodes.Comprehension:
         """visit a Comprehension node by returning a fresh instance of it"""
-        newnode = nodes.Comprehension(parent)
+        newnode = nodes.Comprehension(parent, is_async=bool(node.is_async))
         newnode.postinit(
             self.visit(node.target, newnode),
             self.visit(node.iter, newnode),
             [self.visit(child, newnode) for child in node.ifs],
-            bool(node.is_async),
         )
         return newnode
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1788,11 +1788,15 @@ class TreeRebuilder:
         def visit_matchclass(
             self, node: "ast.MatchClass", parent: NodeNG
         ) -> nodes.MatchClass:
-            newnode = nodes.MatchClass(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchClass(
+                node.lineno,
+                node.col_offset,
+                parent,
+                kwd_attrs=node.kwd_attrs,
+            )
             newnode.postinit(
                 cls=self.visit(node.cls, newnode),
                 patterns=[self.visit(pattern, newnode) for pattern in node.patterns],
-                kwd_attrs=node.kwd_attrs,
                 kwd_patterns=[
                     self.visit(pattern, newnode) for pattern in node.kwd_patterns
                 ],

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -973,7 +973,9 @@ class TreeRebuilder:
 
     def visit_annassign(self, node: "ast.AnnAssign", parent: NodeNG) -> nodes.AnnAssign:
         """visit an AnnAssign node by returning a fresh instance of it"""
-        newnode = nodes.AnnAssign(node.lineno, node.col_offset, parent, simple=node.simple)
+        newnode = nodes.AnnAssign(
+            node.lineno, node.col_offset, parent, simple=node.simple
+        )
         newnode.postinit(
             target=self.visit(node.target, newnode),
             annotation=self.visit(node.annotation, newnode),

--- a/tests/unittest_decorators.py
+++ b/tests/unittest_decorators.py
@@ -13,10 +13,14 @@ class SomeClass:
     def func(self, name=None, var=None, type_annotation=None):
         ...
 
+
 class SomeOtherClass:
-    @astroid.decorators.deprecate_arguments("foo", "bar", hint="pass to `func2` instead")
+    @astroid.decorators.deprecate_arguments(
+        "foo", "bar", hint="pass to `func2` instead"
+    )
     def func(self, foo=None, bar=None, baz=None):
         ...
+
 
 class TestDeprecationDecorators:
     @staticmethod

--- a/tests/unittest_decorators.py
+++ b/tests/unittest_decorators.py
@@ -16,9 +16,9 @@ class SomeClass:
 
 class SomeOtherClass:
     @astroid.decorators.deprecate_arguments(
-        "foo", "bar", hint="pass to `func2` instead"
+        "arg1", "arg2", hint="pass to `func2` instead"
     )
-    def func(self, foo=None, bar=None, baz=None):
+    def func(self, arg1=None, arg2=None, arg3=None):
         ...
 
 
@@ -111,29 +111,29 @@ class TestDeprecationDecorators:
         with pytest.warns(DeprecationWarning) as records:
             SomeOtherClass().func(1, 2, 3)
             assert len(records) == 2
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
-            assert "bar" in records[1].message.args[0]
+            assert "arg2" in records[1].message.args[0]
             assert "'SomeOtherClass.func'" in records[1].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
             SomeOtherClass().func(1, 2)
             assert len(records) == 2
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
-            assert "bar" in records[1].message.args[0]
+            assert "arg2" in records[1].message.args[0]
             assert "'SomeOtherClass.func'" in records[1].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
             SomeOtherClass().func(1)
             assert len(records) == 1
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
             SomeOtherClass().func(1, baz=3)
             assert len(records) == 1
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(None) as records:
@@ -143,37 +143,37 @@ class TestDeprecationDecorators:
     @staticmethod
     def test_deprecated_argument_pass_by_name() -> None:
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(foo=1, bar=2, baz=3)
+            SomeOtherClass().func(arg1=1, arg2=2, baz=3)
             assert len(records) == 2
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
-            assert "bar" in records[1].message.args[0]
+            assert "arg2" in records[1].message.args[0]
             assert "'SomeOtherClass.func'" in records[1].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(foo=1, bar=2)
+            SomeOtherClass().func(arg1=1, arg2=2)
             assert len(records) == 2
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
-            assert "bar" in records[1].message.args[0]
+            assert "arg2" in records[1].message.args[0]
             assert "'SomeOtherClass.func'" in records[1].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(foo=1)
+            SomeOtherClass().func(arg1=1)
             assert len(records) == 1
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(bar=1)
+            SomeOtherClass().func(arg2=1)
             assert len(records) == 1
-            assert "bar" in records[0].message.args[0]
+            assert "arg2" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
             SomeOtherClass().func(1, baz=3)
             assert len(records) == 1
-            assert "foo" in records[0].message.args[0]
+            assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(None) as records:

--- a/tests/unittest_decorators.py
+++ b/tests/unittest_decorators.py
@@ -131,19 +131,19 @@ class TestDeprecationDecorators:
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(1, baz=3)
+            SomeOtherClass().func(1, arg3=3)
             assert len(records) == 1
             assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(None) as records:
-            SomeOtherClass().func(baz=3)
+            SomeOtherClass().func(arg3=3)
             assert len(records) == 0
 
     @staticmethod
     def test_deprecated_argument_pass_by_name() -> None:
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(arg1=1, arg2=2, baz=3)
+            SomeOtherClass().func(arg1=1, arg2=2, arg3=3)
             assert len(records) == 2
             assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
@@ -171,11 +171,11 @@ class TestDeprecationDecorators:
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(DeprecationWarning) as records:
-            SomeOtherClass().func(1, baz=3)
+            SomeOtherClass().func(1, arg3=3)
             assert len(records) == 1
             assert "arg1" in records[0].message.args[0]
             assert "'SomeOtherClass.func'" in records[0].message.args[0]
 
         with pytest.warns(None) as records:
-            SomeOtherClass().func(baz=3)
+            SomeOtherClass().func(arg3=3)
             assert len(records) == 0

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -52,6 +52,7 @@ from astroid import (
 )
 from astroid.const import PY38_PLUS, PY310_PLUS, Context
 from astroid.context import InferenceContext
+from astroid.decorators import deprecate_arguments
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -1711,19 +1712,41 @@ class TestPatternMatching:
         node_class for node_class in nodes.ALL_NODE_CLASSES
         if isinstance(node_class, type) and issubclass(node_class, nodes.NodeNG) and node_class is not nodes.EvaluatedObject
     ])
-def test_fields_declaration(node_class):
-    expected_init_fields = set(node_class._other_fields)
-    expected_postinit_fields = node_class._astroid_fields + node_class._other_other_fields
-    args = set(inspect.signature(node_class.__init__).parameters.keys())
-    args -= {"self"}
+def test_init_fields_declaration(node_class):
+    expected_args = set(node_class._other_fields)
+    actual_args = set(inspect.signature(node_class.__init__).parameters.keys())
+    actual_args -= {"self"}
 
     if node_class not in {nodes.Module, nodes.EvaluatedObject}:
-        expected_init_fields |= {"lineno", "col_offset"}
+        expected_args |= {"lineno", "col_offset"}
 
-    assert "parent" not in expected_init_fields
-    expected_init_fields |= {"parent"}
+    assert "parent" not in expected_args
+    expected_args |= {"parent"}
 
-    assert args == expected_init_fields
+    assert actual_args == expected_args
+
+@pytest.mark.parametrize(
+    "node_class", [
+        node_class for node_class in nodes.ALL_NODE_CLASSES
+        if isinstance(node_class, type) and issubclass(node_class, nodes.NodeNG) and node_class is not nodes.EvaluatedObject
+    ])
+def test_postinit_fields_declaration(node_class):
+    expected_args = set(node_class._astroid_fields + node_class._other_other_fields)
+
+    if not expected_args:
+        assert not hasattr(node_class, "postinit")
+        return
+
+    expected_args = {arg.lstrip("_") for arg in expected_args}
+    actual_args = set(inspect.signature(node_class.postinit).parameters.keys())
+    deprecated_args = getattr(node_class.postinit, "deprecated_args", [])
+    actual_args -= {"self", *deprecated_args}
+    if issubclass(node_class, nodes.LocalsDictNodeNG):
+        expected_args -= {"locals"}
+    if node_class is nodes.Module:
+        expected_args -= {"globals"}
+
+    assert actual_args == expected_args
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1740,7 +1740,7 @@ def test_init_fields_declaration(node_class):
         and node_class is not nodes.EvaluatedObject
     ],
 )
-def test_postinit_fields_declaration(node_class):
+def test_postinit_fields_declaration(node_class: nodes.NodeNG) -> None:
     expected_args = set(node_class._astroid_fields + node_class._other_other_fields)
 
     if not expected_args:

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -52,13 +52,11 @@ from astroid import (
 )
 from astroid.const import PY38_PLUS, PY310_PLUS, Context
 from astroid.context import InferenceContext
-from astroid.decorators import deprecate_arguments
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
     AttributeInferenceError,
 )
-from astroid.nodes import node_classes
 from astroid.nodes.node_classes import (
     AssignAttr,
     AssignName,
@@ -1707,11 +1705,17 @@ class TestPatternMatching:
             *case1.pattern.kwd_patterns,
         ]
 
+
 @pytest.mark.parametrize(
-    "node_class", [
-        node_class for node_class in nodes.ALL_NODE_CLASSES
-        if isinstance(node_class, type) and issubclass(node_class, nodes.NodeNG) and node_class is not nodes.EvaluatedObject
-    ])
+    "node_class",
+    [
+        node_class
+        for node_class in nodes.ALL_NODE_CLASSES
+        if isinstance(node_class, type)
+        and issubclass(node_class, nodes.NodeNG)
+        and node_class is not nodes.EvaluatedObject
+    ],
+)
 def test_init_fields_declaration(node_class):
     expected_args = set(node_class._other_fields)
     actual_args = set(inspect.signature(node_class.__init__).parameters.keys())
@@ -1725,11 +1729,17 @@ def test_init_fields_declaration(node_class):
 
     assert actual_args == expected_args
 
+
 @pytest.mark.parametrize(
-    "node_class", [
-        node_class for node_class in nodes.ALL_NODE_CLASSES
-        if isinstance(node_class, type) and issubclass(node_class, nodes.NodeNG) and node_class is not nodes.EvaluatedObject
-    ])
+    "node_class",
+    [
+        node_class
+        for node_class in nodes.ALL_NODE_CLASSES
+        if isinstance(node_class, type)
+        and issubclass(node_class, nodes.NodeNG)
+        and node_class is not nodes.EvaluatedObject
+    ],
+)
 def test_postinit_fields_declaration(node_class):
     expected_args = set(node_class._astroid_fields + node_class._other_other_fields)
 
@@ -1747,6 +1757,7 @@ def test_postinit_fields_declaration(node_class):
         expected_args -= {"globals"}
 
     assert actual_args == expected_args
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -1704,6 +1704,13 @@ class TestPatternMatching:
             *case1.pattern.kwd_patterns,
         ]
 
+@pytest.mark.parametrize(
+    "node_class", nodes.ALL_NODE_CLASSES
+)
+def test_fields_declaration(node_class):
+    if not isinstance(node_class, nodes.NodeNG):
+        pass
+    ...
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
It was discovered (and the fix is needed by) #1194 that there isn't strict cohesion between the `*_fields` attributes and the parameters in `__init__` and `postinit`, so I've added tests which enforces this.

Through testing a handful of violators have been found, so a deprecation warning decorator has been added, and parameters have been updated accordingly.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
