### PR TITLE
Fix dataclass inference for marshmallow_dataclass

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,9 @@ Release date: TBA
 
   Closes PyCQA/pylint#5461
 
+* Enable inference of dataclass import from marshmallow_dataclass.
+  This allows the dataclasses brain to recognize dataclasses annotated by marshmallow_dataclass.
+
 
 What's New in astroid 2.9.0?
 ============================

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -3,9 +3,12 @@
 """
 Astroid hook for the dataclasses library
 
-Support both built-in dataclasses and pydantic.dataclasses. References:
+Support built-in dataclasses, pydantic.dataclasses, and marshmallow_dataclass-annotated
+dataclasses. References:
 - https://docs.python.org/3/library/dataclasses.html
 - https://pydantic-docs.helpmanual.io/usage/dataclasses/
+- https://lovasoa.github.io/marshmallow_dataclass/
+
 """
 from typing import FrozenSet, Generator, List, Optional, Tuple
 
@@ -35,7 +38,9 @@ from astroid.util import Uninferable
 
 DATACLASSES_DECORATORS = frozenset(("dataclass",))
 FIELD_NAME = "field"
-DATACLASS_MODULES = frozenset(("dataclasses", "pydantic.dataclasses"))
+DATACLASS_MODULES = frozenset(
+    ("dataclasses", "marshmallow_dataclass", "pydantic.dataclasses")
+)
 DEFAULT_FACTORY = "_HAS_DEFAULT_FACTORY"  # based on typing.py
 
 

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -11,7 +11,7 @@ if not PY37_PLUS:
 
 
 parametrize_module = pytest.mark.parametrize(
-    ("module",), (["dataclasses"], ["pydantic.dataclasses"])
+    ("module",), (["dataclasses"], ["pydantic.dataclasses"], ["marshmallow_dataclass"])
 )
 
 
@@ -304,6 +304,8 @@ def test_inference_generic_collection_attribute(module: str):
         ("dataclasses", "typing"),
         ("pydantic.dataclasses", "typing"),
         ("pydantic.dataclasses", "collections.abc"),
+        ("marshmallow_dataclass", "typing"),
+        ("marshmallow_dataclass", "collections.abc"),
     ],
 )
 def test_inference_callable_attribute(module: str, typing_module: str):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This allows astroid/pylint to understand dataclasses as provided by [marshmallow-dataclass](https://github.com/lovasoa/marshmallow_dataclass), which are basically regular stdlib dataclasses with a few additional private attributes to generate marshmallow schemas from said dataclasses declaration.

Note that despite the fact that this affects inference for both `dataclass` and `field`, pylint still correctly detects that `marshmallow-dataclass` does not provide a `field` function.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

(I'm putting this down as a bugfix because this was "broken" by the fact that recent astroid/pylint versions now correctly infers types from dataclasses, but I guess this could be considered a new feature)
