### PR TITLE
Resolve symlinks in the import path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,7 +21,10 @@ Release date: TBA
   installed on macOS via Homebrew).
 
   Closes #823
+  Closes PyCQA/pylint#3499
+  Closes PyCQA/pylint#4302
   Closes PyCQA/pylint#4798
+  Closes PyCQA/pylint#5081
 
 
 What's New in astroid 2.8.5?

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,13 @@ Release date: TBA
 
   Closes #1239
 
+* Resolve symlinks in the import path
+  Fixes inference error when the import path includes symlinks (e.g. Python
+  installed on macOS via Homebrew).
+
+  Closes #823
+  Closes PyCQA/pylint#4798
+
 
 What's New in astroid 2.8.5?
 ============================

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -154,11 +154,7 @@ class NoSourceFile(Exception):
 
 
 def _normalize_path(path):
-    return os.path.normcase(os.path.abspath(path))
-
-
-def _canonicalize_path(path):
-    return os.path.realpath(os.path.expanduser(path))
+    return os.path.normcase(os.path.realpath(os.path.expanduser(path)))
 
 
 def _path_from_filename(filename, is_jython=IS_JYTHON):
@@ -298,9 +294,8 @@ def _get_relative_base_path(filename, path_to_check):
 def modpath_from_file_with_callback(filename, path=None, is_package_cb=None):
     filename = os.path.expanduser(_path_from_filename(filename))
     for pathname in itertools.chain(
-        path or [], map(_canonicalize_path, sys.path), sys.path
+        path or [], map(_cache_normalize_path, sys.path), sys.path
     ):
-        pathname = _cache_normalize_path(pathname)
         if not pathname:
             continue
         modpath = _get_relative_base_path(filename, pathname)

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -154,7 +154,11 @@ class NoSourceFile(Exception):
 
 
 def _normalize_path(path):
-    return os.path.normcase(os.path.realpath(os.path.expanduser(path)))
+    """Resolve symlinks in path and convert to absolute path.
+    Note that environment variables and ~ in the path need to be expanded in
+    advance.
+    """
+    return os.path.normcase(os.path.realpath(path))
 
 
 def _path_from_filename(filename, is_jython=IS_JYTHON):
@@ -182,7 +186,7 @@ _NORM_PATH_CACHE = {}
 
 
 def _cache_normalize_path(path):
-    """abspath with caching"""
+    """Normalize path with caching."""
     # _module_file calls abspath on every path in sys.path every time it's
     # called; on a larger codebase this easily adds up to half a second just
     # assembling path components. This cache alleviates that.

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -153,7 +153,7 @@ class NoSourceFile(Exception):
     """
 
 
-def _normalize_path(path):
+def _normalize_path(path: str) -> str:
     """Resolve symlinks in path and convert to absolute path.
     Note that environment variables and ~ in the path need to be expanded in
     advance.
@@ -185,7 +185,7 @@ def _handle_blacklist(blacklist, dirnames, filenames):
 _NORM_PATH_CACHE = {}
 
 
-def _cache_normalize_path(path):
+def _cache_normalize_path(path: str) -> str:
     """Normalize path with caching."""
     # _module_file calls abspath on every path in sys.path every time it's
     # called; on a larger codebase this easily adds up to half a second just


### PR DESCRIPTION
Currently, module import fails when the import path contains a symlink.

An example is Python installed on macOS using Homebrew where `/opt/homebrew/opt/python` is a symlink to `/opt/homebrew/Cellar/python@3.9/3.9.8` (exact version varies). As a result, `get_python_lib(standard_lib=True)` returns `/opt/homebrew/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9` while `sys.path` is `[..., '/opt/homebrew/Cellar/python@3.9/3.9.8/Frameworks/Python.framework/Versions/3.9/lib/python3.9', ...]`. The following tests fail due to this inconsistency:

```
FAILED tests/unittest_brain.py::MultiprocessingBrainTest::test_multiprocessing_manager - AssertionError: Uninferable != 'array.array'
FAILED tests/unittest_brain_ctypes.py::test_cdata_member_access - astroid.exceptions.InferenceError: StopIteration raised without ...
FAILED tests/unittest_builder.py::BuilderTest::test_socket_build - AssertionError: 'connect' not found in <ClassDef.socket l.214 a...
FAILED tests/unittest_modutils.py::StandardLibModuleTest::test_4 - AssertionError: False is not true
FAILED tests/unittest_modutils.py::StandardLibModuleTest::test_datetime - AssertionError: False is not true
FAILED tests/unittest_regrtest.py::NonRegressionTests::test_ssl_protocol - AssertionError: Uninferable is not an instance of <clas...
```

## Description

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

Fixes #823