### PR TITLE
Require Python 3.6.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ What's New in astroid 2.9.1?
 ============================
 Release date: TBA
 
+* Require Python 3.6.2 to use astroid.
 
 
 What's New in astroid 2.9.0?

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     setuptools>=20.0
     typed-ast>=1.4.0,<2.0;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.10;python_version<"3.10"
-python_requires = ~=3.6
+python_requires = >=3.6.2
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     typing-extensions>=3.10;python_version<"3.10"
 python_requires = >=3.6.2
 
-
 [options.packages.find]
 include =
     astroid*


### PR DESCRIPTION
## Description

Require Python 3.6.2 going forward to better support typing. Similar to planned change in pylint with `2.12.1` https://github.com/PyCQA/pylint/pull/5068. There should be at least one version supported by pylint `2.12.0` without this change! I.e. if pylint `2.12.0` requires `2.9.0`, this should only go into `>= 2.9.1`.


Related #1267