### PR TITLE
Always treat __class_getitem__ as a classmethod

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,8 @@ Release date: TBA
 
   Closes #1239
 
+* Always treat ``__class_getitem__`` as a classmethod.
+
 
 What's New in astroid 2.8.5?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ What's New in astroid 2.9.0?
 ============================
 Release date: TBA
 
+* Always treat ``__class_getitem__`` as a classmethod.
 
 
 What's New in astroid 2.8.6?
@@ -19,8 +20,6 @@ Release date: TBA
 * Fix bug with Python 3.7.0 / 3.7.1 and ``typing.NoReturn``.
 
   Closes #1239
-
-* Always treat ``__class_getitem__`` as a classmethod.
 
 
 What's New in astroid 2.8.5?

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -1570,6 +1570,8 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                 return "classmethod"
             if self.name == "__init_subclass__":
                 return "classmethod"
+            if self.name == "__class_getitem__":
+                return "classmethod"
 
             type_name = "method"
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4612,7 +4612,7 @@ class TestBool(unittest.TestCase):
             def __class_getitem__(cls, *args, **kwargs):
                 return cls
 
-        Foo[True]
+        Foo[int]
         """
         )
         inferred = next(node.infer())

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4605,6 +4605,20 @@ class TestBool(unittest.TestCase):
             inferred = next(node.infer())
             self.assertEqual(inferred, util.Uninferable)
 
+    def test_class_subscript(self) -> None:
+        node = extract_node(
+            """
+        class Foo:
+            def __class_getitem__(cls, *args, **kwargs):
+                return cls
+
+        Foo[True]
+        """
+        )
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, nodes.ClassDef)
+        self.assertEqual(inferred.name, "Foo")
+
 
 class TestType(unittest.TestCase):
     def test_type(self) -> None:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Consider this code:
```python
class Foo:
    def __class_getitem__(cls, *args, **kwargs):
        return cls
```
    
Without this change, astroid would treat `cls` as an instance of Foo, and thus it will treat Foo[bar] also as an instance, while really it is the same as Foo.

In my project, it fixes pylint warnings like this one:

    conferences/serializers.py:18:0: E0239: Inheriting 'serializers.ModelSerializer[models.Conference]', which is not a class. (inherit-non-class)

where ModelSerializer is a django-rest-framework class having the same definition of `__class_getitem__` as in my example.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |