### PR TITLE
Add common caching class and global cache flushing function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -234,16 +234,6 @@ Release date: 2021-11-21
 
   Closes #1239
 
-* Resolve symlinks in the import path
-  Fixes inference error when the import path includes symlinks (e.g. Python
-  installed on macOS via Homebrew).
-
-  Closes #823
-  Closes PyCQA/pylint#3499
-  Closes PyCQA/pylint#4302
-  Closes PyCQA/pylint#4798
-  Closes PyCQA/pylint#5081
-
 
 What's New in astroid 2.8.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ What's New in astroid 2.11.3?
 =============================
 Release date: TBA
 
+* Add a common caching mechanism (`astroid.cache.LRUCache`) and a global
+  cache flushing function (``astroid.cache.clear_caches()``).
 
 
 What's New in astroid 2.11.2?
@@ -231,6 +233,16 @@ Release date: 2021-11-21
 * Fix bug with Python 3.7.0 / 3.7.1 and ``typing.NoReturn``.
 
   Closes #1239
+
+* Resolve symlinks in the import path
+  Fixes inference error when the import path includes symlinks (e.g. Python
+  installed on macOS via Homebrew).
+
+  Closes #823
+  Closes PyCQA/pylint#3499
+  Closes PyCQA/pylint#4302
+  Closes PyCQA/pylint#4798
+  Closes PyCQA/pylint#5081
 
 
 What's New in astroid 2.8.5?

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -80,7 +80,7 @@ from astroid.exceptions import (
     UnresolvableName,
     UseInferenceDefault,
 )
-from astroid.inference_tip import _inference_tip_cached, inference_tip
+from astroid.inference_tip import inference_tip
 from astroid.objects import ExceptionInstance
 
 # isort: off

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -47,7 +47,7 @@ class LRUCache:
             cache.clear()
 
 
-def lru_cache(arg=None):
+def lru_cache_astroid(arg=None):
     """A decorator to cache the results of a function. Similar to
     functools.lru_cache but uses astroid.cache.LRUCache as its internal cache.
     """

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -1,0 +1,50 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
+import functools
+
+import wrapt
+
+LRU_CACHES = set()
+GENERATOR_CACHES = {}
+INFERENCE_CACHE = {}
+
+
+@wrapt.decorator
+def cached_generator(func, instance, args, kwargs):
+    node = args[0]
+    try:
+        result = GENERATOR_CACHES[func, node]
+    except KeyError:
+        result = GENERATOR_CACHES[func, node] = list(func(*args, **kwargs))
+    return iter(result)
+
+
+def lru_cache(maxsize=128, typed=False):
+    if maxsize is None:
+        maxsize = 128
+
+    def decorator(f):
+        cached_func = functools.lru_cache(maxsize, typed)(f)
+
+        LRU_CACHES.add(cached_func)
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            return cached_func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def clear_inference_cache():
+    INFERENCE_CACHE.clear()
+
+
+def clear_caches():
+    for c in LRU_CACHES:
+        c.cache_clear()
+
+    GENERATOR_CACHES.clear()
+    INFERENCE_CACHE.clear()

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -19,7 +19,7 @@ V = typing.TypeVar("V")
 class LRUCache(typing.Generic[K, V]):
     """An LRU cache that keeps track of its instances."""
 
-    instances: WeakSet["LRUCache[typing.Any, typing.Any]"] = WeakSet()
+    instances: "WeakSet[LRUCache[typing.Any, typing.Any]]" = WeakSet()
 
     def __init__(self) -> None:
         self.cache: typing.OrderedDict[K, V] = OrderedDict()

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -83,37 +83,6 @@ def lru_cache_astroid(arg: typing.Optional[F] = None) -> F:
     return typing.cast(F, decorator)
 
 
