### PR TITLE
Resolve dependency conflicts with pylint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test.txt -r requirements_test_brain.txt
+          pip install -e .
       - name: Generate pre-commit restore key
         id: generate-pre-commit-key
         run: >-
@@ -155,6 +156,7 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test.txt -r requirements_test_brain.txt
+          pip install -e .
 
   pytest-linux:
     name: Run tests Python ${{ matrix.python-version }} (Linux)
@@ -280,6 +282,7 @@ jobs:
           . venv\\Scripts\\activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test_min.txt -r requirements_test_brain.txt
+          pip install -e .
 
   pytest-windows:
     name: Run tests Python ${{ matrix.python-version }} (Windows)
@@ -359,6 +362,7 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test_min.txt
+          pip install -e .
 
   pytest-pypy:
     name: Run tests Python ${{ matrix.python-version }}

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,2 +1,1 @@
--e .
 pytest


### PR DESCRIPTION
## Description

`astroid` and `pylint` create circular dependencies which sometimes causes CI to fail completely. This happens if we update the minor version of astroid while still using a pylint version which is incompatible.

This PR doesn't completely fix the issue. It just separates the installs of `pylint` and `astroid` so that the `pip` dependency resolver doesn't complain.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
https://github.com/PyCQA/astroid/runs/4279233543?check_suite_focus=true#step:6:70