### PR TITLE
Fix crash in `LocalsDictNodeNG.qname` if name does not exist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,11 @@ Release date: TBA
 
 * Fix typing and update explanation for ``Arguments.args`` being ``None``.
 
+* Fix crash in LocalsDictNodeNG.qname() if a variable named "type" is used in
+  a generator expression.
+
+  Closes PyCQA/pylint#5461
+
 
 What's New in astroid 2.9.0?
 ============================

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -243,7 +243,11 @@ class LocalsDictNodeNG(node_classes.LookupMixIn, node_classes.NodeNG):
         # pylint: disable=no-member; github.com/pycqa/astroid/issues/278
         if self.parent is None:
             return self.name
-        return f"{self.parent.frame().qname()}.{self.name}"
+        try:
+            maybe_name = '.' + self.name
+        except AttributeError:
+            maybe_name = ''
+        return f"{self.parent.frame().qname()}{maybe_name}"
 
     def scope(self: T) -> T:
         """The first parent node defining a new scope.

--- a/astroid/nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes.py
@@ -244,9 +244,9 @@ class LocalsDictNodeNG(node_classes.LookupMixIn, node_classes.NodeNG):
         if self.parent is None:
             return self.name
         try:
-            maybe_name = '.' + self.name
+            maybe_name = "." + self.name
         except AttributeError:
-            maybe_name = ''
+            maybe_name = ""
         return f"{self.parent.frame().qname()}{maybe_name}"
 
     def scope(self: T) -> T:

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1684,6 +1684,11 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         self.assertIsInstance(result, Generator)
         self.assertEqual(result.parent, func)
 
+    def test_list_comp_qname(self) -> None:
+        # Variable inside generator is a builtin
+        node = builder.extract_node("[type for type in [] if type['id']]")
+        self.assertEqual(node.qname(), '')
+
     def test_type_three_arguments(self) -> None:
         classes = builder.extract_node(
             """

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1687,7 +1687,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
     def test_list_comp_qname(self) -> None:
         # Variable inside generator is a builtin
         node = builder.extract_node("[type for type in [] if type['id']]")
-        self.assertEqual(node.qname(), '')
+        self.assertEqual(node.qname(), "")
 
     def test_type_three_arguments(self) -> None:
         classes = builder.extract_node(


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

https://github.com/PyCQA/pylint/issues/5461 reports an issue similar if not identical to #278.

Not all scoped nodes have a `name` attribute. The body of `LocalsDictNodeNG.qname()` is aware of this, disables `no-member` checks, and links to #278, but still depended on there being a `name`.

There was a commit (189b98bcdf8d2e5ec46d0dd3455adbaa516127ff) to remove `qname()` to a mixin, but I can't find that it ever made it into a release, so I'm not certain why it was closed.

Now, we have code depending on `qname()`, so I'm thinking it's safer to just work around the crash.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue


Closes https://github.com/PyCQA/pylint/issues/5461