-_GENERATOR_CACHE: LRUCache[typing.Any, typing.Any] = LRUCache()
-
-
-def cached_generator(arg: typing.Optional[F] = None) -> F:
-    """A decorator to cache the elements returned by a generator. The input
-    generator is consumed and cached as a list.
-    """
-
-    @wrapt.decorator  # type: ignore[misc] # wrapt.decorator is untyped
-    def decorator(
-        func: F,
-        instance: typing.Any,
-        args: typing.Tuple[typing.Any, ...],
-        kwargs: typing.Dict[str, typing.Any],
-    ) -> typing.Any:
-        key = func, args[0]
-
-        if key in _GENERATOR_CACHE:
-            result = _GENERATOR_CACHE[key]
-        else:
-            result = _GENERATOR_CACHE[key] = list(func(*args, **kwargs))
-
-        return iter(result)
-
-    if callable(arg):
-        # pylint: disable=no-value-for-parameter
-        return typing.cast(F, decorator(arg))
-
-    return typing.cast(F, decorator)
-
-
 def clear_caches() -> None:
     """Clears all caches."""
     LRUCache.clear_all()

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -57,17 +57,17 @@ def lru_cache_astroid(arg: typing.Optional[F] = None) -> F:
     """
     cache: LRUCache[typing.Tuple[typing.Any, ...], typing.Any] = LRUCache()
 
-    @wrapt.decorator
+    @wrapt.decorator  # type: ignore[misc] # wrapt.decorator is untyped
     def decorator(
         func: F,
         instance: typing.Any,
         args: typing.Tuple[typing.Any, ...],
-        kwargs: typing.Dict[typing.Any, typing.Any],
+        kwargs: typing.Dict[str, typing.Any],
     ) -> typing.Any:
         key: typing.Tuple[typing.Any, ...] = (instance,) + args
 
         for kv in kwargs:
-            key += kv
+            key += typing.cast(typing.Any, kv)
 
         if key in cache:
             result = cache[key]
@@ -91,12 +91,12 @@ def cached_generator(arg: typing.Optional[F] = None) -> F:
     generator is consumed and cached as a list.
     """
 
-    @wrapt.decorator
+    @wrapt.decorator  # type: ignore[misc] # wrapt.decorator is untyped
     def decorator(
         func: F,
         instance: typing.Any,
         args: typing.Tuple[typing.Any, ...],
-        kwargs: typing.Dict[typing.Any, typing.Any],
+        kwargs: typing.Dict[str, typing.Any],
     ) -> typing.Any:
         key = func, args[0]
 

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -68,6 +68,7 @@ def lru_cache(arg=None):
         return result
 
     if callable(arg):
+        # pylint: disable=no-value-for-parameter
         return decorator(arg)
 
     return decorator
@@ -93,6 +94,7 @@ def cached_generator(arg=None):
         return iter(result)
 
     if callable(arg):
+        # pylint: disable=no-value-for-parameter
         return decorator(arg)
 
     return decorator

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -4,7 +4,7 @@
 
 """ Caching utilities used in various places."""
 
-
+import typing
 from collections import OrderedDict
 from weakref import WeakSet
 
@@ -12,36 +12,39 @@ import wrapt
 
 LRU_CACHE_CAPACITY = 128
 
+K = typing.TypeVar("K")
+V = typing.TypeVar("V")
 
-class LRUCache:
+
+class LRUCache(typing.Generic[K, V]):
     """An LRU cache that keeps track of its instances."""
 
-    instances = WeakSet()
+    instances: WeakSet["LRUCache[typing.Any, typing.Any]"] = WeakSet()
 
-    def __init__(self):
-        self.cache = OrderedDict()
+    def __init__(self) -> None:
+        self.cache: typing.OrderedDict[K, V] = OrderedDict()
         LRUCache.instances.add(self)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: K, value: V) -> None:
         self.cache[key] = value
 
         if len(self.cache) > LRU_CACHE_CAPACITY:
             self.cache.popitem(last=False)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: K) -> V:
         if key in self.cache:
             self.cache.move_to_end(key)
 
         return self.cache[key]
 
-    def __contains__(self, key):
+    def __contains__(self, key: K) -> bool:
         return key in self.cache
 
-    def clear(self):
+    def clear(self) -> None:
         self.cache.clear()
 
     @classmethod
-    def clear_all(cls):
+    def clear_all(cls) -> None:
         """Clears all LRUCache instances."""
         for cache in cls.instances:
             cache.clear()
@@ -100,6 +103,6 @@ def cached_generator(arg=None):
     return decorator
 
 
-def clear_caches():
+def clear_caches() -> None:
     """Clears all caches."""
     LRUCache.clear_all()

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -50,15 +50,23 @@ class LRUCache(typing.Generic[K, V]):
             cache.clear()
 
 
-def lru_cache_astroid(arg=None):
+F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
+
+
+def lru_cache_astroid(arg: typing.Optional[F] = None) -> F:
     """A decorator to cache the results of a function. Similar to
     functools.lru_cache but uses astroid.cache.LRUCache as its internal cache.
     """
-    cache = LRUCache()
+    cache: LRUCache[typing.Tuple[typing.Any, ...], typing.Any] = LRUCache()
 
     @wrapt.decorator
-    def decorator(func, instance, args, kwargs):
-        key = (instance,) + args
+    def decorator(
+        func: F,
+        instance: typing.Any,
+        args: typing.Tuple[typing.Any, ...],
+        kwargs: typing.Dict[typing.Any, typing.Any],
+    ) -> typing.Any:
+        key: typing.Tuple[typing.Any, ...] = (instance,) + args
 
         for kv in kwargs:
             key += kv
@@ -72,21 +80,26 @@ def lru_cache_astroid(arg=None):
 
     if callable(arg):
         # pylint: disable=no-value-for-parameter
-        return decorator(arg)
+        return typing.cast(F, decorator(arg))
 
-    return decorator
-
-
-_GENERATOR_CACHE = LRUCache()
+    return typing.cast(F, decorator)
 
 
-def cached_generator(arg=None):
+_GENERATOR_CACHE: LRUCache[typing.Any, typing.Any] = LRUCache()
+
+
+def cached_generator(arg: typing.Optional[F] = None) -> F:
     """A decorator to cache the elements returned by a generator. The input
     generator is consumed and cached as a list.
     """
 
     @wrapt.decorator
-    def decorator(func, instance, args, kwargs):
+    def decorator(
+        func: F,
+        instance: typing.Any,
+        args: typing.Tuple[typing.Any, ...],
+        kwargs: typing.Dict[typing.Any, typing.Any],
+    ) -> typing.Any:
         key = func, args[0]
 
         if key in _GENERATOR_CACHE:
@@ -98,9 +111,9 @@ def cached_generator(arg=None):
 
     if callable(arg):
         # pylint: disable=no-value-for-parameter
-        return decorator(arg)
+        return typing.cast(F, decorator(arg))
 
-    return decorator
+    return typing.cast(F, decorator)
 
 
 def clear_caches() -> None:

--- a/astroid/cache.py
+++ b/astroid/cache.py
@@ -14,6 +14,7 @@ LRU_CACHE_CAPACITY = 128
 
 K = typing.TypeVar("K")
 V = typing.TypeVar("V")
+F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
 
 
 class LRUCache(typing.Generic[K, V]):
@@ -48,9 +49,6 @@ class LRUCache(typing.Generic[K, V]):
         """Clears all LRUCache instances."""
         for cache in cls.instances:
             cache.clear()
-
-
-F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
 
 
 def lru_cache_astroid(arg: typing.Optional[F] = None) -> F:

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -5,7 +5,7 @@
 """Various context related utilities, including inference and call contexts."""
 import contextlib
 import pprint
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 from astroid.cache import LRUCache
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -7,20 +7,17 @@ import contextlib
 import pprint
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
-from astroid.cache import INFERENCE_CACHE
+from astroid.cache import LRUCache
 
 if TYPE_CHECKING:
     from astroid.nodes.node_classes import Keyword, NodeNG
+
 
 _InferenceCache = Dict[
     Tuple["NodeNG", Optional[str], Optional[str], Optional[str]], Sequence["NodeNG"]
 ]
 
-_INFERENCE_CACHE: _InferenceCache = {}
-
-
-def _invalidate_cache() -> None:
-    _INFERENCE_CACHE.clear()
+_INFERENCE_CACHE = LRUCache()
 
 
 class InferenceContext:
@@ -108,7 +105,7 @@ class InferenceContext:
         Currently the key is ``(node, lookupname, callcontext, boundnode)``
         and the value is tuple of the inferred results
         """
-        return INFERENCE_CACHE
+        return _INFERENCE_CACHE
 
     def push(self, node):
         """Push node into inference path

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -7,6 +7,8 @@ import contextlib
 import pprint
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
+from astroid.cache import INFERENCE_CACHE
+
 if TYPE_CHECKING:
     from astroid.nodes.node_classes import Keyword, NodeNG
 
@@ -106,7 +108,7 @@ class InferenceContext:
         Currently the key is ``(node, lookupname, callcontext, boundnode)``
         and the value is tuple of the inferred results
         """
-        return _INFERENCE_CACHE
+        return INFERENCE_CACHE
 
     def push(self, node):
         """Push node into inference path

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -5,7 +5,7 @@
 """Various context related utilities, including inference and call contexts."""
 import contextlib
 import pprint
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, List, Optional
 
 from astroid.cache import LRUCache
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -85,7 +85,7 @@ def inference_tip(infer_function: InferFn, raise_on_overwrite: bool = False) -> 
             )
 
         # pylint: disable=no-value-for-parameter
-        node._explicit_inference = cached_generator(infer_function)
+        node._explicit_inference = cached_generator()(infer_function)
         return node
 
     return transform

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -9,6 +9,7 @@ import typing
 import wrapt
 
 from astroid import bases, util
+from astroid.cache import cached_generator
 from astroid.exceptions import InferenceOverwriteError, UseInferenceDefault
 from astroid.nodes import NodeNG
 from astroid.typing import InferFn
@@ -82,8 +83,9 @@ def inference_tip(infer_function: InferFn, raise_on_overwrite: bool = False) -> 
                     node=node,
                 )
             )
+
         # pylint: disable=no-value-for-parameter
-        node._explicit_inference = _inference_tip_cached(infer_function)
+        node._explicit_inference = cached_generator(infer_function)
         return node
 
     return transform

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -10,10 +10,9 @@ import importlib.util
 import os
 import sys
 import zipimport
-from functools import lru_cache
 from pathlib import Path
 
