### PR TITLE
Improve filtering of ``NamedExpr``, particularly within ``If`` nodes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,12 @@ Release date: TBA
 
 * Added missing ``kind`` (for ``Const``) and ``conversion`` (for ``FormattedValue``) fields to repr.
 
+* Fix crash with assignment expressions, nested if expressions and filtering of statements
+
+  Closes PyCQA/pylint#5178
+
+* Fix incorrect filtering of assignment expressions statements
+
 
 What's New in astroid 2.8.4?
 ============================

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4828,7 +4828,7 @@ def is_from_decorator(node):
 
 
 def _get_if_statement_ancestor(node: NodeNG) -> Optional[If]:
-    """Return True if the given node is the child of a If node"""
+    """Return the first parent node that is an If node (or None)"""
     for parent in node.node_ancestors():
         if isinstance(parent, If):
             return parent

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4224,7 +4224,7 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
 
     optional_assign = True
     """Whether this node optionally assigns a variable.
-    
+
     Since NamedExpr are not always called they do not always assign."""
 
     def __init__(

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -22,8 +22,11 @@ import sys
 import textwrap
 import unittest
 
+import pytest
+
 from astroid import MANAGER, Instance, nodes, test_utils
 from astroid.builder import AstroidBuilder, extract_node
+from astroid.const import PY38_PLUS
 from astroid.exceptions import InferenceError
 from astroid.raw_building import build_module
 
@@ -156,6 +159,7 @@ def test():
         base = next(result._proxied.bases[0].infer())
         self.assertEqual(base.name, "int")
 
+    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_filter_stmts_nested_if(self) -> None:
         builder = AstroidBuilder()
         data = """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

The crash discussed in the issue was (I think) the result of the original code only doing `_stmts = [node]` without changing `_stmt_parents`.

I did this, but while working on this I also found a number of other issues related to if-statements and assignment expressions. To fix this I have added the `If.is_orelse` attribute and added some basic control flow checks. This should improve the inference of these nodes overall.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

PyCQA/pylint#5178
