### PR TITLE
Fix crash on inference of ``__len__``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.8.5?
 ============================
 Release date: TBA
 
+* Fix crash on inference of ``__len__``
+
+  Closes PyCQA/pylint#5244
+
 * Added missing ``kind`` (for ``Const``) and ``conversion`` (for ``FormattedValue``) fields to repr.
 
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ What's New in astroid 2.8.5?
 ============================
 Release date: TBA
 
-* Fix crash on inference of ``__len__``
+* Fix crash on inference of ``__len__``.
 
   Closes PyCQA/pylint#5244
 

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -258,7 +258,8 @@ def object_len(node, context=None):
     if (
         isinstance(node_frame, scoped_nodes.FunctionDef)
         and node_frame.name == "__len__"
-        and inferred_node is not None
+        and hasattr(inferred_node, "_proxied")
+        and inferred_node._proxied == node_frame.parent
     ):
         message = (
             "Self referential __len__ function will "

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -259,7 +259,6 @@ def object_len(node, context=None):
         isinstance(node_frame, scoped_nodes.FunctionDef)
         and node_frame.name == "__len__"
         and inferred_node is not None
-        and inferred_node._proxied == node_frame.parent
     ):
         message = (
             "Self referential __len__ function will "

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3113,7 +3113,7 @@ def test_no_recursionerror_on_self_referential_length_check() -> None:
     """
     Regression test for https://github.com/PyCQA/astroid/issues/777
 
-    This inference should only raise an InferenceError and no RecursionError
+    This test should only raise an InferenceError and no RecursionError.
     """
     with pytest.raises(InferenceError):
         node = astroid.extract_node(
@@ -3133,7 +3133,7 @@ def test_inference_on_outer_referential_length_check() -> None:
     Regression test for https://github.com/PyCQA/pylint/issues/5244
     See also https://github.com/PyCQA/astroid/pull/1234
 
-    This inference should succeed without any error
+    This test should succeed without any error.
     """
     node = astroid.extract_node(
         """
@@ -3160,7 +3160,7 @@ def test_no_attributeerror_on_self_referential_length_check() -> None:
     Regression test for https://github.com/PyCQA/pylint/issues/5244
     See also https://github.com/PyCQA/astroid/pull/1234
 
-    This inference should only raise an InferenceError and no AttributeError
+    This test should only raise an InferenceError and no AttributeError.
     """
     with pytest.raises(InferenceError):
         node = astroid.extract_node(

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3112,6 +3112,8 @@ def test_str_and_bytes(code, expected_class, expected_value):
 def test_no_recursionerror_on_self_referential_length_check() -> None:
     """
     Regression test for https://github.com/PyCQA/astroid/issues/777
+
+    This inference should only raise an InferenceError and no RecursionError
     """
     with pytest.raises(InferenceError):
         node = astroid.extract_node(
@@ -3129,6 +3131,9 @@ def test_no_recursionerror_on_self_referential_length_check() -> None:
 def test_inference_on_outer_referential_length_check() -> None:
     """
     Regression test for https://github.com/PyCQA/pylint/issues/5244
+    See also https://github.com/PyCQA/astroid/pull/1234
+
+    This inference should succeed without any error
     """
     node = astroid.extract_node(
         """
@@ -3153,6 +3158,9 @@ def test_inference_on_outer_referential_length_check() -> None:
 def test_no_attributeerror_on_self_referential_length_check() -> None:
     """
     Regression test for https://github.com/PyCQA/pylint/issues/5244
+    See also https://github.com/PyCQA/astroid/pull/1234
+
+    This inference should only raise an InferenceError and no AttributeError
     """
     with pytest.raises(InferenceError):
         node = astroid.extract_node(

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3126,5 +3126,50 @@ def test_no_recursionerror_on_self_referential_length_check() -> None:
         node.inferred()
 
 
+def test_no_inference_on_outer_referential_length_check() -> None:
+    """
+    Regression test for https://github.com/PyCQA/pylint/issues/5244
+    """
+    node = astroid.extract_node(
+        """
+    class A:
+        def __len__(self) -> int:
+            return 42
+
+    class Crash:
+        def __len__(self) -> int:
+            a = A()
+            return len(a)
+
+    len(Crash()) #@
+    """
+    )
+    inferred = node.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 42
+
+
+def test_no_attributeerror_on_self_referential_length_check() -> None:
+    """
+    Regression test for https://github.com/PyCQA/pylint/issues/5244
+    """
+    with pytest.raises(InferenceError):
+        node = astroid.extract_node(
+            """
+        class MyClass:
+            def some_func(self):
+                return lambda: 42
+
+            def __len__(self):
+                return len(self.some_func())
+
+        len(MyClass()) #@
+        """
+        )
+        assert isinstance(node, nodes.NodeNG)
+        node.inferred()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3126,7 +3126,7 @@ def test_no_recursionerror_on_self_referential_length_check() -> None:
         node.inferred()
 
 
-def test_no_inference_on_outer_referential_length_check() -> None:
+def test_inference_on_outer_referential_length_check() -> None:
     """
     Regression test for https://github.com/PyCQA/pylint/issues/5244
     """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This is a weird one.

I found this while working on the primer tests for `pylint` where running on the codebase of `numpy` created a crash. I issued https://github.com/PyCQA/pylint/issues/5244 for this. Initially I thought it had something to do with the brain for `numpy` as the crash only occurred when the directory name starts with `numpy`.
However, removing this single line seems to fix the issue. Furthermore, (locally) all tests for `astroid` and `pylint` pass with this change. I have looked at the commit that added this line (https://github.com/PyCQA/astroid/commit/25384d4bebf0187b6704c818c7df64945793362c) but did not immediately understand why this was added. In any case, no tests seems to have been added or this line is redundant and the removing it is the way forward.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Would close https://github.com/PyCQA/pylint/issues/5244