### PR TITLE
Fix ``mypy`` warnings for ``astroid/rebuilder``

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4489,7 +4489,7 @@ class MatchSingleton(Pattern):
     def __init__(
         self,
         *,
-        value: Literal[True, False, None],  # type: ignore[assignment] # See https://github.com/python/mypy/pull/10389
+        value: Literal[True, False, None],
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4489,12 +4489,12 @@ class MatchSingleton(Pattern):
     def __init__(
         self,
         *,
-        value: Literal[True, False, None],
+        value: Optional[bool],
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
     ) -> None:
-        self.value: Literal[True, False, None] = value
+        self.value = value
         super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
 
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4489,7 +4489,7 @@ class MatchSingleton(Pattern):
     def __init__(
         self,
         *,
-        value: Optional[bool],
+        value: Literal[True, False, None],  # type: ignore[assignment] # See https://github.com/python/mypy/pull/10389
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -107,7 +107,7 @@ class TreeRebuilder:
     def _get_doc(self, node: T_Doc) -> Tuple[T_Doc, Optional[str]]:
         try:
             if PY37_PLUS and hasattr(node, "docstring"):
-                doc = node.docstring  # type: ignore[union-attr, attr-defined] # mypy doesn't recognize hasattr
+                doc = node.docstring  # type: ignore[union-attr,attr-defined] # mypy doesn't recognize hasattr
                 return node, doc
             if node.body and isinstance(node.body[0], self._module.Expr):
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -107,7 +107,7 @@ class TreeRebuilder:
     def _get_doc(self, node: T_Doc) -> Tuple[T_Doc, Optional[str]]:
         try:
             if PY37_PLUS and hasattr(node, "docstring"):
-                doc = node.docstring  # type: ignore # mypy doesn't recognize hasattr
+                doc = node.docstring  # type: ignore[union-attr, attr-defined] # mypy doesn't recognize hasattr
                 return node, doc
             if node.body and isinstance(node.body[0], self._module.Expr):
 
@@ -875,13 +875,11 @@ class TreeRebuilder:
             type_comment_posonlyargs=type_comment_posonlyargs,
         )
         # save argument names in locals:
+        if not newnode.parent:
+            raise ParentMissingError(target=newnode)
         if vararg:
-            if not newnode.parent:
-                raise ParentMissingError(target=newnode)
             newnode.parent.set_local(vararg, newnode)
         if kwarg:
-            if not newnode.parent:
-                raise ParentMissingError(target=newnode)
             newnode.parent.set_local(kwarg, newnode)
         return newnode
 
@@ -1365,7 +1363,7 @@ class TreeRebuilder:
             # Prohibit a local save if we are in an ExceptHandler.
             if not isinstance(parent, nodes.ExceptHandler):
                 # mypy doesn't recognize that newnode has to be AssignAttr
-                self._delayed_assattr.append(newnode)  # type: ignore
+                self._delayed_assattr.append(newnode)  # type: ignore [arg-type]
         else:
             newnode = nodes.Attribute(node.attr, node.lineno, node.col_offset, parent)
         newnode.postinit(self.visit(node.value, newnode))

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -875,12 +875,10 @@ class TreeRebuilder:
             type_comment_posonlyargs=type_comment_posonlyargs,
         )
         # save argument names in locals:
-        if not newnode.parent:
-            raise ParentMissingError(target=newnode)
         if vararg:
-            newnode.parent.set_local(vararg, newnode)
+            newnode.parent.set_local(vararg, newnode)  # type: ignore[union-attr] # newnode is initialized with a parent
         if kwarg:
-            newnode.parent.set_local(kwarg, newnode)
+            newnode.parent.set_local(kwarg, newnode)  # type: ignore[union-attr] # newnode is initialized with a parent
         return newnode
 
     def visit_assert(self, node: "ast.Assert", parent: NodeNG) -> nodes.Assert:

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1361,7 +1361,7 @@ class TreeRebuilder:
             # Prohibit a local save if we are in an ExceptHandler.
             if not isinstance(parent, nodes.ExceptHandler):
                 # mypy doesn't recognize that newnode has to be AssignAttr
-                self._delayed_assattr.append(newnode)  # type: ignore [arg-type]
+                self._delayed_assattr.append(newnode)  # type: ignore[arg-type]
         else:
             newnode = nodes.Attribute(node.attr, node.lineno, node.col_offset, parent)
         newnode.postinit(self.visit(node.value, newnode))


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

Only 130 warnings left before we can turn on `mypy`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
