### PR TITLE
Add flake8 typing import to the pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,8 +46,8 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-bugbear]
-        exclude: tests/testdata|doc/conf.py|astroid/__init__.py|setup.py
+        additional_dependencies: [flake8-bugbear, flake8-typing-imports==1.11.0]
+        exclude: tests/testdata|doc/conf.py|astroid/__init__.py
   - repo: local
     hooks:
       - id: pylint

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -2,4 +2,5 @@ black==21.7b0
 pylint==2.11.1
 isort==5.9.2
 flake8==4.0.1
+flake8-typing-imports==1.11.0
 mypy==0.910

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     setuptools>=20.0
     typed-ast>=1.4.0,<2.0;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.10;python_version<"3.10"
-python_requires = ~=3.6
+python_requires = >= 3.6.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
## Description

Add a typing check to pre-commit, also apply flake8 to more files.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Related Issue

Should have helped for #1239, but did not.