### PR TITLE
Fix crash if a variable named "type" is subscripted in a generator expression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@ Release date: TBA
 
 * Fix typing and update explanation for ``Arguments.args`` being ``None``.
 
-* Fix crash if a variable named "type" is subscripted in a generator expression.
+* Fix crash if a variable named ``type`` is subscripted in a generator expression.
 
   Closes PyCQA/pylint#5461
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,10 @@ Release date: TBA
 
 * Fix typing and update explanation for ``Arguments.args`` being ``None``.
 
+* Fix crash if a variable named "type" is subscripted in a generator expression.
+
+  Closes PyCQA/pylint#5461
+
 
 What's New in astroid 2.9.0?
 ============================

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -48,7 +48,10 @@ def infer_type_sub(node, context=None):
     :rtype: nodes.NodeNG
     """
     node_scope, _ = node.scope().lookup("type")
-    if node_scope.qname() != "builtins":
+    if (
+        not isinstance(node_scope, nodes.Module)
+        or node_scope.qname() != "builtins"
+    ):
         raise UseInferenceDefault()
     class_src = """
     class type:

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -48,10 +48,7 @@ def infer_type_sub(node, context=None):
     :rtype: nodes.NodeNG
     """
     node_scope, _ = node.scope().lookup("type")
-    if (
-        not isinstance(node_scope, nodes.Module)
-        or node_scope.qname() != "builtins"
-    ):
+    if not isinstance(node_scope, nodes.Module) or node_scope.qname() != "builtins":
         raise UseInferenceDefault()
     class_src = """
     class type:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4200,6 +4200,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == 123
 
+    def test_uninferable_type_subscript(self) -> None:
+        node = extract_node("[type for type in [] if type['id']]")
+        with self.assertRaises(InferenceError):
+            _ = next(node.infer())
+
 
 class GetattrTest(unittest.TestCase):
     def test_yes_when_unknown(self) -> None:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Fix crash when subscripting variable "type" inside a generator expression at the module level. Approach discussed [here](https://github.com/PyCQA/astroid/pull/1284#pullrequestreview-823449216). 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/5461
