### PR TITLE
Skip ExceptionModelTest.test_oserror if six is installed

### DIFF
--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -20,6 +20,13 @@ import astroid
 from astroid import builder, nodes, objects, test_utils, util
 from astroid.exceptions import InferenceError
 
+try:
+    import six  # pylint: disable=unused-import
+
+    HAS_SIX = True
+except ImportError:
+    HAS_SIX = False
+
 
 class InstanceModelTest(unittest.TestCase):
     def test_instance_special_model(self) -> None:
@@ -566,6 +573,7 @@ class ExceptionModelTest(unittest.TestCase):
         inferred = next(ast_node.infer())
         assert isinstance(inferred, astroid.Const)
 
+    @unittest.skipIf(HAS_SIX, "This test fails if the six library is installed")
     def test_oserror(self) -> None:
         ast_nodes = builder.extract_node(
             """


### PR DESCRIPTION
## Description

`ExceptionModelTest.test_oserror` fails if the `six` package is installed (see https://github.com/PyCQA/astroid/issues/798#issuecomment-970300043 for the details). This PR skips the test it if `six` is present.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Related Issue

Closes #798