-from astroid.cache import lru_cache
+from astroid.cache import lru_cache_astroid
 from astroid.interpreter._import import util
 
 ModuleType = enum.Enum(
@@ -262,7 +261,7 @@ def _is_setuptools_namespace(location):
         return extend_path or declare_namespace
 
 
-@lru_cache
+@lru_cache_astroid
 def _cached_set_diff(left, right):
     result = set(left)
     result.difference_update(right)

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -262,7 +262,7 @@ def _is_setuptools_namespace(location):
         return extend_path or declare_namespace
 
 
-@lru_cache()
+@lru_cache
 def _cached_set_diff(left, right):
     result = set(left)
     result.difference_update(right)

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -13,7 +13,8 @@ import zipimport
 from functools import lru_cache
 from pathlib import Path
 
-from . import util
+from astroid.cache import lru_cache
+from astroid.interpreter._import import util
 
 ModuleType = enum.Enum(
     "ModuleType",

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -25,11 +25,11 @@ import itertools
 import os
 import pprint
 import types
-from functools import lru_cache
 from typing import TYPE_CHECKING, Optional
 
 import astroid
 from astroid import util
+from astroid.cache import lru_cache
 from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
@@ -100,7 +100,7 @@ class ObjectModel:
     def __contains__(self, name):
         return name in self.attributes()
 
-    @lru_cache(maxsize=None)
+    @lru_cache()
     def attributes(self):
         """Get the attributes which are exported by this object model."""
         return [

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -100,7 +100,7 @@ class ObjectModel:
     def __contains__(self, name):
         return name in self.attributes()
 
-    @lru_cache()
+    @lru_cache
     def attributes(self):
         """Get the attributes which are exported by this object model."""
         return [

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Optional
 
 import astroid
 from astroid import util
-from astroid.cache import lru_cache
+from astroid.cache import lru_cache_astroid
 from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
@@ -100,7 +100,7 @@ class ObjectModel:
     def __contains__(self, name):
         return name in self.attributes()
 
-    @lru_cache
+    @lru_cache_astroid
     def attributes(self):
         """Get the attributes which are exported by this object model."""
         return [

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -25,7 +25,7 @@ import types
 from pathlib import Path
 from typing import Set
 
-from astroid.cache import lru_cache
+from astroid.cache import lru_cache_astroid
 from astroid.const import IS_JYTHON, IS_PYPY
 from astroid.interpreter._import import spec, util
 
@@ -139,7 +139,7 @@ def _handle_blacklist(blacklist, dirnames, filenames):
             filenames.remove(norecurs)
 
 
-@lru_cache
+@lru_cache_astroid
 def _cache_normalize_path(path: str) -> str:
     """Normalize path with caching."""
     # _module_file calls abspath on every path in sys.path every time it's

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -9,7 +9,6 @@ import itertools
 import sys
 import typing
 import warnings
-from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,7 +23,7 @@ from typing import (
 
 from astroid import decorators, mixins, util
 from astroid.bases import Instance, _infer_stmts
-from astroid.cache import lru_cache
+from astroid.cache import lru_cache_astroid
 from astroid.const import Context
 from astroid.context import InferenceContext
 from astroid.exceptions import (
@@ -367,7 +366,7 @@ class BaseContainer(
 class LookupMixIn:
     """Mixin to look up a name in the right scope."""
 
-    @lru_cache
+    @lru_cache_astroid
     def lookup(self, name):
         """Lookup where the given variable is assigned.
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -367,7 +367,7 @@ class BaseContainer(
 class LookupMixIn:
     """Mixin to look up a name in the right scope."""
 
-    @lru_cache()
+    @lru_cache
     def lookup(self, name):
         """Lookup where the given variable is assigned.
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -24,6 +24,7 @@ from typing import (
 
 from astroid import decorators, mixins, util
 from astroid.bases import Instance, _infer_stmts
+from astroid.cache import lru_cache
 from astroid.const import Context
 from astroid.context import InferenceContext
 from astroid.exceptions import (
@@ -366,7 +367,7 @@ class BaseContainer(
 class LookupMixIn:
     """Mixin to look up a name in the right scope."""
 
-    @lru_cache(maxsize=None)
+    @lru_cache()
     def lookup(self, name):
         """Lookup where the given variable is assigned.
 

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -4,7 +4,7 @@
 
 import collections
 
-from astroid.cache import clear_caches, lru_cache
+from astroid.cache import clear_caches, lru_cache_astroid
 
 
 class TransformVisitor:
@@ -19,7 +19,7 @@ class TransformVisitor:
     def __init__(self):
         self.transforms = collections.defaultdict(list)
 
-    @lru_cache
+    @lru_cache_astroid
     def _transform(self, node):
         """Call matching transforms for the given node if any and return the
         transformed node.

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -19,7 +19,7 @@ class TransformVisitor:
     def __init__(self):
         self.transforms = collections.defaultdict(list)
 
-    @lru_cache()
+    @lru_cache
     def _transform(self, node):
         """Call matching transforms for the given node if any and return the
         transformed node.

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -4,7 +4,7 @@
 
 import collections
 
-from astroid.cache import INFERENCE_CACHE, lru_cache
+from astroid.cache import clear_caches, lru_cache
 
 
 class TransformVisitor:
@@ -36,7 +36,7 @@ class TransformVisitor:
                 # if the transformation function returns something, it's
                 # expected to be a replacement for the node
                 if ret is not None:
-                    INFERENCE_CACHE.clear()
+                    clear_caches()
                     node = ret
                 if ret.__class__ != cls:
                     # Can no longer apply the rest of the transforms.

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -3,9 +3,8 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 import collections
-from functools import lru_cache
 
-from astroid.context import _invalidate_cache
+from astroid.cache import INFERENCE_CACHE, lru_cache
 
 
 class TransformVisitor:
@@ -17,12 +16,10 @@ class TransformVisitor:
     transforms for each encountered node.
     """
 
-    TRANSFORM_MAX_CACHE_SIZE = 10000
-
     def __init__(self):
         self.transforms = collections.defaultdict(list)
 
-    @lru_cache(maxsize=TRANSFORM_MAX_CACHE_SIZE)
+    @lru_cache()
     def _transform(self, node):
         """Call matching transforms for the given node if any and return the
         transformed node.
@@ -39,7 +36,7 @@ class TransformVisitor:
                 # if the transformation function returns something, it's
                 # expected to be a replacement for the node
                 if ret is not None:
-                    _invalidate_cache()
+                    INFERENCE_CACHE.clear()
                     node = ret
                 if ret.__class__ != cls:
                     # Can no longer apply the rest of the transforms.

--- a/tests/unittest_cache.py
+++ b/tests/unittest_cache.py
@@ -1,0 +1,93 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
+import pytest
+
+import astroid.cache
+from astroid.cache import LRUCache
+
+
+class TestLRUCache:
+    """
+    Test astroid.cache.LRUCache
+    """
+
+    def test_set_and_get(self):
+        """
+        Test __setitem__, __getitem__, and __contains__
+        """
+        cache = LRUCache()
+        cache["a"] = 123
+
+        assert cache["a"] == 123
+        assert "a" in cache
+        assert "b" not in cache
+
+    def test_clear(self):
+        """
+        Test LRUCache.clear()
+        """
+        cache = LRUCache()
+        cache["c"] = 789
+
+        assert "c" in cache
+
+        cache.clear()
+
+        assert "c" not in cache
+
+    @pytest.fixture
+    def reduce_cache_capacity(self):
+        """
+        A fixture to temporarily decrease the cache capactiy
+        """
+        astroid.cache.LRU_CACHE_CAPACITY = 3
+        yield
+        astroid.cache.LRU_CACHE_CAPACITY = 128
+
+    def test_eviction(self, reduce_cache_capacity):
+        """
+        Test cache eviction behavior
+        """
+        cache = LRUCache()
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["c"] = 3
+
+        assert "a" in cache
+        assert "b" in cache
+        assert "c" in cache
+
+        cache["d"] = 3
+
+        # "a" is evicted since it's the least recelty used item
+        assert "a" not in cache
+        assert "b" in cache
+        assert "c" in cache
+        assert "d" in cache
+
+        assert cache["b"] == 2
+        cache["e"] = 4
+        assert "b" in cache
+        # "c" is evicted since "b" was recently referenced
+        assert "c" not in cache
+        assert "d" in cache
+        assert "e" in cache
+
+    def test_clear_caches(self):
+        """
+        Test clear_caches() (global cache flush)
+        """
+        cache1 = LRUCache()
+        cache1["abc"] = 123
+
+        cache2 = LRUCache()
+        cache2["def"] = 456
+
+        assert "abc" in cache1
+        assert "def" in cache2
+
+        astroid.cache.clear_caches()
+
+        assert "abc" not in cache1
+        assert "def" not in cache2

--- a/tests/unittest_cache.py
+++ b/tests/unittest_cache.py
@@ -8,14 +8,10 @@ from astroid.cache import LRUCache
 
 
 class TestLRUCache:
-    """
-    Test astroid.cache.LRUCache
-    """
+    """Test astroid.cache.LRUCache"""
 
     def test_set_and_get(self):
-        """
-        Test __setitem__, __getitem__, and __contains__
-        """
+        """Test __setitem__, __getitem__, and __contains__"""
         cache = LRUCache()
         cache["a"] = 123
 
@@ -24,9 +20,7 @@ class TestLRUCache:
         assert "b" not in cache
 
     def test_clear(self):
-        """
-        Test LRUCache.clear()
-        """
+        """Test LRUCache.clear()"""
         cache = LRUCache()
         cache["c"] = 789
 
@@ -38,17 +32,13 @@ class TestLRUCache:
 
     @pytest.fixture
     def reduce_cache_capacity(self):
-        """
-        A fixture to temporarily decrease the cache capactiy
-        """
+        """A fixture to temporarily decrease the cache capactiy"""
         astroid.cache.LRU_CACHE_CAPACITY = 3
         yield
         astroid.cache.LRU_CACHE_CAPACITY = 128
 
     def test_eviction(self, reduce_cache_capacity):
-        """
-        Test cache eviction behavior
-        """
+        """Test cache eviction behaviour"""
         cache = LRUCache()
         cache["a"] = 1
         cache["b"] = 2
@@ -60,7 +50,7 @@ class TestLRUCache:
 
         cache["d"] = 3
 
-        # "a" is evicted since it's the least recelty used item
+        # "a" is evicted since it's the least recenlty used item
         assert "a" not in cache
         assert "b" in cache
         assert "c" in cache
@@ -75,9 +65,7 @@ class TestLRUCache:
         assert "e" in cache
 
     def test_clear_caches(self):
-        """
-        Test clear_caches() (global cache flush)
-        """
+        """Test clear_caches() (global cache flush)"""
         cache1 = LRUCache()
         cache1["abc"] = 123
 


### PR DESCRIPTION
## Description

This PR adds an LRU cache class `astroid.cache.LRUCache` and modifies the inference cache, inference tip cache, generator cache and `@lru_cache` to use this new cache. `LRUCache` is bounded by default and can also be manually flushed by calling `astroid.cache.clear_caches()` to address the memory leak issue discussed in #792.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

Closes #792
