### PR TITLE
Fix typing of ``Arguments.args``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ Release date: TBA
 
   Closes #1260
 
+* Fix typing and update explanation for ``Arguments.args`` being ``None``.
+
 
 What's New in astroid 2.9.0?
 ============================

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -860,9 +860,10 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
 
         self.args: typing.Optional[typing.List[AssignName]]
         """The names of the required arguments.
+
         Can be None if the assosciated function does not have a retrievable
-        signature and the arguments are therefore unknown. This happens with builtin
-        functions implemented in C.
+        signature and the arguments are therefore unknown.
+        This happens with builtin functions implemented in C.
         """
 
         self.defaults: typing.List[NodeNG]

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -858,8 +858,12 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         self.kwarg: Optional[str] = kwarg  # can be None
         """The name of the variable length keyword arguments."""
 
-        self.args: typing.List[AssignName]
-        """The names of the required arguments."""
+        self.args: typing.Optional[typing.List[AssignName]]
+        """The names of the required arguments.
+        Can be None if the assosciated function does not have a retrievable
+        signature and the arguments are therefore unknown. This happens with builtin
+        functions implemented in C.
+        """
 
         self.defaults: typing.List[NodeNG]
         """The default values for arguments that can be passed positionally."""


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Based on discussion in `pylint` here: https://github.com/PyCQA/pylint/pull/5409#discussion_r762497136

I have added changelog entry to increase visibility for this change.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue
