### PR TITLE
fix deque.insert() signature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,10 @@ Release date: TBA
 
 * Require Python 3.6.2 to use astroid.
 
+* Fix ``deque.insert()`` signature in ``collections`` brain.
+
+  Closes #1260
+
 
 What's New in astroid 2.9.0?
 ============================

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -61,7 +61,7 @@ def _deque_mock():
         def __copy__(self): return deque(self.iterable)
         def copy(self): return deque(self.iterable)
         def index(self, x, start=0, end=0): return 0
-        def insert(self, x, i): pass
+        def insert(self, i, x): pass
         def __add__(self, other): pass
         def __iadd__(self, other): pass
         def __mul__(self, other): pass


### PR DESCRIPTION
## Description

The collections brain had the arguments of `deque.insert()` reversed, which would case a false `arguments-renamed` error if an overriding class uses the correct order.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

Closes #1260
