### PR TITLE
Change order of decorators in tests

### DIFF
--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2293,8 +2293,8 @@ def test_slots_duplicate_bases_issue_1089() -> None:
 
 
 class TestFrameNodes:
-    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     @staticmethod
+    @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
     def test_frame_node():
         """Test if the frame of FunctionDef, ClassDef and Module is correctly set"""
         module = builder.parse(


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

`pytest` needs the `staticmethod` before the mark otherwise it complains that this is not a function to be called.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

