### PR TITLE
Remove unused code - TreeRebuilder docstring

### DIFF
--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -48,7 +48,7 @@ from typing import (
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
-from astroid.const import PY37_PLUS, PY38, PY38_PLUS, Context
+from astroid.const import PY38, PY38_PLUS, Context
 from astroid.manager import AstroidManager
 from astroid.nodes import NodeNG
 
@@ -106,11 +106,7 @@ class TreeRebuilder:
 
     def _get_doc(self, node: T_Doc) -> Tuple[T_Doc, Optional[str]]:
         try:
-            if PY37_PLUS and hasattr(node, "docstring"):
-                doc = node.docstring  # type: ignore[union-attr,attr-defined] # mypy doesn't recognize hasattr
-                return node, doc
             if node.body and isinstance(node.body[0], self._module.Expr):
-
                 first_value = node.body[0].value
                 if isinstance(first_value, self._module.Str) or (
                     PY38_PLUS


### PR DESCRIPTION
## Description

Followup to https://github.com/PyCQA/astroid/pull/1276#discussion_r767059002
Remove unused part in `TreeRebuilder._get_doc`.

No node, I'm aware of, has a `docstring` attribute. Furthermore, this is currently not covered by our tests.
https://coveralls.io/builds/44947653/source?filename=astroid%2Frebuilder.py#L110

Unless someone knows what it is / was used for, I would recommend to remove it. If it indeed was used for something, we should find out soon enough through issues. That isn't how I would recommend to do it usually, but in this case it should most likely be fine.

@Pierre-Sassoulas Would you be ok with merging this? And if so, do we need to wait for `2.10`? Personally, I would also be ok with `2.9.1` as it shouldn't change anything 🤞🏻 It would also help with #1276.

--
The original commit that added it https://github.com/PyCQA/astroid/commit/2c655de34603e5a0f88b369d3e4b68556fdb0641.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |