### PR TITLE
Remove forgotten debug ``print`` statement from tests

### DIFF
--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6027,7 +6027,6 @@ def test_property_inference() -> None:
     assert inferred.type == "property"
 
     inferred = next(prop_result.infer())
-    print(prop_result.as_string())
     assert isinstance(inferred, nodes.Const)
     assert inferred.value == 42
 


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

This print is shown when running `pytest -s`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

