### PR TITLE
Add as_string visitor for Unknown node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.9.0?
 ============================
 Release date: TBA
 
+* Add missing ``as_string`` visitor method for ``Unknown`` node.
+
+  Closes #1264
+
 
 
 What's New in astroid 2.8.6?

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,12 +6,12 @@ What's New in astroid 2.9.0?
 ============================
 Release date: TBA
 
-
 * Always treat ``__class_getitem__`` as a classmethod.
 
 * Add missing ``as_string`` visitor method for ``Unknown`` node.
 
   Closes #1264
+
 
 What's New in astroid 2.8.6?
 ============================

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         MatchSingleton,
         MatchStar,
         MatchValue,
+        Unknown,
     )
 
 # pylint: disable=unused-argument
@@ -642,6 +643,9 @@ class AsStringVisitor:
 
     def visit_evaluatedobject(self, node):
         return node.original.accept(self)
+
+    def visit_unknown(self, node: "Unknown") -> str:
+        return str(node)
 
 
 def _import_string(names):

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -306,6 +306,11 @@ everything = f""" " \' \r \t \\ {{ }} {'x' + x!r:a} {["'"]!s:{a}}"""
         ast = abuilder.string_build(code)
         self.assertEqual(ast.as_string().strip(), code.strip())
 
+    @staticmethod
+    def test_as_string_unknown() -> None:
+        assert nodes.Unknown().as_string() == "Unknown.Unknown()"
+        assert nodes.Unknown(lineno=1, col_offset=0).as_string() == "Unknown.Unknown()"
+
 
 class _NodeTest(unittest.TestCase):
     """test transformation of If Node"""


### PR DESCRIPTION
## Description

This PR adds an `as_string` visitor method for the `Unknown` node, similar to [`visit_uninferable`](https://github.com/cdce8p/astroid/blob/40d556070fd566b7bb43cb3ed0e498045b88f2d0/astroid/nodes/as_string.py#L637-L638).


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #1264