### PR TITLE
Upgrade pylint to 2.12.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   CACHE_VERSION: 3
-  DEFAULT_PYTHON: 3.6
+  DEFAULT_PYTHON: 3.8
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 jobs:

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -292,6 +292,7 @@ def _precache_zipimporters(path=None):
     req_paths = tuple(path or sys.path)
     cached_paths = tuple(pic)
     new_paths = _cached_set_diff(req_paths, cached_paths)
+    # pylint: disable=no-member
     for entry_path in new_paths:
         try:
             pic[entry_path] = zipimport.zipimporter(entry_path)

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -234,8 +234,8 @@ class AstroidManager:
             except ValueError:
                 continue
             try:
+                # pylint: disable-next=no-member
                 importer = zipimport.zipimporter(eggpath + ext)
-                # pylint: enable=no-member
                 zmodname = resource.replace(os.path.sep, ".")
                 if importer.is_package(resource):
                     zmodname = zmodname + ".__init__"

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -33,8 +33,7 @@ if TYPE_CHECKING:
     from astroid import nodes
 
     if sys.version_info >= (3, 6, 2):
-        # To be fixed with https://github.com/PyCQA/pylint/pull/5316
-        from typing import NoReturn  # pylint: disable=unused-import
+        from typing import NoReturn
     else:
         from typing_extensions import NoReturn
 
@@ -445,7 +444,7 @@ class NodeNG:
         We need this method since not all nodes have :attr:`lineno` set.
         """
         line = self.lineno
-        _node: Optional[NodeNG] = self  # pylint: disable = used-before-assignment
+        _node: Optional[NodeNG] = self
         try:
             while line is None:
                 _node = next(_node.get_children())

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 black==21.7b0
-pylint==2.12.1
+pylint==2.12.2
 isort==5.9.2
 flake8==4.0.1
 flake8-typing-imports==1.11.0


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |


The default python is now also 3.8