### PR TITLE
Use ``functools.cached_property`` instead of ``cachedproperty``

### DIFF
--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -70,6 +70,12 @@ class cachedproperty:
     __slots__ = ("wrapped",)
 
     def __init__(self, wrapped):
+        warnings.warn(
+            "astroid.decorators.cachedproperty will be deprecated in astroid 3.0.0. "
+            "functools.cached_property offers similar behaviour and is supported by mypy and "
+            "other projects.",
+            DeprecationWarning,
+        )
         try:
             wrapped.__name__
         except AttributeError as exc:

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -16,6 +16,7 @@
 """This module contains some mixins for the different nodes.
 """
 import itertools
+from functools import cached_property
 
 from astroid import decorators
 from astroid.exceptions import AttributeInferenceError
@@ -24,7 +25,7 @@ from astroid.exceptions import AttributeInferenceError
 class BlockRangeMixIn:
     """override block range"""
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         return self.lineno
 
@@ -127,7 +128,7 @@ class MultiLineBlockMixin:
     Assign nodes, etc.
     """
 
-    @decorators.cachedproperty
+    @cached_property
     def _multi_line_blocks(self):
         return tuple(getattr(self, field) for field in self._multi_line_block_fields)
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -41,7 +41,7 @@ import itertools
 import sys
 import typing
 import warnings
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, Callable, Generator, Optional
 
 from astroid import decorators, mixins, util
@@ -923,7 +923,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
             return name
         return None
 
-    @decorators.cachedproperty
+    @cached_property
     def fromlineno(self):
         """The first line that this node appears on in the source code.
 
@@ -932,7 +932,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         lineno = super().fromlineno
         return max(lineno, self.parent.fromlineno or 0)
 
-    @decorators.cachedproperty
+    @cached_property
     def arguments(self):
         """Get all the arguments for this node, including positional only and positional and keyword"""
         return list(itertools.chain((self.posonlyargs or ()), self.args or ()))
@@ -2439,7 +2439,7 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
         if body is not None:
             self.body = body
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -2556,7 +2556,7 @@ class For(
             self.orelse = orelse
         self.type_annotation = type_annotation
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -2845,7 +2845,7 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         if isinstance(self.parent, If) and self in self.parent.orelse:
             self.is_orelse = True
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -3398,7 +3398,7 @@ class Slice(NodeNG):
             return const
         return attr
 
-    @decorators.cachedproperty
+    @cached_property
     def _proxied(self):
         builtins = AstroidManager().builtins_module
         return builtins.getattr("slice")[0]
@@ -3912,7 +3912,7 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         if orelse is not None:
             self.orelse = orelse
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -4009,7 +4009,7 @@ class With(
             self.body = body
         self.type_annotation = type_annotation
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -2,6 +2,7 @@ import pprint
 import sys
 import typing
 import warnings
+from functools import cached_property
 from functools import singledispatch as _singledispatch
 from typing import (
     TYPE_CHECKING,
@@ -405,14 +406,14 @@ class NodeNG:
     # these are lazy because they're relatively expensive to compute for every
     # single node, and they rarely get looked at
 
-    @decorators.cachedproperty
+    @cached_property
     def fromlineno(self) -> Optional[int]:
         """The first line that this node appears on in the source code."""
         if self.lineno is None:
             return self._fixed_source_line()
         return self.lineno
 
-    @decorators.cachedproperty
+    @cached_property
     def tolineno(self) -> Optional[int]:
         """The last line that this node appears on in the source code."""
         if not self._astroid_fields:

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -47,6 +47,7 @@ import os
 import sys
 import typing
 import warnings
+from functools import cached_property
 from typing import List, Optional, TypeVar, Union, overload
 
 from astroid import bases
@@ -1502,7 +1503,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         self.type_comment_returns = type_comment_returns
         self.type_comment_args = type_comment_args
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def extra_decorators(self):
         """The extra decorators that this function can have.
 
@@ -1545,7 +1546,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                             decorators.append(assign.value)
         return decorators
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def type(
         self,
     ):  # pylint: disable=invalid-overridden-method,too-many-return-statements
@@ -1617,7 +1618,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                 pass
         return type_name
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def fromlineno(self):
         """The first line that this node appears on in the source code.
 
@@ -1633,7 +1634,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
 
         return lineno
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -2184,7 +2185,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         doc=("Whether this is a new style class or not\n\n" ":type: bool or None"),
     )
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -22,8 +22,9 @@ leads to an inferred FrozenSet:
     Call(func=Name('frozenset'), args=Tuple(...))
 """
 
+from functools import cached_property
 
-from astroid import bases, decorators, util
+from astroid import bases, util
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -45,7 +46,7 @@ class FrozenSet(node_classes.BaseContainer):
     def _infer(self, context=None):
         yield self
 
-    @decorators.cachedproperty
+    @cached_property
     def _proxied(self):  # pylint: disable=method-hidden
         ast_builtins = AstroidManager().builtins_module
         return ast_builtins.getattr("frozenset")[0]
@@ -114,7 +115,7 @@ class Super(node_classes.NodeNG):
         index = mro.index(self.mro_pointer)
         return mro[index + 1 :]
 
-    @decorators.cachedproperty
+    @cached_property
     def _proxied(self):
         ast_builtins = AstroidManager().builtins_module
         return ast_builtins.getattr("super")[0]
@@ -218,7 +219,7 @@ class ExceptionInstance(bases.Instance):
     the case of .args.
     """
 
-    @decorators.cachedproperty
+    @cached_property
     def special_attributes(self):
         qname = self.qname()
         instance = objectmodel.BUILTIN_EXCEPTIONS.get(


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

@cdce8p Pinging you as you wrote https://github.com/python/mypy/pull/10408 which prompted me to do this.

We could remove the deprecation but I don't see why we would include this decorator in our codebase if we're not using it ourselves. The added benefit of `mypy` supporting the `functools` one is necessary for us to enable `mypy` at some point.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
