### PR TITLE
Add annotations for always None attributes

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -767,6 +767,9 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
 
     _other_fields = ("vararg", "kwarg")
 
+    lineno: None
+    col_offset: None
+
     def __init__(
         self,
         vararg: Optional[str] = None,
@@ -1778,6 +1781,9 @@ class Comprehension(NodeNG):
 
     optional_assign = True
     """Whether this node optionally assigns a variable."""
+
+    lineno: None
+    col_offset: None
 
     def __init__(self, parent: Optional[NodeNG] = None) -> None:
         """
@@ -4416,6 +4422,9 @@ class MatchCase(mixins.MultiLineBlockMixin, NodeNG):
 
     _astroid_fields = ("pattern", "guard", "body")
     _multi_line_block_fields = ("body",)
+
+    lineno: None
+    col_offset: None
 
     def __init__(self, *, parent: Optional[NodeNG] = None) -> None:
         self.pattern: Pattern

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -469,6 +469,10 @@ class Module(LocalsDictNodeNG):
     )
     _other_other_fields = ("locals", "globals")
 
+    lineno: None
+    col_offset: None
+    parent: None
+
     def __init__(
         self,
         name,


### PR DESCRIPTION
## Description

Triggered by https://github.com/PyCQA/astroid/pull/1258#issuecomment-973825372

`lineno`, `col_offset` are always `None` for `Arguments`, `Comprehension`, `MatchCase`, `Module`. Add better type annotations for it.