### PR TITLE
Add  `end_lineno` and `end_col_offset` to nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 1.0.1
     hooks:
       - id: black-disable-checker
+        exclude: tests/unittest_nodes_lineno.py
   - repo: https://github.com/psf/black
     rev: 21.10b0
     hooks:

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ What's New in astroid 2.9.0?
 ============================
 Release date: TBA
 
+* Add ``end_lineno`` and ``end_col_offset`` attributes to astroid nodes.
 
 
 What's New in astroid 2.8.6?

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -1,6 +1,7 @@
 import enum
 import sys
 
+PY38 = sys.version_info[:2] == (3, 8)
 PY37_PLUS = sys.version_info >= (3, 7)
 PY38_PLUS = sys.version_info >= (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -285,6 +285,9 @@ class BaseContainer(
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -297,7 +300,13 @@ class BaseContainer(
         self.elts: typing.List[NodeNG] = []
         """The elements in the node."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, elts: typing.List[NodeNG]) -> None:
         """Do some setup after initialisation.
@@ -619,6 +628,9 @@ class AssignName(
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param name: The name that is assigned to.
@@ -633,7 +645,13 @@ class AssignName(
         self.name: Optional[str] = name
         """The name that is assigned to."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
 
 class DelName(
@@ -660,6 +678,9 @@ class DelName(
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param name: The name that is being deleted.
@@ -674,7 +695,13 @@ class DelName(
         self.name: Optional[str] = name
         """The name that is being deleted."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
 
 class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
@@ -702,6 +729,9 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param name: The name that this node refers to.
@@ -716,7 +746,13 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
         self.name: Optional[str] = name
         """The name that this node refers to."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def _get_name_nodes(self):
         yield self
@@ -1134,6 +1170,9 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param attrname: The name of the attribute being assigned to.
@@ -1151,7 +1190,13 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         self.attrname: Optional[str] = attrname
         """The name of the attribute being assigned to."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, expr: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -1182,6 +1227,9 @@ class Assert(Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1197,7 +1245,13 @@ class Assert(Statement):
         self.fail: Optional[NodeNG] = None  # can be None
         """The message shown when the assertion fails."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self, test: Optional[NodeNG] = None, fail: Optional[NodeNG] = None
@@ -1238,6 +1292,9 @@ class Assign(mixins.AssignTypeMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1256,7 +1313,13 @@ class Assign(mixins.AssignTypeMixin, Statement):
         self.type_annotation: Optional[NodeNG] = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -1307,6 +1370,9 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1328,7 +1394,13 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         self.simple: Optional[int] = None
         """Whether :attr:`target` is a pure name or a complex statement."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -1382,6 +1454,9 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param op: The operator that is being combined with the assignment.
@@ -1406,7 +1481,13 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         self.value: Optional[NodeNG] = None
         """The value being assigned to the variable."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self, target: Optional[NodeNG] = None, value: Optional[NodeNG] = None
@@ -1474,6 +1555,9 @@ class BinOp(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param op: The operator.
@@ -1494,7 +1578,13 @@ class BinOp(NodeNG):
         self.right: Optional[NodeNG] = None
         """What is being applied to the operator on the right side."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self, left: Optional[NodeNG] = None, right: Optional[NodeNG] = None
@@ -1564,6 +1654,9 @@ class BoolOp(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param op: The operator.
@@ -1581,7 +1674,13 @@ class BoolOp(NodeNG):
         self.values: typing.List[NodeNG] = []
         """The values being applied to the operator."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, values: Optional[typing.List[NodeNG]] = None) -> None:
         """Do some setup after initialisation.
@@ -1626,6 +1725,9 @@ class Call(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1644,7 +1746,13 @@ class Call(NodeNG):
         self.keywords: typing.List["Keyword"] = []
         """The keyword arguments being given to the call."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -1704,6 +1812,9 @@ class Compare(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1719,7 +1830,13 @@ class Compare(NodeNG):
         self.ops: typing.List[typing.Tuple[str, NodeNG]] = []
         """The remainder of the operators and their relevant right hand value."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -1881,6 +1998,9 @@ class Const(mixins.NoChildrenMixin, NodeNG, Instance):
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
         kind: Optional[str] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param value: The value that the constant represents.
@@ -1900,7 +2020,13 @@ class Const(mixins.NoChildrenMixin, NodeNG, Instance):
         self.kind: Optional[str] = kind  # can be None
         """"The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def __getattr__(self, name):
         # This is needed because of Proxy's __getattr__ method.
@@ -2023,6 +2149,9 @@ class Decorators(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2038,7 +2167,13 @@ class Decorators(NodeNG):
         :type: list(Name or Call) or None
         """
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, nodes: typing.List[NodeNG]) -> None:
         """Do some setup after initialisation.
@@ -2086,6 +2221,9 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param attrname: The name of the attribute that is being deleted.
@@ -2106,7 +2244,13 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
         self.attrname: Optional[str] = attrname
         """The name of the attribute that is being deleted."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, expr: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -2138,6 +2282,9 @@ class Delete(mixins.AssignTypeMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2150,7 +2297,13 @@ class Delete(mixins.AssignTypeMixin, Statement):
         self.targets: typing.List[NodeNG] = []
         """What is being deleted."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, targets: Optional[typing.List[NodeNG]] = None) -> None:
         """Do some setup after initialisation.
@@ -2182,6 +2335,9 @@ class Dict(NodeNG, Instance):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2194,7 +2350,13 @@ class Dict(NodeNG, Instance):
         self.items: typing.List[typing.Tuple[NodeNG, NodeNG]] = []
         """The key-value pairs contained in the dictionary."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, items: typing.List[typing.Tuple[NodeNG, NodeNG]]) -> None:
         """Do some setup after initialisation.
@@ -2321,6 +2483,9 @@ class Expr(Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2333,7 +2498,13 @@ class Expr(Statement):
         self.value: Optional[NodeNG] = None
         """What the expression does."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, value: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -2392,6 +2563,9 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2413,7 +2587,13 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
         self.body: typing.List[NodeNG] = []
         """The contents of the block."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def get_children(self):
         if self.type is not None:
@@ -2509,6 +2689,9 @@ class For(
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2533,7 +2716,13 @@ class For(
         self.type_annotation: Optional[NodeNG] = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(
@@ -2622,6 +2811,9 @@ class Await(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2634,7 +2826,13 @@ class Await(NodeNG):
         self.value: Optional[NodeNG] = None
         """What to wait for."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, value: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -2666,6 +2864,9 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param fromname: The module that is being imported from.
@@ -2702,7 +2903,13 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         This is always 0 for absolute imports.
         """
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
 
 class Attribute(NodeNG):
@@ -2718,6 +2925,9 @@ class Attribute(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param attrname: The name of the attribute.
@@ -2738,7 +2948,13 @@ class Attribute(NodeNG):
         self.attrname: Optional[str] = attrname
         """The name of the attribute."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, expr: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -2769,6 +2985,9 @@ class Global(mixins.NoChildrenMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param names: The names being declared as global.
@@ -2783,7 +3002,13 @@ class Global(mixins.NoChildrenMixin, Statement):
         self.names: typing.List[str] = names
         """The names being declared as global."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def _infer_name(self, frame, name):
         return name
@@ -2806,6 +3031,9 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2827,7 +3055,13 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         self.is_orelse: bool = False
         """Whether the if-statement is the orelse-block of another if statement."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -2956,6 +3190,9 @@ class IfExp(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2974,7 +3211,13 @@ class IfExp(NodeNG):
         self.orelse: Optional[NodeNG] = None
         """The contents of the ``else`` block."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -3022,6 +3265,9 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param names: The names being imported.
@@ -3040,7 +3286,13 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         and the alias that the name is assigned to (if any).
         """
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
 
 class Index(NodeNG):
@@ -3073,6 +3325,9 @@ class Keyword(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param arg: The argument being assigned to.
@@ -3090,7 +3345,13 @@ class Keyword(NodeNG):
         self.value: Optional[NodeNG] = None
         """The value being assigned to the keyword argument."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, value: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -3120,6 +3381,9 @@ class List(BaseContainer):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param ctx: Whether the list is assigned to or loaded from.
@@ -3134,7 +3398,13 @@ class List(BaseContainer):
         self.ctx: Optional[Context] = ctx
         """Whether the list is assigned to or loaded from."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def pytype(self):
         """Get the name of the type that this node represents.
@@ -3175,6 +3445,9 @@ class Nonlocal(mixins.NoChildrenMixin, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param names: The names being declared as not local.
@@ -3189,7 +3462,13 @@ class Nonlocal(mixins.NoChildrenMixin, Statement):
         self.names: typing.List[str] = names
         """The names being declared as not local."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def _infer_name(self, frame, name):
         return name
@@ -3221,6 +3500,9 @@ class Raise(Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3236,7 +3518,13 @@ class Raise(Statement):
         self.cause: Optional[NodeNG] = None  # can be None
         """The exception being used to raise this one."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -3290,6 +3578,9 @@ class Return(Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3302,7 +3593,13 @@ class Return(Statement):
         self.value: Optional[NodeNG] = None  # can be None
         """The value being returned."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, value: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -3358,6 +3655,9 @@ class Slice(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3376,7 +3676,13 @@ class Slice(NodeNG):
         self.step: Optional[NodeNG] = None  # can be None
         """The step to take between indexes."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -3467,6 +3773,9 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param ctx: Whether the list is assigned to or loaded from.
@@ -3484,7 +3793,13 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
         self.ctx: Optional[Context] = ctx
         """Whether the starred item is assigned to or loaded from."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, value: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -3515,6 +3830,9 @@ class Subscript(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param ctx: Whether the subscripted item is assigned to or loaded from.
@@ -3535,7 +3853,13 @@ class Subscript(NodeNG):
         self.ctx: Optional[Context] = ctx
         """Whether the subscripted item is assigned to or loaded from."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(
@@ -3577,6 +3901,9 @@ class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3595,7 +3922,13 @@ class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         self.orelse: typing.List[NodeNG] = []
         """The contents of the ``else`` block."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -3672,6 +4005,9 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3687,7 +4023,13 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         self.finalbody: typing.List[NodeNG] = []
         """The contents of the ``finally`` block."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -3747,6 +4089,9 @@ class Tuple(BaseContainer):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param ctx: Whether the tuple is assigned to or loaded from.
@@ -3761,7 +4106,13 @@ class Tuple(BaseContainer):
         self.ctx: Optional[Context] = ctx
         """Whether the tuple is assigned to or loaded from."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def pytype(self):
         """Get the name of the type that this node represents.
@@ -3799,6 +4150,9 @@ class UnaryOp(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param op: The operator.
@@ -3816,7 +4170,13 @@ class UnaryOp(NodeNG):
         self.operand: Optional[NodeNG] = None
         """What the unary operator is applied to."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, operand: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -3878,6 +4238,9 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3896,7 +4259,13 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         self.orelse: typing.List[NodeNG] = []
         """The contents of the ``else`` block."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -3976,6 +4345,9 @@ class With(
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3994,7 +4366,13 @@ class With(
         self.type_annotation: Optional[NodeNG] = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -4056,6 +4434,9 @@ class Yield(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4068,7 +4449,13 @@ class Yield(NodeNG):
         self.value: Optional[NodeNG] = None  # can be None
         """The value to yield."""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, value: Optional[NodeNG] = None) -> None:
         """Do some setup after initialisation.
@@ -4114,6 +4501,9 @@ class FormattedValue(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4142,7 +4532,13 @@ class FormattedValue(NodeNG):
         :type: JoinedStr or None
         """
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -4186,6 +4582,9 @@ class JoinedStr(NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4201,7 +4600,13 @@ class JoinedStr(NodeNG):
         :type: list(FormattedValue or Const)
         """
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, values: Optional[typing.List[NodeNG]] = None) -> None:
         """Do some setup after initialisation.
@@ -4238,6 +4643,9 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4256,7 +4664,13 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
         self.value: NodeNG
         """The value that gets assigned in the expression"""
 
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, target: NodeNG, value: NodeNG) -> None:
         self.target = target
@@ -4388,10 +4802,19 @@ class Match(Statement):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.subject: NodeNG
         self.cases: typing.List["MatchCase"]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -4464,9 +4887,18 @@ class MatchValue(Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.value: NodeNG
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, *, value: NodeNG) -> None:
         self.value = value
@@ -4501,10 +4933,18 @@ class MatchSingleton(Pattern):
         value: Literal[True, False, None],
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
     ) -> None:
         self.value: Literal[True, False, None] = value
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
 
 class MatchSequence(Pattern):
@@ -4531,9 +4971,18 @@ class MatchSequence(Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.patterns: typing.List[Pattern]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, *, patterns: typing.List[Pattern]) -> None:
         self.patterns = patterns
@@ -4559,11 +5008,20 @@ class MatchMapping(mixins.AssignTypeMixin, Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.keys: typing.List[NodeNG]
         self.patterns: typing.List[Pattern]
         self.rest: Optional[AssignName]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -4612,12 +5070,21 @@ class MatchClass(Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.cls: NodeNG
         self.patterns: typing.List[Pattern]
         self.kwd_attrs: typing.List[str]
         self.kwd_patterns: typing.List[Pattern]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -4653,9 +5120,18 @@ class MatchStar(mixins.AssignTypeMixin, Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.name: Optional[AssignName]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, *, name: Optional[AssignName]) -> None:
         self.name = name
@@ -4703,10 +5179,19 @@ class MatchAs(mixins.AssignTypeMixin, Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.pattern: Optional[Pattern]
         self.name: Optional[AssignName]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(
         self,
@@ -4748,9 +5233,18 @@ class MatchOr(Pattern):
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional[NodeNG] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         self.patterns: typing.List[Pattern]
-        super().__init__(lineno=lineno, col_offset=col_offset, parent=parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, *, patterns: typing.List[Pattern]) -> None:
         self.patterns = patterns

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -805,6 +805,8 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
 
     lineno: None
     col_offset: None
+    end_lineno: None
+    end_col_offset: None
 
     def __init__(
         self,
@@ -1901,6 +1903,8 @@ class Comprehension(NodeNG):
 
     lineno: None
     col_offset: None
+    end_lineno: None
+    end_col_offset: None
 
     def __init__(self, parent: Optional[NodeNG] = None) -> None:
         """
@@ -4848,6 +4852,8 @@ class MatchCase(mixins.MultiLineBlockMixin, NodeNG):
 
     lineno: None
     col_offset: None
+    end_lineno: None
+    end_col_offset: None
 
     def __init__(self, *, parent: Optional[NodeNG] = None) -> None:
         self.pattern: Pattern

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -296,6 +296,11 @@ class BaseContainer(
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.elts: typing.List[NodeNG] = []
         """The elements in the node."""
@@ -641,6 +646,11 @@ class AssignName(
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.name: Optional[str] = name
         """The name that is assigned to."""
@@ -691,6 +701,11 @@ class DelName(
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.name: Optional[str] = name
         """The name that is being deleted."""
@@ -742,6 +757,11 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.name: Optional[str] = name
         """The name that this node refers to."""
@@ -1185,6 +1205,11 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.expr: Optional[NodeNG] = None
         """What has the attribute that is being assigned to."""
@@ -1240,6 +1265,11 @@ class Assert(Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.test: Optional[NodeNG] = None
         """The test that passes or fails the assertion."""
@@ -1305,6 +1335,11 @@ class Assign(mixins.AssignTypeMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.targets: typing.List[NodeNG] = []
         """What is being assigned to."""
@@ -1383,6 +1418,11 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.target: Optional[NodeNG] = None
         """What is being assigned to."""
@@ -1470,6 +1510,11 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.target: Optional[NodeNG] = None
         """What is being assigned to."""
@@ -1570,6 +1615,11 @@ class BinOp(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.left: Optional[NodeNG] = None
         """What is being applied to the operator on the left side."""
@@ -1669,6 +1719,11 @@ class BoolOp(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.op: Optional[str] = op
         """The operator."""
@@ -1738,6 +1793,11 @@ class Call(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.func: Optional[NodeNG] = None
         """What is being called."""
@@ -1825,6 +1885,11 @@ class Compare(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.left: Optional[NodeNG] = None
         """The value at the left being applied to a comparison operator."""
@@ -2017,6 +2082,11 @@ class Const(mixins.NoChildrenMixin, NodeNG, Instance):
         :param parent: The parent node in the syntax tree.
 
         :param kind: The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: typing.Any = value
         """The value that the constant represents."""
@@ -2164,6 +2234,11 @@ class Decorators(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.nodes: typing.List[NodeNG]
         """The decorators that this node contains.
@@ -2238,6 +2313,11 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.expr: Optional[NodeNG] = None
         """The name that this node represents.
@@ -2297,6 +2377,11 @@ class Delete(mixins.AssignTypeMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.targets: typing.List[NodeNG] = []
         """What is being deleted."""
@@ -2350,6 +2435,11 @@ class Dict(NodeNG, Instance):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.items: typing.List[typing.Tuple[NodeNG, NodeNG]] = []
         """The key-value pairs contained in the dictionary."""
@@ -2498,6 +2588,11 @@ class Expr(Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: Optional[NodeNG] = None
         """What the expression does."""
@@ -2578,6 +2673,11 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.type: Optional[NodeNG] = None  # can be None
         """The types that the block handles.
@@ -2704,6 +2804,11 @@ class For(
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.target: Optional[NodeNG] = None
         """What the loop assigns to."""
@@ -2826,6 +2931,11 @@ class Await(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: Optional[NodeNG] = None
         """What to wait for."""
@@ -2885,6 +2995,11 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.modname: Optional[str] = fromname  # can be None
         """The module that is being imported from.
@@ -2942,6 +3057,11 @@ class Attribute(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.expr: Optional[NodeNG] = None
         """The name that this node represents.
@@ -3002,6 +3122,11 @@ class Global(mixins.NoChildrenMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.names: typing.List[str] = names
         """The names being declared as global."""
@@ -3046,6 +3171,11 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.test: Optional[NodeNG] = None
         """The condition that the statement tests."""
@@ -3205,6 +3335,11 @@ class IfExp(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.test: Optional[NodeNG] = None
         """The condition that the statement tests."""
@@ -3282,6 +3417,11 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.names: typing.List[typing.Tuple[str, Optional[str]]] = names or []
         """The names being imported.
@@ -3342,6 +3482,11 @@ class Keyword(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.arg: Optional[str] = arg  # can be None
         """The argument being assigned to."""
@@ -3398,6 +3543,11 @@ class List(BaseContainer):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.ctx: Optional[Context] = ctx
         """Whether the list is assigned to or loaded from."""
@@ -3462,6 +3612,11 @@ class Nonlocal(mixins.NoChildrenMixin, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.names: typing.List[str] = names
         """The names being declared as not local."""
@@ -3515,6 +3670,11 @@ class Raise(Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.exc: Optional[NodeNG] = None  # can be None
         """What is being raised."""
@@ -3593,6 +3753,11 @@ class Return(Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: Optional[NodeNG] = None  # can be None
         """The value being returned."""
@@ -3670,6 +3835,11 @@ class Slice(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.lower: Optional[NodeNG] = None  # can be None
         """The lower index in the slice."""
@@ -3790,6 +3960,11 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: Optional[NodeNG] = None
         """What is being unpacked."""
@@ -3847,6 +4022,11 @@ class Subscript(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: Optional[NodeNG] = None
         """What is being indexed."""
@@ -3916,6 +4096,11 @@ class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.body: typing.List[NodeNG] = []
         """The contents of the block to catch exceptions from."""
@@ -4020,6 +4205,11 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.body: typing.Union[typing.List[TryExcept], typing.List[NodeNG]] = []
         """The try-except that the finally is attached to."""
@@ -4106,6 +4296,11 @@ class Tuple(BaseContainer):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.ctx: Optional[Context] = ctx
         """Whether the tuple is assigned to or loaded from."""
@@ -4167,6 +4362,11 @@ class UnaryOp(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.op: Optional[str] = op
         """The operator."""
@@ -4253,6 +4453,11 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.test: Optional[NodeNG] = None
         """The condition that the loop tests."""
@@ -4360,6 +4565,11 @@ class With(
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.items: typing.List[typing.Tuple[NodeNG, Optional[NodeNG]]] = []
         """The pairs of context managers and the names they are assigned to."""
@@ -4449,6 +4659,11 @@ class Yield(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: Optional[NodeNG] = None  # can be None
         """The value to yield."""
@@ -4516,6 +4731,11 @@ class FormattedValue(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.value: NodeNG
         """The value to be formatted into the string."""
@@ -4597,6 +4817,11 @@ class JoinedStr(NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.values: typing.List[NodeNG] = []
         """The string expressions to be joined.
@@ -4658,6 +4883,11 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno: The last line this node appears on in the source code.
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.target: NodeNG
         """The assignment target

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -90,6 +90,9 @@ class NodeNG:
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
         parent: Optional["NodeNG"] = None,
+        *,
+        end_lineno: Optional[int] = None,
+        end_col_offset: Optional[int] = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -98,6 +101,10 @@ class NodeNG:
             source code.
 
         :param parent: The parent node in the syntax tree.
+
+        :param end_lineno:
+
+        :param end_col_offset:
         """
         self.lineno: Optional[int] = lineno
         """The line that this node appears on in the source code."""
@@ -107,6 +114,12 @@ class NodeNG:
 
         self.parent: Optional["NodeNG"] = parent
         """The parent node in the syntax tree."""
+
+        self.end_lineno: Optional[int] = end_lineno
+        """ """
+
+        self.end_col_offset: Optional[int] = end_col_offset
+        """ """
 
     def infer(self, context=None, **kwargs):
         """Get a generator of the inferred values.

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -102,9 +102,10 @@ class NodeNG:
 
         :param parent: The parent node in the syntax tree.
 
-        :param end_lineno:
+        :param end_lineno: The last line this node appears on in the source code.
 
-        :param end_col_offset:
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
         """
         self.lineno: Optional[int] = lineno
         """The line that this node appears on in the source code."""
@@ -116,10 +117,12 @@ class NodeNG:
         """The parent node in the syntax tree."""
 
         self.end_lineno: Optional[int] = end_lineno
-        """ """
+        """The last line this node appears on in the source code."""
 
         self.end_col_offset: Optional[int] = end_col_offset
-        """ """
+        """The end column this node appears on in the source code.
+        Note: This is after the last symbol.
+        """
 
     def infer(self, context=None, **kwargs):
         """Get a generator of the inferred values.

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -916,6 +916,13 @@ class GeneratorExp(ComprehensionScope):
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param end_lineno: The last line this node appears on in the source code.
+        :type end_lineno: Optional[int]
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
+        :type end_col_offset: Optional[int]
         """
         self.locals = {}
         """A map of the name of a local variable to the node defining the local.
@@ -1007,6 +1014,13 @@ class DictComp(ComprehensionScope):
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param end_lineno: The last line this node appears on in the source code.
+        :type end_lineno: Optional[int]
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
+        :type end_col_offset: Optional[int]
         """
         self.locals = {}
         """A map of the name of a local variable to the node defining the local.
@@ -1098,6 +1112,13 @@ class SetComp(ComprehensionScope):
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param end_lineno: The last line this node appears on in the source code.
+        :type end_lineno: Optional[int]
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
+        :type end_col_offset: Optional[int]
         """
         self.locals = {}
         """A map of the name of a local variable to the node defining the local.
@@ -1312,6 +1333,13 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param end_lineno: The last line this node appears on in the source code.
+        :type end_lineno: Optional[int]
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
+        :type end_col_offset: Optional[int]
         """
         self.locals = {}
         """A map of the name of a local variable to the node defining it.
@@ -1537,6 +1565,13 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param end_lineno: The last line this node appears on in the source code.
+        :type end_lineno: Optional[int]
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
+        :type end_col_offset: Optional[int]
         """
         self.name = name
         """The name of the function.
@@ -2167,6 +2202,13 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         :param parent: The parent node in the syntax tree.
         :type parent: NodeNG or None
+
+        :param end_lineno: The last line this node appears on in the source code.
+        :type end_lineno: Optional[int]
+
+        :param end_col_offset: The end column this node appears on in the
+            source code. Note: This is after the last symbol.
+        :type end_col_offset: Optional[int]
         """
         self.instance_attrs = {}
         self.locals = {}

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -471,6 +471,8 @@ class Module(LocalsDictNodeNG):
 
     lineno: None
     col_offset: None
+    end_lineno: None
+    end_col_offset: None
     parent: None
 
     def __init__(

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -895,7 +895,15 @@ class GeneratorExp(ComprehensionScope):
     :type: list(Comprehension) or None
     """
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         """
         :param lineno: The line that this node appears on in the source code.
         :type lineno: int or None
@@ -913,7 +921,13 @@ class GeneratorExp(ComprehensionScope):
         :type: dict(str, NodeNG)
         """
 
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, elt=None, generators=None):
         """Do some setup after initialisation.
@@ -972,7 +986,15 @@ class DictComp(ComprehensionScope):
     :type: list(Comprehension) or None
     """
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         """
         :param lineno: The line that this node appears on in the source code.
         :type lineno: int or None
@@ -990,7 +1012,13 @@ class DictComp(ComprehensionScope):
         :type: dict(str, NodeNG)
         """
 
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, key=None, value=None, generators=None):
         """Do some setup after initialisation.
@@ -1049,7 +1077,15 @@ class SetComp(ComprehensionScope):
     :type: list(Comprehension) or None
     """
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         """
         :param lineno: The line that this node appears on in the source code.
         :type lineno: int or None
@@ -1067,7 +1103,13 @@ class SetComp(ComprehensionScope):
         :type: dict(str, NodeNG)
         """
 
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, elt=None, generators=None):
         """Do some setup after initialisation.
@@ -1158,14 +1200,28 @@ class ListComp(_ListComp, ComprehensionScope):
 
     _other_other_fields = ("locals",)
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         self.locals = {}
         """A map of the name of a local variable to the node defining it.
 
         :type: dict(str, NodeNG)
         """
 
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
 
 def _infer_decorator_callchain(node):
@@ -1235,7 +1291,15 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
                 return "method"
         return "function"
 
-    def __init__(self, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         """
         :param lineno: The line that this node appears on in the source code.
         :type lineno: int or None
@@ -1262,7 +1326,13 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         :type: list(NodeNG)
         """
 
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
 
     def postinit(self, args: Arguments, body):
         """Do some setup after initialisation.
@@ -1438,7 +1508,17 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
     )
     _type = None
 
-    def __init__(self, name=None, doc=None, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        name=None,
+        doc=None,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         """
         :param name: The name of the function.
         :type name: str or None
@@ -1469,7 +1549,13 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         """
 
         self.instance_attrs = {}
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
         if parent:
             frame = parent.frame()
             frame.set_local(name, self)
@@ -2052,7 +2138,17 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     _other_other_fields = ("locals", "_newstyle")
     _newstyle = None
 
-    def __init__(self, name=None, doc=None, lineno=None, col_offset=None, parent=None):
+    def __init__(
+        self,
+        name=None,
+        doc=None,
+        lineno=None,
+        col_offset=None,
+        parent=None,
+        *,
+        end_lineno=None,
+        end_col_offset=None,
+    ):
         """
         :param name: The name of the class.
         :type name: str or None
@@ -2109,7 +2205,13 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         :type doc: str or None
         """
 
-        super().__init__(lineno, col_offset, parent)
+        super().__init__(
+            lineno=lineno,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
         if parent is not None:
             parent.frame().set_local(name, self)
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1607,7 +1607,7 @@ class TreeRebuilder:
             if not isinstance(parent, nodes.ExceptHandler):
                 self._delayed_assattr.append(newnode)
         else:
-            if sys.version_info >= (3, 8):
+            if sys.version_info >= (3, 8):  # pylint: disable=else-if-used
                 newnode = nodes.Attribute(
                     attrname=node.attr,
                     lineno=node.lineno,
@@ -1859,7 +1859,7 @@ class TreeRebuilder:
                     node.id, node.lineno, node.col_offset, parent
                 )
         else:
-            if sys.version_info >= (3, 8):
+            if sys.version_info >= (3, 8):  # pylint: disable=else-if-used
                 newnode = nodes.Name(
                     name=node.id,
                     lineno=node.lineno,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -2120,7 +2120,6 @@ class TreeRebuilder:
 
     def visit_tryexcept(self, node: "ast.Try", parent: NodeNG) -> nodes.TryExcept:
         """visit a TryExcept node by returning a fresh instance of it"""
-        # TODO check lineno and col_offset
         if sys.version_info >= (3, 8):
             newnode = nodes.TryExcept(
                 lineno=node.lineno,
@@ -2143,7 +2142,6 @@ class TreeRebuilder:
     ) -> Union[nodes.TryExcept, nodes.TryFinally, None]:
         # python 3.3 introduce a new Try node replacing
         # TryFinally/TryExcept nodes
-        # TODO check lineno and col_offset
         if node.finalbody:
             if sys.version_info >= (3, 8):
                 newnode = nodes.TryFinally(
@@ -2168,7 +2166,6 @@ class TreeRebuilder:
 
     def visit_tryfinally(self, node: "ast.Try", parent: NodeNG) -> nodes.TryFinally:
         """visit a TryFinally node by returning a fresh instance of it"""
-        # TODO check lineno and col_offset
         if sys.version_info >= (3, 8):
             newnode = nodes.TryFinally(
                 lineno=node.lineno,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1607,7 +1607,9 @@ class TreeRebuilder:
             if not isinstance(parent, nodes.ExceptHandler):
                 self._delayed_assattr.append(newnode)
         else:
-            if sys.version_info >= (3, 8):  # pylint: disable=else-if-used
+            # pylint: disable-next=else-if-used
+            # Preserve symmetry with other cases
+            if sys.version_info >= (3, 8):
                 newnode = nodes.Attribute(
                     attrname=node.attr,
                     lineno=node.lineno,
@@ -1859,7 +1861,9 @@ class TreeRebuilder:
                     node.id, node.lineno, node.col_offset, parent
                 )
         else:
-            if sys.version_info >= (3, 8):  # pylint: disable=else-if-used
+            # pylint: disable-next=else-if-used
+            # Preserve symmetry with other cases
+            if sys.version_info >= (3, 8):
                 newnode = nodes.Name(
                     name=node.id,
                     lineno=node.lineno,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -47,7 +47,7 @@ from typing import (
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
-from astroid.const import PY37_PLUS, PY38_PLUS, PY39_PLUS, Context
+from astroid.const import PY37_PLUS, PY38_PLUS, Context
 from astroid.manager import AstroidManager
 from astroid.nodes import NodeNG
 
@@ -880,7 +880,16 @@ class TreeRebuilder:
 
     def visit_assert(self, node: "ast.Assert", parent: NodeNG) -> nodes.Assert:
         """visit a Assert node by returning a fresh instance of it"""
-        newnode = nodes.Assert(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Assert(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Assert(node.lineno, node.col_offset, parent)
         msg: Optional[NodeNG] = None
         if node.msg:
             msg = self.visit(node.msg, newnode)
@@ -953,7 +962,16 @@ class TreeRebuilder:
         return self._visit_for(nodes.AsyncFor, node, parent)
 
     def visit_await(self, node: "ast.Await", parent: NodeNG) -> nodes.Await:
-        newnode = nodes.Await(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Await(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Await(node.lineno, node.col_offset, parent)
         newnode.postinit(value=self.visit(node.value, newnode))
         return newnode
 
@@ -962,7 +980,16 @@ class TreeRebuilder:
 
     def visit_assign(self, node: "ast.Assign", parent: NodeNG) -> nodes.Assign:
         """visit a Assign node by returning a fresh instance of it"""
-        newnode = nodes.Assign(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Assign(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Assign(node.lineno, node.col_offset, parent)
         type_annotation = self.check_type_comment(node, parent=newnode)
         newnode.postinit(
             targets=[self.visit(child, newnode) for child in node.targets],
@@ -973,7 +1000,16 @@ class TreeRebuilder:
 
     def visit_annassign(self, node: "ast.AnnAssign", parent: NodeNG) -> nodes.AnnAssign:
         """visit an AnnAssign node by returning a fresh instance of it"""
-        newnode = nodes.AnnAssign(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.AnnAssign(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.AnnAssign(node.lineno, node.col_offset, parent)
         newnode.postinit(
             target=self.visit(node.target, newnode),
             annotation=self.visit(node.annotation, newnode),
@@ -1003,23 +1039,43 @@ class TreeRebuilder:
         """
         if node_name is None:
             return None
-        newnode = nodes.AssignName(
-            node_name,
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.AssignName(
+                name=node_name,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.AssignName(
+                node_name,
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         self._save_assignment(newnode)
         return newnode
 
     def visit_augassign(self, node: "ast.AugAssign", parent: NodeNG) -> nodes.AugAssign:
         """visit a AugAssign node by returning a fresh instance of it"""
-        newnode = nodes.AugAssign(
-            self._parser_module.bin_op_classes[type(node.op)] + "=",
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.AugAssign(
+                op=self._parser_module.bin_op_classes[type(node.op)] + "=",
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.AugAssign(
+                self._parser_module.bin_op_classes[type(node.op)] + "=",
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         newnode.postinit(
             self.visit(node.target, newnode), self.visit(node.value, newnode)
         )
@@ -1027,12 +1083,22 @@ class TreeRebuilder:
 
     def visit_binop(self, node: "ast.BinOp", parent: NodeNG) -> nodes.BinOp:
         """visit a BinOp node by returning a fresh instance of it"""
-        newnode = nodes.BinOp(
-            self._parser_module.bin_op_classes[type(node.op)],
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.BinOp(
+                op=self._parser_module.bin_op_classes[type(node.op)],
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.BinOp(
+                self._parser_module.bin_op_classes[type(node.op)],
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         newnode.postinit(
             self.visit(node.left, newnode), self.visit(node.right, newnode)
         )
@@ -1040,22 +1106,49 @@ class TreeRebuilder:
 
     def visit_boolop(self, node: "ast.BoolOp", parent: NodeNG) -> nodes.BoolOp:
         """visit a BoolOp node by returning a fresh instance of it"""
-        newnode = nodes.BoolOp(
-            self._parser_module.bool_op_classes[type(node.op)],
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.BoolOp(
+                op=self._parser_module.bool_op_classes[type(node.op)],
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.BoolOp(
+                self._parser_module.bool_op_classes[type(node.op)],
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         newnode.postinit([self.visit(child, newnode) for child in node.values])
         return newnode
 
     def visit_break(self, node: "ast.Break", parent: NodeNG) -> nodes.Break:
         """visit a Break node by returning a fresh instance of it"""
+        if sys.version_info >= (3, 8):
+            return nodes.Break(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
         return nodes.Break(node.lineno, node.col_offset, parent)
 
     def visit_call(self, node: "ast.Call", parent: NodeNG) -> nodes.Call:
         """visit a CallFunc node by returning a fresh instance of it"""
-        newnode = nodes.Call(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Call(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Call(node.lineno, node.col_offset, parent)
         newnode.postinit(
             func=self.visit(node.func, newnode),
             args=[self.visit(child, newnode) for child in node.args],
@@ -1068,7 +1161,20 @@ class TreeRebuilder:
     ) -> nodes.ClassDef:
         """visit a ClassDef node to become astroid"""
         node, doc = self._get_doc(node)
-        newnode = nodes.ClassDef(node.name, doc, node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.ClassDef(
+                name=node.name,
+                doc=doc,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.ClassDef(
+                node.name, doc, node.lineno, node.col_offset, parent
+            )
         metaclass = None
         for keyword in node.keywords:
             if keyword.arg == "metaclass":
@@ -1091,11 +1197,28 @@ class TreeRebuilder:
 
     def visit_continue(self, node: "ast.Continue", parent: NodeNG) -> nodes.Continue:
         """visit a Continue node by returning a fresh instance of it"""
+        if sys.version_info >= (3, 8):
+            return nodes.Continue(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
         return nodes.Continue(node.lineno, node.col_offset, parent)
 
     def visit_compare(self, node: "ast.Compare", parent: NodeNG) -> nodes.Compare:
         """visit a Compare node by returning a fresh instance of it"""
-        newnode = nodes.Compare(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Compare(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Compare(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.left, newnode),
             [
@@ -1134,18 +1257,37 @@ class TreeRebuilder:
             return None
         # /!\ node is actually an _ast.FunctionDef node while
         # parent is an astroid.nodes.FunctionDef node
-        if PY38_PLUS:
+        if sys.version_info >= (3, 8):
             # Set the line number of the first decorator for Python 3.8+.
             lineno = node.decorator_list[0].lineno
+            end_lineno = node.decorator_list[-1].end_lineno
+            end_col_offset = node.decorator_list[-1].end_col_offset
         else:
             lineno = node.lineno
-        newnode = nodes.Decorators(lineno, node.col_offset, parent)
+            end_lineno = None
+            end_col_offset = None
+        newnode = nodes.Decorators(
+            lineno=lineno,
+            col_offset=node.col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.decorator_list])
         return newnode
 
     def visit_delete(self, node: "ast.Delete", parent: NodeNG) -> nodes.Delete:
         """visit a Delete node by returning a fresh instance of it"""
-        newnode = nodes.Delete(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Delete(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Delete(node.lineno, node.col_offset, parent)
         newnode.postinit([self.visit(child, newnode) for child in node.targets])
         return newnode
 
@@ -1157,23 +1299,50 @@ class TreeRebuilder:
             rebuilt_value = self.visit(value, newnode)
             if not key:
                 # Extended unpacking
-                rebuilt_key = nodes.DictUnpack(
-                    rebuilt_value.lineno, rebuilt_value.col_offset, parent
-                )
+                if sys.version_info >= (3, 8):
+                    rebuilt_key = nodes.DictUnpack(
+                        lineno=rebuilt_value.lineno,
+                        col_offset=rebuilt_value.col_offset,
+                        end_lineno=rebuilt_value.end_lineno,
+                        end_col_offset=rebuilt_value.end_col_offset,
+                        parent=parent,
+                    )
+                else:
+                    rebuilt_key = nodes.DictUnpack(
+                        rebuilt_value.lineno, rebuilt_value.col_offset, parent
+                    )
             else:
                 rebuilt_key = self.visit(key, newnode)
             yield rebuilt_key, rebuilt_value
 
     def visit_dict(self, node: "ast.Dict", parent: NodeNG) -> nodes.Dict:
         """visit a Dict node by returning a fresh instance of it"""
-        newnode = nodes.Dict(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Dict(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Dict(node.lineno, node.col_offset, parent)
         items = list(self._visit_dict_items(node, parent, newnode))
         newnode.postinit(items)
         return newnode
 
     def visit_dictcomp(self, node: "ast.DictComp", parent: NodeNG) -> nodes.DictComp:
         """visit a DictComp node by returning a fresh instance of it"""
-        newnode = nodes.DictComp(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.DictComp(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.DictComp(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.key, newnode),
             self.visit(node.value, newnode),
@@ -1183,7 +1352,16 @@ class TreeRebuilder:
 
     def visit_expr(self, node: "ast.Expr", parent: NodeNG) -> nodes.Expr:
         """visit a Expr node by returning a fresh instance of it"""
-        newnode = nodes.Expr(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Expr(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Expr(node.lineno, node.col_offset, parent)
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
@@ -1201,7 +1379,16 @@ class TreeRebuilder:
         self, node: "ast.ExceptHandler", parent: NodeNG
     ) -> nodes.ExceptHandler:
         """visit an ExceptHandler node by returning a fresh instance of it"""
-        newnode = nodes.ExceptHandler(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.ExceptHandler(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.ExceptHandler(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.type, newnode),
             self.visit_assignname(node, newnode, node.name),
@@ -1234,7 +1421,16 @@ class TreeRebuilder:
         self, cls: Type[T_For], node: Union["ast.For", "ast.AsyncFor"], parent: NodeNG
     ) -> T_For:
         """visit a For node by returning a fresh instance of it"""
-        newnode = cls(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = cls(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = cls(node.lineno, node.col_offset, parent)
         type_annotation = self.check_type_comment(node, parent=newnode)
         newnode.postinit(
             target=self.visit(node.target, newnode),
@@ -1253,14 +1449,26 @@ class TreeRebuilder:
     ) -> nodes.ImportFrom:
         """visit an ImportFrom node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        newnode = nodes.ImportFrom(
-            node.module or "",
-            names,
-            node.level or None,
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.ImportFrom(
+                fromname=node.module or "",
+                names=names,
+                level=node.level or None,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.ImportFrom(
+                node.module or "",
+                names,
+                node.level or None,
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         # store From names to add them to locals after building
         self._import_from_nodes.append(newnode)
         return newnode
@@ -1301,7 +1509,18 @@ class TreeRebuilder:
             # the framework for *years*.
             lineno = node.decorator_list[0].lineno
 
-        newnode = cls(node.name, doc, lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = cls(
+                name=node.name,
+                doc=doc,
+                lineno=lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = cls(node.name, doc, lineno, node.col_offset, parent)
         decorators = self.visit_decorators(node, newnode)
         returns: Optional[NodeNG]
         if node.returns:
@@ -1333,7 +1552,16 @@ class TreeRebuilder:
         self, node: "ast.GeneratorExp", parent: NodeNG
     ) -> nodes.GeneratorExp:
         """visit a GeneratorExp node by returning a fresh instance of it"""
-        newnode = nodes.GeneratorExp(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.GeneratorExp(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.GeneratorExp(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.elt, newnode),
             [self.visit(child, newnode) for child in node.generators],
@@ -1349,25 +1577,69 @@ class TreeRebuilder:
         if context == Context.Del:
             # FIXME : maybe we should reintroduce and visit_delattr ?
             # for instance, deactivating assign_ctx
-            newnode = nodes.DelAttr(node.attr, node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.DelAttr(
+                    attrname=node.attr,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.DelAttr(node.attr, node.lineno, node.col_offset, parent)
         elif context == Context.Store:
-            newnode = nodes.AssignAttr(node.attr, node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.AssignAttr(
+                    attrname=node.attr,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.AssignAttr(
+                    node.attr, node.lineno, node.col_offset, parent
+                )
             # Prohibit a local save if we are in an ExceptHandler.
             if not isinstance(parent, nodes.ExceptHandler):
                 self._delayed_assattr.append(newnode)
         else:
-            newnode = nodes.Attribute(node.attr, node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.Attribute(
+                    attrname=node.attr,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.Attribute(
+                    node.attr, node.lineno, node.col_offset, parent
+                )
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_global(self, node: "ast.Global", parent: NodeNG) -> nodes.Global:
         """visit a Global node to become astroid"""
-        newnode = nodes.Global(
-            node.names,
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Global(
+                names=node.names,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Global(
+                node.names,
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         if self._global_names:  # global at the module level, no effect
             for name in node.names:
                 self._global_names[-1].setdefault(name, []).append(newnode)
@@ -1375,7 +1647,16 @@ class TreeRebuilder:
 
     def visit_if(self, node: "ast.If", parent: NodeNG) -> nodes.If:
         """visit an If node by returning a fresh instance of it"""
-        newnode = nodes.If(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.If(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.If(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.test, newnode),
             [self.visit(child, newnode) for child in node.body],
@@ -1385,7 +1666,16 @@ class TreeRebuilder:
 
     def visit_ifexp(self, node: "ast.IfExp", parent: NodeNG) -> nodes.IfExp:
         """visit a IfExp node by returning a fresh instance of it"""
-        newnode = nodes.IfExp(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.IfExp(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.IfExp(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.test, newnode),
             self.visit(node.body, newnode),
@@ -1396,12 +1686,22 @@ class TreeRebuilder:
     def visit_import(self, node: "ast.Import", parent: NodeNG) -> nodes.Import:
         """visit a Import node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        newnode = nodes.Import(
-            names,
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Import(
+                names=names,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Import(
+                names,
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         # save import names in parent's locals:
         for (name, asname) in newnode.names:
             name = asname or name
@@ -1409,14 +1709,32 @@ class TreeRebuilder:
         return newnode
 
     def visit_joinedstr(self, node: "ast.JoinedStr", parent: NodeNG) -> nodes.JoinedStr:
-        newnode = nodes.JoinedStr(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.JoinedStr(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.JoinedStr(node.lineno, node.col_offset, parent)
         newnode.postinit([self.visit(child, newnode) for child in node.values])
         return newnode
 
     def visit_formattedvalue(
         self, node: "ast.FormattedValue", parent: NodeNG
     ) -> nodes.FormattedValue:
-        newnode = nodes.FormattedValue(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.FormattedValue(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.FormattedValue(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.value, newnode),
             node.conversion,
@@ -1425,7 +1743,16 @@ class TreeRebuilder:
         return newnode
 
     def visit_namedexpr(self, node: "ast.NamedExpr", parent: NodeNG) -> nodes.NamedExpr:
-        newnode = nodes.NamedExpr(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.NamedExpr(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.NamedExpr(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.target, newnode), self.visit(node.value, newnode)
         )
@@ -1438,8 +1765,15 @@ class TreeRebuilder:
 
     def visit_keyword(self, node: "ast.keyword", parent: NodeNG) -> nodes.Keyword:
         """visit a Keyword node by returning a fresh instance of it"""
-        if PY39_PLUS:
-            newnode = nodes.Keyword(node.arg, node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 9):
+            newnode = nodes.Keyword(
+                arg=node.arg,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
         else:
             newnode = nodes.Keyword(node.arg, parent=parent)
         newnode.postinit(self.visit(node.value, newnode))
@@ -1454,15 +1788,37 @@ class TreeRebuilder:
     def visit_list(self, node: "ast.List", parent: NodeNG) -> nodes.List:
         """visit a List node by returning a fresh instance of it"""
         context = self._get_context(node)
-        newnode = nodes.List(
-            ctx=context, lineno=node.lineno, col_offset=node.col_offset, parent=parent
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.List(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.List(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                parent=parent,
+            )
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
     def visit_listcomp(self, node: "ast.ListComp", parent: NodeNG) -> nodes.ListComp:
         """visit a ListComp node by returning a fresh instance of it"""
-        newnode = nodes.ListComp(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.ListComp(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.ListComp(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.elt, newnode),
             [self.visit(child, newnode) for child in node.generators],
@@ -1476,11 +1832,43 @@ class TreeRebuilder:
         context = self._get_context(node)
         newnode: Union[nodes.Name, nodes.AssignName, nodes.DelName]
         if context == Context.Del:
-            newnode = nodes.DelName(node.id, node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.DelName(
+                    name=node.id,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.DelName(node.id, node.lineno, node.col_offset, parent)
         elif context == Context.Store:
-            newnode = nodes.AssignName(node.id, node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.AssignName(
+                    name=node.id,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.AssignName(
+                    node.id, node.lineno, node.col_offset, parent
+                )
         else:
-            newnode = nodes.Name(node.id, node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.Name(
+                    name=node.id,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.Name(node.id, node.lineno, node.col_offset, parent)
         # XXX REMOVE me :
         if context in (Context.Del, Context.Store):  # 'Aug' ??
             newnode = cast(Union[nodes.AssignName, nodes.DelName], newnode)
@@ -1501,6 +1889,15 @@ class TreeRebuilder:
 
     def visit_nonlocal(self, node: "ast.Nonlocal", parent: NodeNG) -> nodes.Nonlocal:
         """visit a Nonlocal node and return a new instance of it"""
+        if sys.version_info >= (3, 8):
+            return nodes.Nonlocal(
+                names=node.names,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
         return nodes.Nonlocal(
             node.names,
             node.lineno,
@@ -1510,6 +1907,16 @@ class TreeRebuilder:
 
     def visit_constant(self, node: "ast.Constant", parent: NodeNG) -> nodes.Const:
         """visit a Constant node by returning a fresh instance of Const"""
+        if sys.version_info >= (3, 8):
+            return nodes.Const(
+                value=node.value,
+                kind=node.kind,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
         return nodes.Const(
             node.value,
             node.lineno,
@@ -1545,11 +1952,28 @@ class TreeRebuilder:
 
     def visit_pass(self, node: "ast.Pass", parent: NodeNG) -> nodes.Pass:
         """visit a Pass node by returning a fresh instance of it"""
+        if sys.version_info >= (3, 8):
+            return nodes.Pass(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
         return nodes.Pass(node.lineno, node.col_offset, parent)
 
     def visit_raise(self, node: "ast.Raise", parent: NodeNG) -> nodes.Raise:
         """visit a Raise node by returning a fresh instance of it"""
-        newnode = nodes.Raise(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Raise(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Raise(node.lineno, node.col_offset, parent)
         # no traceback; anyway it is not used in Pylint
         newnode.postinit(
             exc=self.visit(node.exc, newnode),
@@ -1559,20 +1983,47 @@ class TreeRebuilder:
 
     def visit_return(self, node: "ast.Return", parent: NodeNG) -> nodes.Return:
         """visit a Return node by returning a fresh instance of it"""
-        newnode = nodes.Return(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Return(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Return(node.lineno, node.col_offset, parent)
         if node.value is not None:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_set(self, node: "ast.Set", parent: NodeNG) -> nodes.Set:
         """visit a Set node by returning a fresh instance of it"""
-        newnode = nodes.Set(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Set(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Set(node.lineno, node.col_offset, parent)
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
     def visit_setcomp(self, node: "ast.SetComp", parent: NodeNG) -> nodes.SetComp:
         """visit a SetComp node by returning a fresh instance of it"""
-        newnode = nodes.SetComp(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.SetComp(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.SetComp(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.elt, newnode),
             [self.visit(child, newnode) for child in node.generators],
@@ -1592,9 +2043,22 @@ class TreeRebuilder:
     def visit_subscript(self, node: "ast.Subscript", parent: NodeNG) -> nodes.Subscript:
         """visit a Subscript node by returning a fresh instance of it"""
         context = self._get_context(node)
-        newnode = nodes.Subscript(
-            ctx=context, lineno=node.lineno, col_offset=node.col_offset, parent=parent
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Subscript(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Subscript(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                parent=parent,
+            )
         newnode.postinit(
             self.visit(node.value, newnode), self.visit(node.slice, newnode)
         )
@@ -1603,15 +2067,37 @@ class TreeRebuilder:
     def visit_starred(self, node: "ast.Starred", parent: NodeNG) -> nodes.Starred:
         """visit a Starred node and return a new instance of it"""
         context = self._get_context(node)
-        newnode = nodes.Starred(
-            ctx=context, lineno=node.lineno, col_offset=node.col_offset, parent=parent
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Starred(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Starred(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                parent=parent,
+            )
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_tryexcept(self, node: "ast.Try", parent: NodeNG) -> nodes.TryExcept:
         """visit a TryExcept node by returning a fresh instance of it"""
-        newnode = nodes.TryExcept(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.TryExcept(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.TryExcept(node.lineno, node.col_offset, parent)
         newnode.postinit(
             [self.visit(child, newnode) for child in node.body],
             [self.visit(child, newnode) for child in node.handlers],
@@ -1625,7 +2111,16 @@ class TreeRebuilder:
         # python 3.3 introduce a new Try node replacing
         # TryFinally/TryExcept nodes
         if node.finalbody:
-            newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
+            if sys.version_info >= (3, 8):
+                newnode = nodes.TryFinally(
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                    end_lineno=node.end_lineno,
+                    end_col_offset=node.end_col_offset,
+                    parent=parent,
+                )
+            else:
+                newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
             body: Union[List[nodes.TryExcept], List[NodeNG]]
             if node.handlers:
                 body = [self.visit_tryexcept(node, newnode)]
@@ -1639,7 +2134,16 @@ class TreeRebuilder:
 
     def visit_tryfinally(self, node: "ast.Try", parent: NodeNG) -> nodes.TryFinally:
         """visit a TryFinally node by returning a fresh instance of it"""
-        newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.TryFinally(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
         newnode.postinit(
             [self.visit(child, newnode) for child in node.body],
             [self.visit(n, newnode) for n in node.finalbody],
@@ -1649,26 +2153,58 @@ class TreeRebuilder:
     def visit_tuple(self, node: "ast.Tuple", parent: NodeNG) -> nodes.Tuple:
         """visit a Tuple node by returning a fresh instance of it"""
         context = self._get_context(node)
-        newnode = nodes.Tuple(
-            ctx=context, lineno=node.lineno, col_offset=node.col_offset, parent=parent
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Tuple(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Tuple(
+                ctx=context,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                parent=parent,
+            )
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
     def visit_unaryop(self, node: "ast.UnaryOp", parent: NodeNG) -> nodes.UnaryOp:
         """visit a UnaryOp node by returning a fresh instance of it"""
-        newnode = nodes.UnaryOp(
-            self._parser_module.unary_op_classes[node.op.__class__],
-            node.lineno,
-            node.col_offset,
-            parent,
-        )
+        if sys.version_info >= (3, 8):
+            newnode = nodes.UnaryOp(
+                op=self._parser_module.unary_op_classes[node.op.__class__],
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.UnaryOp(
+                self._parser_module.unary_op_classes[node.op.__class__],
+                node.lineno,
+                node.col_offset,
+                parent,
+            )
         newnode.postinit(self.visit(node.operand, newnode))
         return newnode
 
     def visit_while(self, node: "ast.While", parent: NodeNG) -> nodes.While:
         """visit a While node by returning a fresh instance of it"""
-        newnode = nodes.While(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.While(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.While(node.lineno, node.col_offset, parent)
         newnode.postinit(
             self.visit(node.test, newnode),
             [self.visit(child, newnode) for child in node.body],
@@ -1694,7 +2230,16 @@ class TreeRebuilder:
         node: Union["ast.With", "ast.AsyncWith"],
         parent: NodeNG,
     ) -> T_With:
-        newnode = cls(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = cls(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = cls(node.lineno, node.col_offset, parent)
 
         def visit_child(child: "ast.withitem") -> Tuple[NodeNG, Optional[NodeNG]]:
             expr = self.visit(child.context_expr, newnode)
@@ -1714,13 +2259,31 @@ class TreeRebuilder:
 
     def visit_yield(self, node: "ast.Yield", parent: NodeNG) -> NodeNG:
         """visit a Yield node by returning a fresh instance of it"""
-        newnode = nodes.Yield(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Yield(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Yield(node.lineno, node.col_offset, parent)
         if node.value is not None:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_yieldfrom(self, node: "ast.YieldFrom", parent: NodeNG) -> NodeNG:
-        newnode = nodes.YieldFrom(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.YieldFrom(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.YieldFrom(node.lineno, node.col_offset, parent)
         if node.value is not None:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
@@ -1728,7 +2291,13 @@ class TreeRebuilder:
     if sys.version_info >= (3, 10):
 
         def visit_match(self, node: "ast.Match", parent: NodeNG) -> nodes.Match:
-            newnode = nodes.Match(node.lineno, node.col_offset, parent)
+            newnode = nodes.Match(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             newnode.postinit(
                 subject=self.visit(node.subject, newnode),
                 cases=[self.visit(case, newnode) for case in node.cases],
@@ -1749,7 +2318,13 @@ class TreeRebuilder:
         def visit_matchvalue(
             self, node: "ast.MatchValue", parent: NodeNG
         ) -> nodes.MatchValue:
-            newnode = nodes.MatchValue(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchValue(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             newnode.postinit(value=self.visit(node.value, newnode))
             return newnode
 
@@ -1760,13 +2335,21 @@ class TreeRebuilder:
                 value=node.value,
                 lineno=node.lineno,
                 col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
                 parent=parent,
             )
 
         def visit_matchsequence(
             self, node: "ast.MatchSequence", parent: NodeNG
         ) -> nodes.MatchSequence:
-            newnode = nodes.MatchSequence(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchSequence(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             newnode.postinit(
                 patterns=[self.visit(pattern, newnode) for pattern in node.patterns]
             )
@@ -1775,7 +2358,13 @@ class TreeRebuilder:
         def visit_matchmapping(
             self, node: "ast.MatchMapping", parent: NodeNG
         ) -> nodes.MatchMapping:
-            newnode = nodes.MatchMapping(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchMapping(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             # Add AssignName node for 'node.name'
             # https://bugs.python.org/issue43994
             newnode.postinit(
@@ -1788,7 +2377,13 @@ class TreeRebuilder:
         def visit_matchclass(
             self, node: "ast.MatchClass", parent: NodeNG
         ) -> nodes.MatchClass:
-            newnode = nodes.MatchClass(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchClass(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             newnode.postinit(
                 cls=self.visit(node.cls, newnode),
                 patterns=[self.visit(pattern, newnode) for pattern in node.patterns],
@@ -1802,14 +2397,26 @@ class TreeRebuilder:
         def visit_matchstar(
             self, node: "ast.MatchStar", parent: NodeNG
         ) -> nodes.MatchStar:
-            newnode = nodes.MatchStar(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchStar(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             # Add AssignName node for 'node.name'
             # https://bugs.python.org/issue43994
             newnode.postinit(name=self.visit_assignname(node, newnode, node.name))
             return newnode
 
         def visit_matchas(self, node: "ast.MatchAs", parent: NodeNG) -> nodes.MatchAs:
-            newnode = nodes.MatchAs(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchAs(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             # Add AssignName node for 'node.name'
             # https://bugs.python.org/issue43994
             newnode.postinit(
@@ -1819,7 +2426,13 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchor(self, node: "ast.MatchOr", parent: NodeNG) -> nodes.MatchOr:
-            newnode = nodes.MatchOr(node.lineno, node.col_offset, parent)
+            newnode = nodes.MatchOr(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
             newnode.postinit(
                 patterns=[self.visit(pattern, newnode) for pattern in node.patterns]
             )

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1401,6 +1401,7 @@ class TreeRebuilder:
         self, node: "ast.ExtSlice", parent: nodes.Subscript
     ) -> nodes.Tuple:
         """visit an ExtSlice node by returning a fresh instance of Tuple"""
+        # TODO: add line and column info?
         newnode = nodes.Tuple(ctx=Context.Load, parent=parent)
         newnode.postinit([self.visit(dim, newnode) for dim in node.dims])  # type: ignore[attr-defined]
         return newnode
@@ -2032,6 +2033,7 @@ class TreeRebuilder:
 
     def visit_slice(self, node: "ast.Slice", parent: nodes.Subscript) -> nodes.Slice:
         """visit a Slice node by returning a fresh instance of it"""
+        # TODO add lineno and col offset info?
         newnode = nodes.Slice(parent=parent)
         newnode.postinit(
             lower=self.visit(node.lower, newnode),
@@ -2088,6 +2090,7 @@ class TreeRebuilder:
 
     def visit_tryexcept(self, node: "ast.Try", parent: NodeNG) -> nodes.TryExcept:
         """visit a TryExcept node by returning a fresh instance of it"""
+        # TODO check lineno and col_offset
         if sys.version_info >= (3, 8):
             newnode = nodes.TryExcept(
                 lineno=node.lineno,
@@ -2110,6 +2113,7 @@ class TreeRebuilder:
     ) -> Union[nodes.TryExcept, nodes.TryFinally, None]:
         # python 3.3 introduce a new Try node replacing
         # TryFinally/TryExcept nodes
+        # TODO check lineno and col_offset
         if node.finalbody:
             if sys.version_info >= (3, 8):
                 newnode = nodes.TryFinally(
@@ -2134,6 +2138,7 @@ class TreeRebuilder:
 
     def visit_tryfinally(self, node: "ast.Try", parent: NodeNG) -> nodes.TryFinally:
         """visit a TryFinally node by returning a fresh instance of it"""
+        # TODO check lineno and col_offset
         if sys.version_info >= (3, 8):
             newnode = nodes.TryFinally(
                 lineno=node.lineno,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1784,7 +1784,16 @@ class TreeRebuilder:
 
     def visit_lambda(self, node: "ast.Lambda", parent: NodeNG) -> nodes.Lambda:
         """visit a Lambda node by returning a fresh instance of it"""
-        newnode = nodes.Lambda(node.lineno, node.col_offset, parent)
+        if sys.version_info >= (3, 8):
+            newnode = nodes.Lambda(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                end_lineno=node.end_lineno,
+                end_col_offset=node.end_col_offset,
+                parent=parent,
+            )
+        else:
+            newnode = nodes.Lambda(node.lineno, node.col_offset, parent)
         newnode.postinit(self.visit(node.args, newnode), self.visit(node.body, newnode))
         return newnode
 

--- a/tests/unittest_nodes_lineno.py
+++ b/tests/unittest_nodes_lineno.py
@@ -7,6 +7,34 @@ from astroid.const import PY38_PLUS, PY39_PLUS, PY310_PLUS
 
 
 @pytest.mark.skipif(
+    PY38_PLUS, reason="end_lineno and end_col_offset were added in PY38"
+)
+class TestEndLinenoNotSet:
+    """Test 'end_lineno' and 'end_col_offset' are initialized as 'None' for Python < 3.8."""
+
+    @staticmethod
+    def test_end_lineno_not_set() -> None:
+        code = textwrap.dedent(
+            """
+        [1, 2, 3]  #@
+        var  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 2
+
+        n1 = ast_nodes[0]
+        assert isinstance(n1, nodes.List)
+        assert (n1.lineno, n1.col_offset) == (1, 0)
+        assert (n1.end_lineno, n1.end_col_offset) == (None, None)
+
+        n2 = ast_nodes[1]
+        assert isinstance(n2, nodes.Name)
+        assert (n2.lineno, n2.col_offset) == (2, 0)
+        assert (n2.end_lineno, n2.end_col_offset) == (None, None)
+
+
+@pytest.mark.skipif(
     not PY38_PLUS, reason="end_lineno and end_col_offset were added in PY38"
 )
 class TestLinenoColOffset:
@@ -160,15 +188,17 @@ class TestLinenoColOffset:
         assert (c1.args[0].lineno, c1.args[0].col_offset) == (1, 5)
         assert (c1.args[0].end_lineno, c1.args[0].end_col_offset) == (1, 9)
 
+        # fmt: off
         if PY39_PLUS:
             # 'lineno' and 'col_offset' information only added in Python 3.9
             assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (1, 11)
             assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (1, 21)
+        else:
+            assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (None, None)
+            assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (None, None)
         assert (c1.keywords[0].value.lineno, c1.keywords[0].value.col_offset) == (1, 16)
-        assert (
-            c1.keywords[0].value.end_lineno,
-            c1.keywords[0].value.end_col_offset,
-        ) == (1, 21)
+        assert (c1.keywords[0].value.end_lineno, c1.keywords[0].value.end_col_offset) == (1, 21)
+        # fmt: on
 
     @staticmethod
     def test_end_lineno_assignment() -> None:
@@ -805,6 +835,9 @@ class TestLinenoColOffset:
             # 'lineno' and 'col_offset' information only added in Python 3.9
             assert (s3.slice.lineno, s3.slice.col_offset) == (3, 4)
             assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (3, 10)
+        else:
+            assert (s3.slice.lineno, s3.slice.col_offset) == (None, None)
+            assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (None, None)
 
     @staticmethod
     def test_end_lineno_import() -> None:
@@ -1171,6 +1204,7 @@ class TestLinenoColOffset:
         assert isinstance(c1.keywords[0], nodes.Keyword)
         assert isinstance(c1.body[0], nodes.Pass)
 
+        # fmt: off
         assert (c1.lineno, c1.col_offset) == (3, 0)
         assert (c1.end_lineno, c1.end_col_offset) == (4, 8)
         assert (c1.decorators.lineno, c1.decorators.col_offset) == (1, 0)
@@ -1181,5 +1215,9 @@ class TestLinenoColOffset:
             # 'lineno' and 'col_offset' information only added in Python 3.9
             assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (3, 16)
             assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (3, 22)
+        else:
+            assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (None, None)
+            assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (None, None)
         assert (c1.body[0].lineno, c1.body[0].col_offset) == (4, 4)
         assert (c1.body[0].end_lineno, c1.body[0].end_col_offset) == (4, 8)
+        # fmt: on

--- a/tests/unittest_nodes_lineno.py
+++ b/tests/unittest_nodes_lineno.py
@@ -1,0 +1,1141 @@
+import textwrap
+
+import pytest
+
+from astroid import builder, nodes
+from astroid.const import PY38_PLUS
+
+
+@pytest.mark.skipif(
+    not PY38_PLUS, reason="end_lineno and end_col_offset were added in PY38"
+)
+class TestLinenoColOffset:
+    """Test 'lineno', 'col_offset', 'end_lineno', and 'end_col_offset' for all nodes."""
+
+    @staticmethod
+    def test_end_lineno_container() -> None:
+        """Container nodes: List, Tuple, Set."""
+        code = textwrap.dedent(
+            """
+        [1, 2, 3]  #@
+        [  #@
+            1, 2, 3
+        ]
+        (1, 2, 3)  #@
+        {1, 2, 3}  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 4
+
+        c1 = ast_nodes[0]
+        assert isinstance(c1, nodes.List)
+        assert (c1.lineno, c1.col_offset) == (1, 0)
+        assert (c1.end_lineno, c1.end_col_offset) == (1, 9)
+
+        c2 = ast_nodes[1]
+        assert isinstance(c2, nodes.List)
+        assert (c2.lineno, c2.col_offset) == (2, 0)
+        assert (c2.end_lineno, c2.end_col_offset) == (4, 1)
+
+        c3 = ast_nodes[2]
+        assert isinstance(c3, nodes.Tuple)
+        assert (c3.lineno, c3.col_offset) == (5, 0)
+        assert (c3.end_lineno, c3.end_col_offset) == (5, 9)
+
+        c4 = ast_nodes[3]
+        assert isinstance(c4, nodes.Set)
+        assert (c4.lineno, c4.col_offset) == (6, 0)
+        assert (c4.end_lineno, c4.end_col_offset) == (6, 9)
+
+    @staticmethod
+    def test_end_lineno_name() -> None:
+        """Name, Assign, AssignName, Delete, DelName."""
+        code = textwrap.dedent(
+            """
+        var = 42  #@
+        var  #@
+        del var  #@
+
+        var2 = (  #@
+            1, 2, 3
+        )
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 4
+
+        n1 = ast_nodes[0]
+        assert isinstance(n1, nodes.Assign)
+        assert isinstance(n1.targets[0], nodes.AssignName)
+        assert isinstance(n1.value, nodes.Const)
+        assert (n1.lineno, n1.col_offset) == (1, 0)
+        assert (n1.end_lineno, n1.end_col_offset) == (1, 8)
+        assert (n1.targets[0].lineno, n1.targets[0].col_offset) == (1, 0)
+        assert (n1.targets[0].end_lineno, n1.targets[0].end_col_offset) == (1, 3)
+        assert (n1.value.lineno, n1.value.col_offset) == (1, 6)
+        assert (n1.value.end_lineno, n1.value.end_col_offset) == (1, 8)
+
+        n2 = ast_nodes[1]
+        assert isinstance(n2, nodes.Name)
+        assert (n2.lineno, n2.col_offset) == (2, 0)
+        assert (n2.end_lineno, n2.end_col_offset) == (2, 3)
+
+        n3 = ast_nodes[2]
+        assert isinstance(n3, nodes.Delete) and isinstance(n3.targets[0], nodes.DelName)
+        assert (n3.lineno, n3.col_offset) == (3, 0)
+        assert (n3.end_lineno, n3.end_col_offset) == (3, 7)
+        assert (n3.targets[0].lineno, n3.targets[0].col_offset) == (3, 4)
+        assert (n3.targets[0].end_lineno, n3.targets[0].end_col_offset) == (3, 7)
+
+        n4 = ast_nodes[3]
+        assert isinstance(n4, nodes.Assign)
+        assert isinstance(n4.targets[0], nodes.AssignName)
+        assert (n4.lineno, n4.col_offset) == (5, 0)
+        assert (n4.end_lineno, n4.end_col_offset) == (7, 1)
+        assert (n4.targets[0].lineno, n4.targets[0].col_offset) == (5, 0)
+        assert (n4.targets[0].end_lineno, n4.targets[0].end_col_offset) == (5, 4)
+
+    @staticmethod
+    def test_end_lineno_attribute() -> None:
+        """Attribute, AssignAttr, DelAttr."""
+        code = textwrap.dedent(
+            """
+        class X:
+            var = 42
+
+        X.var2 = 2  #@
+        X.var2  #@
+        del X.var2  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 3
+
+        a1 = ast_nodes[0]
+        assert isinstance(a1, nodes.Assign)
+        assert isinstance(a1.targets[0], nodes.AssignAttr)
+        assert isinstance(a1.value, nodes.Const)
+        assert (a1.lineno, a1.col_offset) == (4, 0)
+        assert (a1.end_lineno, a1.end_col_offset) == (4, 10)
+        assert (a1.targets[0].lineno, a1.targets[0].col_offset) == (4, 0)
+        assert (a1.targets[0].end_lineno, a1.targets[0].end_col_offset) == (4, 6)
+        assert (a1.value.lineno, a1.value.col_offset) == (4, 9)
+        assert (a1.value.end_lineno, a1.value.end_col_offset) == (4, 10)
+
+        a2 = ast_nodes[1]
+        assert isinstance(a2, nodes.Attribute) and isinstance(a2.expr, nodes.Name)
+        assert (a2.lineno, a2.col_offset) == (5, 0)
+        assert (a2.end_lineno, a2.end_col_offset) == (5, 6)
+        assert (a2.expr.lineno, a2.expr.col_offset) == (5, 0)
+        assert (a2.expr.end_lineno, a2.expr.end_col_offset) == (5, 1)
+
+        a3 = ast_nodes[2]
+        assert isinstance(a3, nodes.Delete) and isinstance(a3.targets[0], nodes.DelAttr)
+        assert (a3.lineno, a3.col_offset) == (6, 0)
+        assert (a3.end_lineno, a3.end_col_offset) == (6, 10)
+        assert (a3.targets[0].lineno, a3.targets[0].col_offset) == (6, 4)
+        assert (a3.targets[0].end_lineno, a3.targets[0].end_col_offset) == (6, 10)
+
+    @staticmethod
+    def test_end_lineno_call() -> None:
+        """Call, Keyword."""
+        code = textwrap.dedent(
+            """
+        func(arg1, arg2=value)  #@
+        """
+        ).strip()
+        c1 = builder.extract_node(code)
+        assert isinstance(c1, nodes.Call)
+        assert isinstance(c1.func, nodes.Name)
+        assert isinstance(c1.args[0], nodes.Name)
+        assert isinstance(c1.keywords[0], nodes.Keyword)
+        assert isinstance(c1.keywords[0].value, nodes.Name)
+
+        assert (c1.lineno, c1.col_offset) == (1, 0)
+        assert (c1.end_lineno, c1.end_col_offset) == (1, 22)
+        assert (c1.func.lineno, c1.func.col_offset) == (1, 0)
+        assert (c1.func.end_lineno, c1.func.end_col_offset) == (1, 4)
+
+        assert (c1.args[0].lineno, c1.args[0].col_offset) == (1, 5)
+        assert (c1.args[0].end_lineno, c1.args[0].end_col_offset) == (1, 9)
+
+        assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (1, 11)
+        assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (1, 21)
+        assert (c1.keywords[0].value.lineno, c1.keywords[0].value.col_offset) == (1, 16)
+        assert (
+            c1.keywords[0].value.end_lineno,
+            c1.keywords[0].value.end_col_offset,
+        ) == (1, 21)
+
+    @staticmethod
+    def test_end_lineno_assignment() -> None:
+        """Assign, AnnAssign, AugAssign."""
+        code = textwrap.dedent(
+            """
+        var = 2  #@
+        var2: int = 2  #@
+        var3 += 2  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 3
+
+        a1 = ast_nodes[0]
+        assert isinstance(a1, nodes.Assign)
+        assert isinstance(a1.targets[0], nodes.AssignName)
+        assert isinstance(a1.value, nodes.Const)
+        assert (a1.lineno, a1.col_offset) == (1, 0)
+        assert (a1.end_lineno, a1.end_col_offset) == (1, 7)
+        assert (a1.targets[0].lineno, a1.targets[0].col_offset) == (1, 0)
+        assert (a1.targets[0].end_lineno, a1.targets[0].end_col_offset) == (1, 3)
+        assert (a1.value.lineno, a1.value.col_offset) == (1, 6)
+        assert (a1.value.end_lineno, a1.value.end_col_offset) == (1, 7)
+
+        a2 = ast_nodes[1]
+        assert isinstance(a2, nodes.AnnAssign)
+        assert isinstance(a2.target, nodes.AssignName)
+        assert isinstance(a2.annotation, nodes.Name)
+        assert isinstance(a2.value, nodes.Const)
+        assert (a2.lineno, a2.col_offset) == (2, 0)
+        assert (a2.end_lineno, a2.end_col_offset) == (2, 13)
+        assert (a2.target.lineno, a2.target.col_offset) == (2, 0)
+        assert (a2.target.end_lineno, a2.target.end_col_offset) == (2, 4)
+        assert (a2.annotation.lineno, a2.annotation.col_offset) == (2, 6)
+        assert (a2.annotation.end_lineno, a2.annotation.end_col_offset) == (2, 9)
+        assert (a2.value.lineno, a2.value.col_offset) == (2, 12)
+        assert (a2.value.end_lineno, a2.value.end_col_offset) == (2, 13)
+
+        a3 = ast_nodes[2]
+        assert isinstance(a3, nodes.AugAssign)
+        assert isinstance(a3.target, nodes.AssignName)
+        assert isinstance(a3.value, nodes.Const)
+        assert (a3.lineno, a3.col_offset) == (3, 0)
+        assert (a3.end_lineno, a3.end_col_offset) == (3, 9)
+        assert (a3.target.lineno, a3.target.col_offset) == (3, 0)
+        assert (a3.target.end_lineno, a3.target.end_col_offset) == (3, 4)
+        assert (a3.value.lineno, a3.value.col_offset) == (3, 8)
+        assert (a3.value.end_lineno, a3.value.end_col_offset) == (3, 9)
+
+    @staticmethod
+    def test_end_lineno_mix_stmts() -> None:
+        """Assert, Break, Continue, Global, Nonlocal, Pass, Raise, Return, Expr."""
+        code = textwrap.dedent(
+            """
+        assert True, "Some message"  #@
+        break  #@
+        continue  #@
+        global var  #@
+        nonlocal var  #@
+        pass  #@
+        raise Exception from ex  #@
+        return 42  #@
+        var  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 9
+
+        s1 = ast_nodes[0]
+        assert isinstance(s1, nodes.Assert)
+        assert isinstance(s1.test, nodes.Const)
+        assert isinstance(s1.fail, nodes.Const)
+        assert (s1.lineno, s1.col_offset) == (1, 0)
+        assert (s1.end_lineno, s1.end_col_offset) == (1, 27)
+        assert (s1.test.lineno, s1.test.col_offset) == (1, 7)
+        assert (s1.test.end_lineno, s1.test.end_col_offset) == (1, 11)
+        assert (s1.fail.lineno, s1.fail.col_offset) == (1, 13)
+        assert (s1.fail.end_lineno, s1.fail.end_col_offset) == (1, 27)
+
+        s2 = ast_nodes[1]
+        assert isinstance(s2, nodes.Break)
+        assert (s2.lineno, s2.col_offset) == (2, 0)
+        assert (s2.end_lineno, s2.end_col_offset) == (2, 5)
+
+        s3 = ast_nodes[2]
+        assert isinstance(s3, nodes.Continue)
+        assert (s3.lineno, s3.col_offset) == (3, 0)
+        assert (s3.end_lineno, s3.end_col_offset) == (3, 8)
+
+        s4 = ast_nodes[3]
+        assert isinstance(s4, nodes.Global)
+        assert (s4.lineno, s4.col_offset) == (4, 0)
+        assert (s4.end_lineno, s4.end_col_offset) == (4, 10)
+
+        s5 = ast_nodes[4]
+        assert isinstance(s5, nodes.Nonlocal)
+        assert (s5.lineno, s5.col_offset) == (5, 0)
+        assert (s5.end_lineno, s5.end_col_offset) == (5, 12)
+
+        s6 = ast_nodes[5]
+        assert isinstance(s6, nodes.Pass)
+        assert (s6.lineno, s6.col_offset) == (6, 0)
+        assert (s6.end_lineno, s6.end_col_offset) == (6, 4)
+
+        s7 = ast_nodes[6]
+        assert isinstance(s7, nodes.Raise)
+        assert isinstance(s7.exc, nodes.Name)
+        assert isinstance(s7.cause, nodes.Name)
+        assert (s7.lineno, s7.col_offset) == (7, 0)
+        assert (s7.end_lineno, s7.end_col_offset) == (7, 23)
+        assert (s7.exc.lineno, s7.exc.col_offset) == (7, 6)
+        assert (s7.exc.end_lineno, s7.exc.end_col_offset) == (7, 15)
+        assert (s7.cause.lineno, s7.cause.col_offset) == (7, 21)
+        assert (s7.cause.end_lineno, s7.cause.end_col_offset) == (7, 23)
+
+        s8 = ast_nodes[7]
+        assert isinstance(s8, nodes.Return)
+        assert isinstance(s8.value, nodes.Const)
+        assert (s8.lineno, s8.col_offset) == (8, 0)
+        assert (s8.end_lineno, s8.end_col_offset) == (8, 9)
+        assert (s8.value.lineno, s8.value.col_offset) == (8, 7)
+        assert (s8.value.end_lineno, s8.value.end_col_offset) == (8, 9)
+
+        s9 = ast_nodes[8].parent
+        assert isinstance(s9, nodes.Expr)
+        assert isinstance(s9.value, nodes.Name)
+        assert (s9.lineno, s9.col_offset) == (9, 0)
+        assert (s9.end_lineno, s9.end_col_offset) == (9, 3)
+        assert (s9.value.lineno, s9.value.col_offset) == (9, 0)
+        assert (s9.value.end_lineno, s9.value.end_col_offset) == (9, 3)
+
+    @staticmethod
+    def test_end_lineno_mix_nodes() -> None:
+        """Await, Starred, Yield, YieldFrom."""
+        code = textwrap.dedent(
+            """
+        await func  #@
+        *args  #@
+        yield 42  #@
+        yield from (1, 2)  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 4
+
+        n1 = ast_nodes[0]
+        assert isinstance(n1, nodes.Await)
+        assert isinstance(n1.value, nodes.Name)
+        assert (n1.lineno, n1.col_offset) == (1, 0)
+        assert (n1.end_lineno, n1.end_col_offset) == (1, 10)
+        assert (n1.value.lineno, n1.value.col_offset) == (1, 6)
+        assert (n1.value.end_lineno, n1.value.end_col_offset) == (1, 10)
+
+        n2 = ast_nodes[1]
+        assert isinstance(n2, nodes.Starred)
+        assert isinstance(n2.value, nodes.Name)
+        assert (n2.lineno, n2.col_offset) == (2, 0)
+        assert (n2.end_lineno, n2.end_col_offset) == (2, 5)
+        assert (n2.value.lineno, n2.value.col_offset) == (2, 1)
+        assert (n2.value.end_lineno, n2.value.end_col_offset) == (2, 5)
+
+        n3 = ast_nodes[2]
+        assert isinstance(n3, nodes.Yield)
+        assert isinstance(n3.value, nodes.Const)
+        assert (n3.lineno, n3.col_offset) == (3, 0)
+        assert (n3.end_lineno, n3.end_col_offset) == (3, 8)
+        assert (n3.value.lineno, n3.value.col_offset) == (3, 6)
+        assert (n3.value.end_lineno, n3.value.end_col_offset) == (3, 8)
+
+        n4 = ast_nodes[3]
+        assert isinstance(n4, nodes.YieldFrom)
+        assert isinstance(n4.value, nodes.Tuple)
+        assert (n4.lineno, n4.col_offset) == (4, 0)
+        assert (n4.end_lineno, n4.end_col_offset) == (4, 17)
+        assert (n4.value.lineno, n4.value.col_offset) == (4, 11)
+        assert (n4.value.end_lineno, n4.value.end_col_offset) == (4, 17)
+
+    @staticmethod
+    def test_end_lineno_ops() -> None:
+        """BinOp, BoolOp, UnaryOp, Compare."""
+        code = textwrap.dedent(
+            """
+        x + y  #@
+        a and b  #@
+        -var  #@
+        a < b  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 4
+
+        o1 = ast_nodes[0]
+        assert isinstance(o1, nodes.BinOp)
+        assert isinstance(o1.left, nodes.Name)
+        assert isinstance(o1.right, nodes.Name)
+        assert (o1.lineno, o1.col_offset) == (1, 0)
+        assert (o1.end_lineno, o1.end_col_offset) == (1, 5)
+        assert (o1.left.lineno, o1.left.col_offset) == (1, 0)
+        assert (o1.left.end_lineno, o1.left.end_col_offset) == (1, 1)
+        assert (o1.right.lineno, o1.right.col_offset) == (1, 4)
+        assert (o1.right.end_lineno, o1.right.end_col_offset) == (1, 5)
+
+        o2 = ast_nodes[1]
+        assert isinstance(o2, nodes.BoolOp)
+        assert isinstance(o2.values[0], nodes.Name)
+        assert isinstance(o2.values[1], nodes.Name)
+        assert (o2.lineno, o2.col_offset) == (2, 0)
+        assert (o2.end_lineno, o2.end_col_offset) == (2, 7)
+        assert (o2.values[0].lineno, o2.values[0].col_offset) == (2, 0)
+        assert (o2.values[0].end_lineno, o2.values[0].end_col_offset) == (2, 1)
+        assert (o2.values[1].lineno, o2.values[1].col_offset) == (2, 6)
+        assert (o2.values[1].end_lineno, o2.values[1].end_col_offset) == (2, 7)
+
+        o3 = ast_nodes[2]
+        assert isinstance(o3, nodes.UnaryOp)
+        assert isinstance(o3.operand, nodes.Name)
+        assert (o3.lineno, o3.col_offset) == (3, 0)
+        assert (o3.end_lineno, o3.end_col_offset) == (3, 4)
+        assert (o3.operand.lineno, o3.operand.col_offset) == (3, 1)
+        assert (o3.operand.end_lineno, o3.operand.end_col_offset) == (3, 4)
+
+        o4 = ast_nodes[3]
+        assert isinstance(o4, nodes.Compare)
+        assert isinstance(o4.left, nodes.Name)
+        assert isinstance(o4.ops[0][1], nodes.Name)
+        assert (o4.lineno, o4.col_offset) == (4, 0)
+        assert (o4.end_lineno, o4.end_col_offset) == (4, 5)
+        assert (o4.left.lineno, o4.left.col_offset) == (4, 0)
+        assert (o4.left.end_lineno, o4.left.end_col_offset) == (4, 1)
+        assert (o4.ops[0][1].lineno, o4.ops[0][1].col_offset) == (4, 4)
+        assert (o4.ops[0][1].end_lineno, o4.ops[0][1].end_col_offset) == (4, 5)
+
+    @staticmethod
+    def test_end_lineno_if() -> None:
+        """If, IfExp, NamedExpr."""
+        code = textwrap.dedent(
+            """
+        if (  #@
+            var := 2  #@
+        ):
+            pass
+        else:
+            pass
+
+        2 if True else 1  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 3
+
+        i1 = ast_nodes[0]
+        assert isinstance(i1, nodes.If)
+        assert isinstance(i1.test, nodes.NamedExpr)
+        assert isinstance(i1.body[0], nodes.Pass)
+        assert isinstance(i1.orelse[0], nodes.Pass)
+        assert (i1.lineno, i1.col_offset) == (1, 0)
+        assert (i1.end_lineno, i1.end_col_offset) == (6, 8)
+        assert (i1.test.lineno, i1.test.col_offset) == (2, 4)
+        assert (i1.test.end_lineno, i1.test.end_col_offset) == (2, 12)
+        assert (i1.body[0].lineno, i1.body[0].col_offset) == (4, 4)
+        assert (i1.body[0].end_lineno, i1.body[0].end_col_offset) == (4, 8)
+        assert (i1.orelse[0].lineno, i1.orelse[0].col_offset) == (6, 4)
+        assert (i1.orelse[0].end_lineno, i1.orelse[0].end_col_offset) == (6, 8)
+
+        i2 = ast_nodes[1]
+        assert isinstance(i2, nodes.NamedExpr)
+        assert isinstance(i2.target, nodes.AssignName)
+        assert isinstance(i2.value, nodes.Const)
+        assert (i2.lineno, i2.col_offset) == (2, 4)
+        assert (i2.end_lineno, i2.end_col_offset) == (2, 12)
+        assert (i2.target.lineno, i2.target.col_offset) == (2, 4)
+        assert (i2.target.end_lineno, i2.target.end_col_offset) == (2, 7)
+        assert (i2.value.lineno, i2.value.col_offset) == (2, 11)
+        assert (i2.value.end_lineno, i2.value.end_col_offset) == (2, 12)
+
+        i3 = ast_nodes[2]
+        assert isinstance(i3, nodes.IfExp)
+        assert isinstance(i3.test, nodes.Const)
+        assert isinstance(i3.body, nodes.Const)
+        assert isinstance(i3.orelse, nodes.Const)
+        assert (i3.lineno, i3.col_offset) == (8, 0)
+        assert (i3.end_lineno, i3.end_col_offset) == (8, 16)
+        assert (i3.test.lineno, i3.test.col_offset) == (8, 5)
+        assert (i3.test.end_lineno, i3.test.end_col_offset) == (8, 9)
+        assert (i3.body.lineno, i3.body.col_offset) == (8, 0)
+        assert (i3.body.end_lineno, i3.body.end_col_offset) == (8, 1)
+        assert (i3.orelse.lineno, i3.orelse.col_offset) == (8, 15)
+        assert (i3.orelse.end_lineno, i3.orelse.end_col_offset) == (8, 16)
+
+    @staticmethod
+    def test_end_lineno_for() -> None:
+        """For, AsyncFor."""
+        code = textwrap.dedent(
+            """
+        for i in lst:  #@
+            pass
+        else:
+            pass
+
+        async for i in lst:  #@
+            pass
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 2
+
+        f1 = ast_nodes[0]
+        assert isinstance(f1, nodes.For)
+        assert isinstance(f1.target, nodes.AssignName)
+        assert isinstance(f1.iter, nodes.Name)
+        assert isinstance(f1.body[0], nodes.Pass)
+        assert isinstance(f1.orelse[0], nodes.Pass)
+        assert (f1.lineno, f1.col_offset) == (1, 0)
+        assert (f1.end_lineno, f1.end_col_offset) == (4, 8)
+        assert (f1.target.lineno, f1.target.col_offset) == (1, 4)
+        assert (f1.target.end_lineno, f1.target.end_col_offset) == (1, 5)
+        assert (f1.iter.lineno, f1.iter.col_offset) == (1, 9)
+        assert (f1.iter.end_lineno, f1.iter.end_col_offset) == (1, 12)
+        assert (f1.body[0].lineno, f1.body[0].col_offset) == (2, 4)
+        assert (f1.body[0].end_lineno, f1.body[0].end_col_offset) == (2, 8)
+        assert (f1.orelse[0].lineno, f1.orelse[0].col_offset) == (4, 4)
+        assert (f1.orelse[0].end_lineno, f1.orelse[0].end_col_offset) == (4, 8)
+
+        f2 = ast_nodes[1]
+        assert isinstance(f2, nodes.AsyncFor)
+        assert isinstance(f2.target, nodes.AssignName)
+        assert isinstance(f2.iter, nodes.Name)
+        assert isinstance(f2.body[0], nodes.Pass)
+        assert (f2.lineno, f2.col_offset) == (6, 0)
+        assert (f2.end_lineno, f2.end_col_offset) == (7, 8)
+        assert (f2.target.lineno, f2.target.col_offset) == (6, 10)
+        assert (f2.target.end_lineno, f2.target.end_col_offset) == (6, 11)
+        assert (f2.iter.lineno, f2.iter.col_offset) == (6, 15)
+        assert (f2.iter.end_lineno, f2.iter.end_col_offset) == (6, 18)
+        assert (f2.body[0].lineno, f2.body[0].col_offset) == (7, 4)
+        assert (f2.body[0].end_lineno, f2.body[0].end_col_offset) == (7, 8)
+
+    @staticmethod
+    def test_end_lineno_const() -> None:
+        """Const (int, str, bool, None, bytes, ellipsis)."""
+        code = textwrap.dedent(
+            """
+        2  #@
+        "Hello"  #@
+        True  #@
+        None  #@
+        b"01"  #@
+        ...  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 6
+
+        c1 = ast_nodes[0]
+        assert isinstance(c1, nodes.Const)
+        assert (c1.lineno, c1.col_offset) == (1, 0)
+        assert (c1.end_lineno, c1.end_col_offset) == (1, 1)
+
+        c2 = ast_nodes[1]
+        assert isinstance(c2, nodes.Const)
+        assert (c2.lineno, c2.col_offset) == (2, 0)
+        assert (c2.end_lineno, c2.end_col_offset) == (2, 7)
+
+        c3 = ast_nodes[2]
+        assert isinstance(c3, nodes.Const)
+        assert (c3.lineno, c3.col_offset) == (3, 0)
+        assert (c3.end_lineno, c3.end_col_offset) == (3, 4)
+
+        c4 = ast_nodes[3]
+        assert isinstance(c4, nodes.Const)
+        assert (c4.lineno, c4.col_offset) == (4, 0)
+        assert (c4.end_lineno, c4.end_col_offset) == (4, 4)
+
+        c5 = ast_nodes[4]
+        assert isinstance(c5, nodes.Const)
+        assert (c5.lineno, c5.col_offset) == (5, 0)
+        assert (c5.end_lineno, c5.end_col_offset) == (5, 5)
+
+        c6 = ast_nodes[5]
+        assert isinstance(c6, nodes.Const)
+        assert (c6.lineno, c6.col_offset) == (6, 0)
+        assert (c6.end_lineno, c6.end_col_offset) == (6, 3)
+
+    @staticmethod
+    def test_end_lineno_function() -> None:
+        """FunctionDef, AsyncFunctionDef, Decorators, Lambda, Arguments."""
+        code = textwrap.dedent(
+            """
+        def func(  #@
+            a: int = 0, /,
+            var: int = 1, *args: Any,
+            keyword: int = 2, **kwargs: Any
+        ) -> None:
+            pass
+
+        @decorator1
+        @decorator2
+        async def func():  #@
+            pass
+
+        lambda x: 2  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 3
+
+        # fmt: off
+        f1 = ast_nodes[0]
+        assert isinstance(f1, nodes.FunctionDef)
+        assert isinstance(f1.args, nodes.Arguments)
+        assert isinstance(f1.returns, nodes.Const)
+        assert isinstance(f1.body[0], nodes.Pass)
+        assert (f1.lineno, f1.col_offset) == (1, 0)
+        assert (f1.end_lineno, f1.end_col_offset) == (6, 8)
+        assert (f1.returns.lineno, f1.returns.col_offset) == (5, 5)
+        assert (f1.returns.end_lineno, f1.returns.end_col_offset) == (5, 9)
+        assert (f1.body[0].lineno, f1.body[0].col_offset) == (6, 4)
+        assert (f1.body[0].end_lineno, f1.body[0].end_col_offset) == (6, 8)
+
+        # pos only arguments
+        assert isinstance(f1.args.posonlyargs[0], nodes.AssignName)
+        assert (f1.args.posonlyargs[0].lineno, f1.args.posonlyargs[0].col_offset) == (2, 4)
+        assert (f1.args.posonlyargs[0].end_lineno, f1.args.posonlyargs[0].end_col_offset) == (2, 10)
+        assert isinstance(f1.args.posonlyargs_annotations[0], nodes.Name)
+        assert (
+            f1.args.posonlyargs_annotations[0].lineno, f1.args.posonlyargs_annotations[0].col_offset
+        ) == (2, 7)
+        assert (
+            f1.args.posonlyargs_annotations[0].end_lineno, f1.args.posonlyargs_annotations[0].end_col_offset
+        ) == (2, 10)
+        assert (f1.args.defaults[0].lineno, f1.args.defaults[0].col_offset) == (2, 13)
+        assert (f1.args.defaults[0].end_lineno, f1.args.defaults[0].end_col_offset) == (2, 14)
+
+        # pos or kw arguments
+        assert isinstance(f1.args.args[0], nodes.AssignName)
+        assert (f1.args.args[0].lineno, f1.args.args[0].col_offset) == (3, 4)
+        assert (f1.args.args[0].end_lineno, f1.args.args[0].end_col_offset) == (3, 12)
+        assert isinstance(f1.args.annotations[0], nodes.Name)
+        assert (f1.args.annotations[0].lineno, f1.args.annotations[0].col_offset) == (3, 9)
+        assert (f1.args.annotations[0].end_lineno, f1.args.annotations[0].end_col_offset) == (3, 12)
+        assert isinstance(f1.args.defaults[1], nodes.Const)
+        assert (f1.args.defaults[1].lineno, f1.args.defaults[1].col_offset) == (3, 15)
+        assert (f1.args.defaults[1].end_lineno, f1.args.defaults[1].end_col_offset) == (3, 16)
+
+        # *args
+        assert isinstance(f1.args.varargannotation, nodes.Name)
+        assert (f1.args.varargannotation.lineno, f1.args.varargannotation.col_offset) == (3, 25)
+        assert (f1.args.varargannotation.end_lineno, f1.args.varargannotation.end_col_offset) == (3, 28)
+
+        # kw_only arguments
+        assert isinstance(f1.args.kwonlyargs[0], nodes.AssignName)
+        assert (f1.args.kwonlyargs[0].lineno, f1.args.kwonlyargs[0].col_offset) == (4, 4)
+        assert (f1.args.kwonlyargs[0].end_lineno, f1.args.kwonlyargs[0].end_col_offset) == (4, 16)
+        assert isinstance(f1.args.kwonlyargs_annotations[0], nodes.Name)
+        assert (f1.args.kwonlyargs_annotations[0].lineno, f1.args.kwonlyargs_annotations[0].col_offset) == (4, 13)
+        assert (f1.args.kwonlyargs_annotations[0].end_lineno, f1.args.kwonlyargs_annotations[0].end_col_offset) == (4, 16)
+        assert isinstance(f1.args.kw_defaults[0], nodes.Const)
+        assert (f1.args.kw_defaults[0].lineno, f1.args.kw_defaults[0].col_offset) == (4, 19)
+        assert (f1.args.kw_defaults[0].end_lineno, f1.args.kw_defaults[0].end_col_offset) == (4, 20)
+
+        # **kwargs
+        assert isinstance(f1.args.kwargannotation, nodes.Name)
+        assert (f1.args.kwargannotation.lineno, f1.args.kwargannotation.col_offset) == (4, 32)
+        assert (f1.args.kwargannotation.end_lineno, f1.args.kwargannotation.end_col_offset) == (4, 35)
+
+        f2 = ast_nodes[1]
+        assert isinstance(f2, nodes.AsyncFunctionDef)
+        assert isinstance(f2.decorators, nodes.Decorators)
+        assert isinstance(f2.decorators.nodes[0], nodes.Name)
+        assert isinstance(f2.decorators.nodes[1], nodes.Name)
+        assert (f2.lineno, f2.col_offset) == (8, 0)
+        assert (f2.end_lineno, f2.end_col_offset) == (11, 8)
+        assert (f2.decorators.lineno, f2.decorators.col_offset) == (8, 0)
+        assert (f2.decorators.end_lineno, f2.decorators.end_col_offset) == (9, 11)
+        assert (f2.decorators.nodes[0].lineno, f2.decorators.nodes[0].col_offset) == (8, 1)
+        assert (f2.decorators.nodes[0].end_lineno, f2.decorators.nodes[0].end_col_offset) == (8, 11)
+        assert (f2.decorators.nodes[1].lineno, f2.decorators.nodes[1].col_offset) == (9, 1)
+        assert (f2.decorators.nodes[1].end_lineno, f2.decorators.nodes[1].end_col_offset) == (9, 11)
+
+        f3 = ast_nodes[2]
+        assert isinstance(f3, nodes.Lambda)
+        assert isinstance(f3.args, nodes.Arguments)
+        assert isinstance(f3.args.args[0], nodes.AssignName)
+        assert isinstance(f3.body, nodes.Const)
+        assert (f3.lineno, f3.col_offset) == (13, 0)
+        assert (f3.end_lineno, f3.end_col_offset) == (13, 11)
+        assert (f3.args.args[0].lineno, f3.args.args[0].col_offset) == (13, 7)
+        assert (f3.args.args[0].end_lineno, f3.args.args[0].end_col_offset) == (13, 8)
+        assert (f3.body.lineno, f3.body.col_offset) == (13, 10)
+        assert (f3.body.end_lineno, f3.body.end_col_offset) == (13, 11)
+        # fmt: on
+
+    @staticmethod
+    def test_end_lineno_dict() -> None:
+        """Dict, DictUnpack."""
+        code = textwrap.dedent(
+            """
+        {  #@
+            1: "Hello",
+            **{2: "World"}  #@
+        }
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 2
+
+        d1 = ast_nodes[0]
+        assert isinstance(d1, nodes.Dict)
+        assert isinstance(d1.items[0][0], nodes.Const)
+        assert isinstance(d1.items[0][1], nodes.Const)
+        assert (d1.lineno, d1.col_offset) == (1, 0)
+        assert (d1.end_lineno, d1.end_col_offset) == (4, 1)
+        assert (d1.items[0][0].lineno, d1.items[0][0].col_offset) == (2, 4)
+        assert (d1.items[0][0].end_lineno, d1.items[0][0].end_col_offset) == (2, 5)
+        assert (d1.items[0][1].lineno, d1.items[0][1].col_offset) == (2, 7)
+        assert (d1.items[0][1].end_lineno, d1.items[0][1].end_col_offset) == (2, 14)
+
+        d2 = ast_nodes[1]
+        assert isinstance(d2, nodes.DictUnpack)
+        assert (d2.lineno, d2.col_offset) == (3, 6)
+        assert (d2.end_lineno, d2.end_col_offset) == (3, 18)
+
+    @staticmethod
+    def test_end_lineno_try() -> None:
+        """TryExcept, TryFinally, ExceptHandler."""
+        code = textwrap.dedent(
+            """
+        try:  #@
+            pass
+        except KeyError as ex:
+            pass
+        except AttributeError as ex:
+            pass
+        else:
+            pass
+
+        try:  #@
+            pass
+        except KeyError as ex:
+            pass
+        else:
+            pass
+        finally:
+            pass
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 2
+
+        t1 = ast_nodes[0]
+        assert isinstance(t1, nodes.TryExcept)
+        assert isinstance(t1.body[0], nodes.Pass)
+        assert isinstance(t1.orelse[0], nodes.Pass)
+        assert (t1.lineno, t1.col_offset) == (1, 0)
+        assert (t1.end_lineno, t1.end_col_offset) == (8, 8)
+        assert (t1.body[0].lineno, t1.body[0].col_offset) == (2, 4)
+        assert (t1.body[0].end_lineno, t1.body[0].end_col_offset) == (2, 8)
+        assert (t1.orelse[0].lineno, t1.orelse[0].col_offset) == (8, 4)
+        assert (t1.orelse[0].end_lineno, t1.orelse[0].end_col_offset) == (8, 8)
+
+        t2 = t1.handlers[0]
+        assert isinstance(t2, nodes.ExceptHandler)
+        assert isinstance(t2.type, nodes.Name)
+        assert isinstance(t2.name, nodes.AssignName)
+        assert isinstance(t2.body[0], nodes.Pass)
+        assert (t2.lineno, t2.col_offset) == (3, 0)
+        assert (t2.end_lineno, t2.end_col_offset) == (4, 8)
+        assert (t2.type.lineno, t2.type.col_offset) == (3, 7)
+        assert (t2.type.end_lineno, t2.type.end_col_offset) == (3, 15)
+        assert (t2.name.lineno, t2.name.col_offset) == (3, 0)
+        assert (t2.name.end_lineno, t2.name.end_col_offset) == (4, 8)
+        assert (t2.body[0].lineno, t2.body[0].col_offset) == (4, 4)
+        assert (t2.body[0].end_lineno, t2.body[0].end_col_offset) == (4, 8)
+
+        t3 = ast_nodes[1]
+        assert isinstance(t3, nodes.TryFinally)
+        assert isinstance(t3.body[0], nodes.TryExcept)
+        assert isinstance(t3.finalbody[0], nodes.Pass)
+        assert (t3.lineno, t3.col_offset) == (10, 0)
+        assert (t3.end_lineno, t3.end_col_offset) == (17, 8)
+        assert (t3.body[0].lineno, t3.body[0].col_offset) == (10, 0)
+        assert (t3.body[0].end_lineno, t3.body[0].end_col_offset) == (17, 8)
+        assert (t3.finalbody[0].lineno, t3.finalbody[0].col_offset) == (17, 4)
+        assert (t3.finalbody[0].end_lineno, t3.finalbody[0].end_col_offset) == (17, 8)
+
+    @staticmethod
+    def test_end_lineno_subscript() -> None:
+        """Subscript, Slice, (ExtSlice, Index)."""
+        code = textwrap.dedent(
+            """
+        var[0]  #@
+        var[1:2:1]  #@
+        var[1, 2]  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 3
+
+        s1 = ast_nodes[0]
+        assert isinstance(s1, nodes.Subscript)
+        assert isinstance(s1.value, nodes.Name)
+        assert isinstance(s1.slice, nodes.Const)
+        assert (s1.lineno, s1.col_offset) == (1, 0)
+        assert (s1.end_lineno, s1.end_col_offset) == (1, 6)
+        assert (s1.value.lineno, s1.value.col_offset) == (1, 0)
+        assert (s1.value.end_lineno, s1.value.end_col_offset) == (1, 3)
+        assert (s1.slice.lineno, s1.slice.col_offset) == (1, 4)
+        assert (s1.slice.end_lineno, s1.slice.end_col_offset) == (1, 5)
+
+        s2 = ast_nodes[1]
+        assert isinstance(s2, nodes.Subscript)
+        assert isinstance(s2.slice, nodes.Slice)
+        assert isinstance(s2.slice.lower, nodes.Const)
+        assert isinstance(s2.slice.upper, nodes.Const)
+        assert isinstance(s2.slice.step, nodes.Const)
+        assert (s2.lineno, s2.col_offset) == (2, 0)
+        assert (s2.end_lineno, s2.end_col_offset) == (2, 10)
+        assert (s2.slice.lower.lineno, s2.slice.lower.col_offset) == (2, 4)
+        assert (s2.slice.lower.end_lineno, s2.slice.lower.end_col_offset) == (2, 5)
+        assert (s2.slice.upper.lineno, s2.slice.upper.col_offset) == (2, 6)
+        assert (s2.slice.upper.end_lineno, s2.slice.upper.end_col_offset) == (2, 7)
+        assert (s2.slice.step.lineno, s2.slice.step.col_offset) == (2, 8)
+        assert (s2.slice.step.end_lineno, s2.slice.step.end_col_offset) == (2, 9)
+
+        s3 = ast_nodes[2]
+        assert isinstance(s3, nodes.Subscript)
+        assert isinstance(s3.slice, nodes.Tuple)
+        assert (s3.lineno, s3.col_offset) == (3, 0)
+        assert (s3.end_lineno, s3.end_col_offset) == (3, 9)
+        assert (s3.slice.lineno, s3.slice.col_offset) == (3, 4)
+        assert (s3.slice.end_lineno, s3.slice.end_col_offset) == (3, 8)
+
+    @staticmethod
+    def test_end_lineno_import() -> None:
+        """Import, ImportFrom."""
+        code = textwrap.dedent(
+            """
+        import a.b  #@
+        import a as x  #@
+        from . import x  #@
+        from .a import y as y  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 4
+
+        i1 = ast_nodes[0]
+        assert isinstance(i1, nodes.Import)
+        assert (i1.lineno, i1.col_offset) == (1, 0)
+        assert (i1.end_lineno, i1.end_col_offset) == (1, 10)
+
+        i2 = ast_nodes[1]
+        assert isinstance(i2, nodes.Import)
+        assert (i2.lineno, i2.col_offset) == (2, 0)
+        assert (i2.end_lineno, i2.end_col_offset) == (2, 13)
+
+        i3 = ast_nodes[2]
+        assert isinstance(i3, nodes.ImportFrom)
+        assert (i3.lineno, i3.col_offset) == (3, 0)
+        assert (i3.end_lineno, i3.end_col_offset) == (3, 15)
+
+        i4 = ast_nodes[3]
+        assert isinstance(i4, nodes.ImportFrom)
+        assert (i4.lineno, i4.col_offset) == (4, 0)
+        assert (i4.end_lineno, i4.end_col_offset) == (4, 21)
+
+    @staticmethod
+    def test_end_lineno_with() -> None:
+        """With, AsyncWith."""
+        code = textwrap.dedent(
+            """
+        with open(file) as fp, \\
+                open(file2) as fp2:  #@
+            pass
+
+        async with open(file) as fp:  #@
+            pass
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 2
+
+        w1 = ast_nodes[0].parent
+        assert isinstance(w1, nodes.With)
+        assert isinstance(w1.items[0][0], nodes.Call)
+        assert isinstance(w1.items[0][1], nodes.AssignName)
+        assert isinstance(w1.items[1][0], nodes.Call)
+        assert isinstance(w1.items[1][1], nodes.AssignName)
+        assert isinstance(w1.body[0], nodes.Pass)
+        assert (w1.lineno, w1.col_offset) == (1, 0)
+        assert (w1.end_lineno, w1.end_col_offset) == (3, 8)
+        assert (w1.items[0][0].lineno, w1.items[0][0].col_offset) == (1, 5)
+        assert (w1.items[0][0].end_lineno, w1.items[0][0].end_col_offset) == (1, 15)
+        assert (w1.items[0][1].lineno, w1.items[0][1].col_offset) == (1, 19)
+        assert (w1.items[0][1].end_lineno, w1.items[0][1].end_col_offset) == (1, 21)
+        assert (w1.items[1][0].lineno, w1.items[1][0].col_offset) == (2, 8)
+        assert (w1.items[1][0].end_lineno, w1.items[1][0].end_col_offset) == (2, 19)
+        assert (w1.items[1][1].lineno, w1.items[1][1].col_offset) == (2, 23)
+        assert (w1.items[1][1].end_lineno, w1.items[1][1].end_col_offset) == (2, 26)
+        assert (w1.body[0].lineno, w1.body[0].col_offset) == (3, 4)
+        assert (w1.body[0].end_lineno, w1.body[0].end_col_offset) == (3, 8)
+
+        w2 = ast_nodes[1]
+        assert isinstance(w2, nodes.AsyncWith)
+        assert isinstance(w2.items[0][0], nodes.Call)
+        assert isinstance(w2.items[0][1], nodes.AssignName)
+        assert isinstance(w2.body[0], nodes.Pass)
+        assert (w2.lineno, w2.col_offset) == (5, 0)
+        assert (w2.end_lineno, w2.end_col_offset) == (6, 8)
+        assert (w2.items[0][0].lineno, w2.items[0][0].col_offset) == (5, 11)
+        assert (w2.items[0][0].end_lineno, w2.items[0][0].end_col_offset) == (5, 21)
+        assert (w2.items[0][1].lineno, w2.items[0][1].col_offset) == (5, 25)
+        assert (w2.items[0][1].end_lineno, w2.items[0][1].end_col_offset) == (5, 27)
+        assert (w2.body[0].lineno, w2.body[0].col_offset) == (6, 4)
+        assert (w2.body[0].end_lineno, w2.body[0].end_col_offset) == (6, 8)
+
+    @staticmethod
+    def test_end_lineno_while() -> None:
+        """While."""
+        code = textwrap.dedent(
+            """
+        while 2:
+            pass
+        else:
+            pass
+        """
+        ).strip()
+        w1 = builder.extract_node(code)
+        assert isinstance(w1, nodes.While)
+        assert isinstance(w1.test, nodes.Const)
+        assert isinstance(w1.body[0], nodes.Pass)
+        assert isinstance(w1.orelse[0], nodes.Pass)
+        assert (w1.lineno, w1.col_offset) == (1, 0)
+        assert (w1.end_lineno, w1.end_col_offset) == (4, 8)
+        assert (w1.test.lineno, w1.test.col_offset) == (1, 6)
+        assert (w1.test.end_lineno, w1.test.end_col_offset) == (1, 7)
+        assert (w1.body[0].lineno, w1.body[0].col_offset) == (2, 4)
+        assert (w1.body[0].end_lineno, w1.body[0].end_col_offset) == (2, 8)
+        assert (w1.orelse[0].lineno, w1.orelse[0].col_offset) == (4, 4)
+        assert (w1.orelse[0].end_lineno, w1.orelse[0].end_col_offset) == (4, 8)
+
+    @staticmethod
+    def test_end_lineno_string() -> None:
+        """FormattedValue, JoinedStr."""
+        code = textwrap.dedent(
+            """
+        f"Hello World: {42.1234:02d}"
+        """
+        ).strip()
+        s1 = builder.extract_node(code)
+        assert isinstance(s1, nodes.JoinedStr)
+        assert isinstance(s1.values[0], nodes.Const)
+        assert (s1.lineno, s1.col_offset) == (1, 0)
+        assert (s1.end_lineno, s1.end_col_offset) == (1, 29)
+        assert (s1.values[0].lineno, s1.values[0].col_offset) == (1, 0)
+        assert (s1.values[0].end_lineno, s1.values[0].end_col_offset) == (1, 29)
+
+        s2 = s1.values[1]
+        assert isinstance(s2, nodes.FormattedValue)
+        assert (s2.lineno, s2.col_offset) == (1, 0)
+        assert (s2.end_lineno, s2.end_col_offset) == (1, 29)
+        assert isinstance(s2.value, nodes.Const)  # 42.1234
+        assert (s2.value.lineno, s2.value.col_offset) == (1, 16)
+        assert (s2.value.end_lineno, s2.value.end_col_offset) == (1, 23)
+        assert isinstance(s2.format_spec, nodes.JoinedStr)  # 02d
+        assert (s2.format_spec.lineno, s2.format_spec.col_offset) == (1, 0)
+        assert (s2.format_spec.end_lineno, s2.format_spec.end_col_offset) == (1, 29)
+
+    @staticmethod
+    def test_end_lineno_match() -> None:
+        """Match, MatchValue, MatchSingleton, MatchSequence, MatchMapping,
+        MatchClass, MatchStar, MatchOr, MatchAs.
+        """
+        code = textwrap.dedent(
+            """
+        match x:  #@
+            case 200 if True:  #@
+                pass
+            case True:  #@
+                pass
+            case (1, 2, *args): #@
+                pass
+            case {1: "Hello", **rest}: #@
+                pass
+            case Point2d(0, y=0):  #@
+                pass
+            case 200 | 300:  #@
+                pass
+            case 200 as c:  #@
+                pass
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 8
+
+        # fmt: off
+        m1 = ast_nodes[0]
+        assert isinstance(m1, nodes.Match)
+        assert (m1.lineno, m1.col_offset) == (1, 0)
+        assert (m1.end_lineno, m1.end_col_offset) == (15, 12)
+        assert (m1.subject.lineno, m1.subject.col_offset) == (1, 6)
+        assert (m1.subject.end_lineno, m1.subject.end_col_offset) == (1, 7)
+
+        m2 = ast_nodes[1]
+        assert isinstance(m2, nodes.MatchCase)
+        assert isinstance(m2.pattern, nodes.MatchValue)
+        assert isinstance(m2.guard, nodes.Const)
+        assert isinstance(m2.body[0], nodes.Pass)
+        assert (m2.pattern.lineno, m2.pattern.col_offset) == (2, 9)
+        assert (m2.pattern.end_lineno, m2.pattern.end_col_offset) == (2, 12)
+        assert (m2.guard.lineno, m2.guard.col_offset) == (2, 16)
+        assert (m2.guard.end_lineno, m2.guard.end_col_offset) == (2, 20)
+        assert (m2.body[0].lineno, m2.body[0].col_offset) == (3, 8)
+        assert (m2.body[0].end_lineno, m2.body[0].end_col_offset) == (3, 12)
+
+        m3 = ast_nodes[2]
+        assert isinstance(m3, nodes.MatchCase)
+        assert isinstance(m3.pattern, nodes.MatchSingleton)
+        assert (m3.pattern.lineno, m3.pattern.col_offset) == (4, 9)
+        assert (m3.pattern.end_lineno, m3.pattern.end_col_offset) == (4, 13)
+
+        m4 = ast_nodes[3]
+        assert isinstance(m4, nodes.MatchCase)
+        assert isinstance(m4.pattern, nodes.MatchSequence)
+        assert isinstance(m4.pattern.patterns[0], nodes.MatchValue)
+        assert (m4.pattern.lineno, m4.pattern.col_offset) == (6, 9)
+        assert (m4.pattern.end_lineno, m4.pattern.end_col_offset) == (6, 22)
+        assert (m4.pattern.patterns[0].lineno, m4.pattern.patterns[0].col_offset) == (6, 10)
+        assert (m4.pattern.patterns[0].end_lineno, m4.pattern.patterns[0].end_col_offset) == (6, 11)
+
+        m5 = m4.pattern.patterns[2]
+        assert isinstance(m5, nodes.MatchStar)
+        assert isinstance(m5.name, nodes.AssignName)
+        assert (m5.lineno, m5.col_offset) == (6, 16)
+        assert (m5.end_lineno, m5.end_col_offset) == (6, 21)
+        assert (m5.name.lineno, m5.name.col_offset) == (6, 16)
+        assert (m5.name.end_lineno, m5.name.end_col_offset) == (6, 21)
+
+        m6 = ast_nodes[4]
+        assert isinstance(m6, nodes.MatchCase)
+        assert isinstance(m6.pattern, nodes.MatchMapping)
+        assert isinstance(m6.pattern.keys[0], nodes.Const)
+        assert isinstance(m6.pattern.patterns[0], nodes.MatchValue)
+        assert isinstance(m6.pattern.rest, nodes.AssignName)
+        assert (m6.pattern.lineno, m6.pattern.col_offset) == (8, 9)
+        assert (m6.pattern.end_lineno, m6.pattern.end_col_offset) == (8, 29)
+        assert (m6.pattern.keys[0].lineno, m6.pattern.keys[0].col_offset) == (8, 10)
+        assert (m6.pattern.keys[0].end_lineno, m6.pattern.keys[0].end_col_offset) == (8, 11)
+        assert (m6.pattern.patterns[0].lineno, m6.pattern.patterns[0].col_offset) == (8, 13)
+        assert (m6.pattern.patterns[0].end_lineno, m6.pattern.patterns[0].end_col_offset) == (8, 20)
+        assert (m6.pattern.rest.lineno, m6.pattern.rest.col_offset) == (8, 9)
+        assert (m6.pattern.rest.end_lineno, m6.pattern.rest.end_col_offset) == (8, 29)
+
+        m7 = ast_nodes[5]
+        assert isinstance(m7, nodes.MatchCase)
+        assert isinstance(m7.pattern, nodes.MatchClass)
+        assert isinstance(m7.pattern.cls, nodes.Name)
+        assert isinstance(m7.pattern.patterns[0], nodes.MatchValue)
+        assert isinstance(m7.pattern.kwd_patterns[0], nodes.MatchValue)
+        assert (m7.pattern.lineno, m7.pattern.col_offset) == (10, 9)
+        assert (m7.pattern.end_lineno, m7.pattern.end_col_offset) == (10, 24)
+        assert (m7.pattern.cls.lineno, m7.pattern.cls.col_offset) == (10, 9)
+        assert (m7.pattern.cls.end_lineno, m7.pattern.cls.end_col_offset) == (10, 16)
+        assert (m7.pattern.patterns[0].lineno, m7.pattern.patterns[0].col_offset) == (10, 17)
+        assert (m7.pattern.patterns[0].end_lineno, m7.pattern.patterns[0].end_col_offset) == (10, 18)
+        assert (m7.pattern.kwd_patterns[0].lineno, m7.pattern.kwd_patterns[0].col_offset) == (10, 22)
+        assert (m7.pattern.kwd_patterns[0].end_lineno, m7.pattern.kwd_patterns[0].end_col_offset) == (10, 23)
+
+        m8 = ast_nodes[6]
+        assert isinstance(m8, nodes.MatchCase)
+        assert isinstance(m8.pattern, nodes.MatchOr)
+        assert isinstance(m8.pattern.patterns[0], nodes.MatchValue)
+        assert (m8.pattern.lineno, m8.pattern.col_offset) == (12, 9)
+        assert (m8.pattern.end_lineno, m8.pattern.end_col_offset) == (12, 18)
+        assert (m8.pattern.patterns[0].lineno, m8.pattern.patterns[0].col_offset) == (12, 9)
+        assert (m8.pattern.patterns[0].end_lineno, m8.pattern.patterns[0].end_col_offset) == (12, 12)
+
+        m9 = ast_nodes[7]
+        assert isinstance(m9, nodes.MatchCase)
+        assert isinstance(m9.pattern, nodes.MatchAs)
+        assert isinstance(m9.pattern.pattern, nodes.MatchValue)
+        assert isinstance(m9.pattern.name, nodes.AssignName)
+        assert (m9.pattern.lineno, m9.pattern.col_offset) == (14, 9)
+        assert (m9.pattern.end_lineno, m9.pattern.end_col_offset) == (14, 17)
+        assert (m9.pattern.pattern.lineno, m9.pattern.pattern.col_offset) == (14, 9)
+        assert (m9.pattern.pattern.end_lineno, m9.pattern.pattern.end_col_offset) == (14, 12)
+        assert (m9.pattern.name.lineno, m9.pattern.name.col_offset) == (14, 9)
+        assert (m9.pattern.name.end_lineno, m9.pattern.name.end_col_offset) == (14, 17)
+        # fmt: on
+
+    @staticmethod
+    def test_end_lineno_comprehension() -> None:
+        """ListComp, SetComp, DictComp, GeneratorExpr."""
+        code = textwrap.dedent(
+            """
+        [x for x in var]  #@
+        {x for x in var}  #@
+        {x: y for x, y in var}  #@
+        (x for x in var)  #@
+        """
+        ).strip()
+        ast_nodes = builder.extract_node(code)
+        assert isinstance(ast_nodes, list) and len(ast_nodes) == 4
+
+        c1 = ast_nodes[0]
+        assert isinstance(c1, nodes.ListComp)
+        assert isinstance(c1.elt, nodes.Name)
+        assert isinstance(c1.generators[0], nodes.Comprehension)  # type: ignore
+        assert (c1.lineno, c1.col_offset) == (1, 0)
+        assert (c1.end_lineno, c1.end_col_offset) == (1, 16)
+        assert (c1.elt.lineno, c1.elt.col_offset) == (1, 1)
+        assert (c1.elt.end_lineno, c1.elt.end_col_offset) == (1, 2)
+
+        c2 = ast_nodes[1]
+        assert isinstance(c2, nodes.SetComp)
+        assert isinstance(c2.elt, nodes.Name)
+        assert isinstance(c2.generators[0], nodes.Comprehension)  # type: ignore
+        assert (c2.lineno, c2.col_offset) == (2, 0)
+        assert (c2.end_lineno, c2.end_col_offset) == (2, 16)
+        assert (c2.elt.lineno, c2.elt.col_offset) == (2, 1)
+        assert (c2.elt.end_lineno, c2.elt.end_col_offset) == (2, 2)
+
+        c3 = ast_nodes[2]
+        assert isinstance(c3, nodes.DictComp)
+        assert isinstance(c3.key, nodes.Name)
+        assert isinstance(c3.value, nodes.Name)
+        assert isinstance(c3.generators[0], nodes.Comprehension)  # type: ignore
+        assert (c3.lineno, c3.col_offset) == (3, 0)
+        assert (c3.end_lineno, c3.end_col_offset) == (3, 22)
+        assert (c3.key.lineno, c3.key.col_offset) == (3, 1)
+        assert (c3.key.end_lineno, c3.key.end_col_offset) == (3, 2)
+        assert (c3.value.lineno, c3.value.col_offset) == (3, 4)
+        assert (c3.value.end_lineno, c3.value.end_col_offset) == (3, 5)
+
+        c4 = ast_nodes[3]
+        assert isinstance(c4, nodes.GeneratorExp)
+        assert isinstance(c4.elt, nodes.Name)
+        assert isinstance(c4.generators[0], nodes.Comprehension)  # type: ignore
+        assert (c4.lineno, c4.col_offset) == (4, 0)
+        assert (c4.end_lineno, c4.end_col_offset) == (4, 16)
+        assert (c4.elt.lineno, c4.elt.col_offset) == (4, 1)
+        assert (c4.elt.end_lineno, c4.elt.end_col_offset) == (4, 2)
+
+    @staticmethod
+    def test_end_lineno_class() -> None:
+        """ClassDef, Keyword."""
+        code = textwrap.dedent(
+            """
+        @decorator1
+        @decorator2
+        class X(Parent, var=42):
+            pass
+        """
+        ).strip()
+        c1 = builder.extract_node(code)
+        assert isinstance(c1, nodes.ClassDef)
+        assert isinstance(c1.decorators, nodes.Decorators)
+        assert isinstance(c1.bases[0], nodes.Name)
+        assert isinstance(c1.keywords[0], nodes.Keyword)
+        assert isinstance(c1.body[0], nodes.Pass)
+
+        assert (c1.lineno, c1.col_offset) == (3, 0)
+        assert (c1.end_lineno, c1.end_col_offset) == (4, 8)
+        assert (c1.decorators.lineno, c1.decorators.col_offset) == (1, 0)
+        assert (c1.decorators.end_lineno, c1.decorators.end_col_offset) == (2, 11)
+        assert (c1.bases[0].lineno, c1.bases[0].col_offset) == (3, 8)
+        assert (c1.bases[0].end_lineno, c1.bases[0].end_col_offset) == (3, 14)
+        assert (c1.keywords[0].lineno, c1.keywords[0].col_offset) == (3, 16)
+        assert (c1.keywords[0].end_lineno, c1.keywords[0].end_col_offset) == (3, 22)
+        assert (c1.body[0].lineno, c1.body[0].col_offset) == (4, 4)
+        assert (c1.body[0].end_lineno, c1.body[0].end_col_offset) == (4, 8)

--- a/tests/unittest_nodes_lineno.py
+++ b/tests/unittest_nodes_lineno.py
@@ -588,6 +588,7 @@ class TestLinenoColOffset:
         assert (f1.body[0].end_lineno, f1.body[0].end_col_offset) == (6, 8)
 
         # pos only arguments
+        # TODO fix column offset: arg -> arg (AssignName)
         assert isinstance(f1.args.posonlyargs[0], nodes.AssignName)
         assert (f1.args.posonlyargs[0].lineno, f1.args.posonlyargs[0].col_offset) == (2, 4)
         assert (f1.args.posonlyargs[0].end_lineno, f1.args.posonlyargs[0].end_col_offset) == (2, 10)
@@ -737,6 +738,7 @@ class TestLinenoColOffset:
         assert (t2.end_lineno, t2.end_col_offset) == (4, 8)
         assert (t2.type.lineno, t2.type.col_offset) == (3, 7)
         assert (t2.type.end_lineno, t2.type.end_col_offset) == (3, 15)
+        # TODO fix column offset: ExceptHandler -> name (AssignName)
         assert (t2.name.lineno, t2.name.col_offset) == (3, 0)
         assert (t2.name.end_lineno, t2.name.end_col_offset) == (4, 8)
         assert (t2.body[0].lineno, t2.body[0].col_offset) == (4, 4)
@@ -1003,6 +1005,7 @@ class TestLinenoColOffset:
         assert isinstance(m5.name, nodes.AssignName)
         assert (m5.lineno, m5.col_offset) == (6, 16)
         assert (m5.end_lineno, m5.end_col_offset) == (6, 21)
+        # TODO fix column offset: MatchStar -> name (AssignName)
         assert (m5.name.lineno, m5.name.col_offset) == (6, 16)
         assert (m5.name.end_lineno, m5.name.end_col_offset) == (6, 21)
 
@@ -1018,6 +1021,7 @@ class TestLinenoColOffset:
         assert (m6.pattern.keys[0].end_lineno, m6.pattern.keys[0].end_col_offset) == (8, 11)
         assert (m6.pattern.patterns[0].lineno, m6.pattern.patterns[0].col_offset) == (8, 13)
         assert (m6.pattern.patterns[0].end_lineno, m6.pattern.patterns[0].end_col_offset) == (8, 20)
+        # TODO fix column offset: MatchMapping -> rest (AssignName)
         assert (m6.pattern.rest.lineno, m6.pattern.rest.col_offset) == (8, 9)
         assert (m6.pattern.rest.end_lineno, m6.pattern.rest.end_col_offset) == (8, 29)
 
@@ -1054,6 +1058,7 @@ class TestLinenoColOffset:
         assert (m9.pattern.end_lineno, m9.pattern.end_col_offset) == (14, 17)
         assert (m9.pattern.pattern.lineno, m9.pattern.pattern.col_offset) == (14, 9)
         assert (m9.pattern.pattern.end_lineno, m9.pattern.pattern.end_col_offset) == (14, 12)
+        # TODO fix column offset: MatchAs -> name (AssignName)
         assert (m9.pattern.name.lineno, m9.pattern.name.col_offset) == (14, 9)
         assert (m9.pattern.name.end_lineno, m9.pattern.name.end_col_offset) == (14, 17)
         # fmt: on


### PR DESCRIPTION
## Description

In Python 3.8, `end_lineno` and `end_col_offset` where added to all AST nodes which already had `lineno`  and `col_offset` information. This PR adds them to the astoid nodes. Part of https://github.com/PyCQA/pylint/issues/5336

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Todo list
- [x] Add docstrings for `end_lineno`, `end_col_offset`
- [x] Write changelog entry
- [x] Write tests for _all_ nodes
- [ ] Decide if `sys.version_info >= (3, 8)` checks are ok, or if `getattr(node, 'end_lineno', None)` should be used.
Note: ` getattr` can't be checked with `mypy`.
- [x] Resolve open `TODOs` in code
- [ ] ...