### PR TITLE
Revert "Add stubs for ``setuptools`` and ``typed-ast`` to dependencies"

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,8 +5,5 @@ coverage~=5.5
 pre-commit~=2.13
 pytest-cov~=2.11
 tbump~=6.3.2
-# Type packages for mypy
 types-typed-ast; implementation_name=="cpython" and python_version<"3.8"
 types-pkg_resources==0.1.2
-types-setuptools==57.4.4
-types-typed-ast==1.5.0


### PR DESCRIPTION
Reverts PyCQA/astroid#1294

Sorry about this guys. Seems like something messed up with my local requirements.. `types-pkg_resources` was not installed in my virtualenv. `mypy` recommends installing `types-setuptools` when `types-pkg_resources` is missing..
As @cdce8p pointed out the error with `typed-ast` is likely due to incorrect placement of import guards, which will be taken care of in #1296.