### PR TITLE
Create a ``NamedTuple`` instance for NamedTuples

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,9 @@ Release date: TBA
 * On Python versions >= 3.9, ``astroid`` now understands subscripting
   builtin classes such as ``enumerate`` or ``staticmethod``.
 
+* Instances of NamedTuples both from typing and collections will now be cast to a
+  NamedTuple instance. This instance proxies the definition of that NamedTuple.
+
 * Fixed inference of ``Enums`` when they are imported under an alias.
 
   Closes PyCQA/pylint#5776

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -621,3 +621,7 @@ class AsyncGenerator(Generator):
 
     def __str__(self):
         return f"AsyncGenerator({self._proxied.name})"
+
+
+class NamedTuple(BaseInstance):
+    """Special node representing a NamedTuple instance"""

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -6,6 +6,11 @@ import enum
 import sys
 from pathlib import Path
 
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
+
 PY38 = sys.version_info[:2] == (3, 8)
 PY38_PLUS = sys.version_info >= (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)
@@ -33,3 +38,6 @@ Del = Context.Del
 
 ASTROID_INSTALL_DIRECTORY = Path(__file__).parent
 BRAIN_MODULES_DIRECTORY = ASTROID_INSTALL_DIRECTORY / "brain"
+
+NAMEDTUPLE_BASENAMES: Final[frozenset[str]] = frozenset(("namedtuple", "NamedTuple"))
+"""Const used to identify namedtuples in the basenames of subclasses"""

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, NoReturn, TypeVar, overload
 
 from astroid import bases
 from astroid import decorators as decorators_mod
-from astroid import mixins, util
+from astroid import util
 from astroid.const import IS_PYPY, NAMEDTUPLE_BASENAMES, PY38, PY38_PLUS, PY39_PLUS
 from astroid.context import (
     CallContext,

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -20,8 +20,8 @@ from typing import TYPE_CHECKING, NoReturn, TypeVar, overload
 
 from astroid import bases
 from astroid import decorators as decorators_mod
-from astroid import util
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS
+from astroid import mixins, util
+from astroid.const import IS_PYPY, NAMEDTUPLE_BASENAMES, PY38, PY38_PLUS, PY39_PLUS
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2521,6 +2521,8 @@ class ClassDef(
                 return objects.ExceptionInstance(self)
         except MroError:
             pass
+        if any(i in NAMEDTUPLE_BASENAMES for i in self.basenames):
+            return bases.NamedTuple(self)
         return bases.Instance(self)
 
     def getattr(self, name, context=None, class_context=True):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1502,7 +1502,8 @@ class TypingBrain(unittest.TestCase):
         """
         )
         self.assertEqual(
-            [anc.name for anc in klass.ancestors()], ["X", "tuple", "object"]
+            [anc.name for anc in klass.ancestors()],
+            ["X", "tuple", "object", "NamedTuple"],
         )
         for anc in klass.ancestors():
             self.assertFalse(anc.parent is None)
@@ -1611,7 +1612,7 @@ class TypingBrain(unittest.TestCase):
         """
         )
         inferred = next(result.infer())
-        self.assertIsInstance(inferred, astroid.Instance)
+        self.assertIsInstance(inferred, bases.NamedTuple)
 
         class_attr = inferred.getattr("CLASS_ATTR")[0]
         self.assertIsInstance(class_attr, astroid.AssignName)
@@ -1784,7 +1785,7 @@ class TypingBrain(unittest.TestCase):
         """
         )
         inferred = next(node.infer())
-        self.assertIsInstance(inferred, astroid.Instance)
+        self.assertIsInstance(inferred, bases.NamedTuple)
 
     @test_utils.require_version("3.8")
     def test_typed_dict(self):
@@ -3131,7 +3132,7 @@ def test_http_client_brain() -> None:
     """
     )
     inferred = next(node.infer())
-    assert isinstance(inferred, astroid.Instance)
+    assert isinstance(inferred, bases.NamedTuple)
 
 
 def test_http_status_brain() -> None:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 
 import pytest
 
-from astroid import Slice, arguments
+from astroid import Slice, arguments, bases
 from astroid import decorators as decoratorsmod
 from astroid import helpers, nodes, objects, test_utils, util
 from astroid.arguments import CallSite
@@ -2193,8 +2193,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
         """
         ast = parse(code, __name__)
-        bases = ast["Second"].bases[0]
-        inferred = next(bases.infer())
+        base_classes = ast["Second"].bases[0]
+        inferred = next(base_classes.infer())
         self.assertTrue(inferred)
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertEqual(inferred.qname(), "collections.Counter")
@@ -6249,7 +6249,7 @@ def test_inferaugassign_picking_parent_instead_of_stmt() -> None:
     # as a string.
     node = extract_node(code)
     inferred = next(node.infer())
-    assert isinstance(inferred, Instance)
+    assert isinstance(inferred, bases.NamedTuple)
     assert inferred.name == "SomeClass"
 
 

--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -8,7 +8,7 @@ import xml
 import pytest
 
 import astroid
-from astroid import builder, nodes, objects, test_utils, util
+from astroid import bases, builder, nodes, objects, test_utils, util
 from astroid.const import PY311_PLUS
 from astroid.exceptions import InferenceError
 
@@ -203,9 +203,9 @@ class ClassModelTest(unittest.TestCase):
         called_mro = next(ast_nodes[5].infer())
         self.assertEqual(called_mro.elts, mro.elts)
 
-        bases = next(ast_nodes[6].infer())
-        self.assertIsInstance(bases, astroid.Tuple)
-        self.assertEqual([cls.name for cls in bases.elts], ["object"])
+        bases_classes = next(ast_nodes[6].infer())
+        self.assertIsInstance(bases_classes, astroid.Tuple)
+        self.assertEqual([cls.name for cls in bases_classes.elts], ["object"])
 
         cls = next(ast_nodes[7].infer())
         self.assertIsInstance(cls, astroid.ClassDef)
@@ -694,7 +694,7 @@ class LruCacheModelTest(unittest.TestCase):
         self.assertIsInstance(wrapped, astroid.FunctionDef)
         self.assertEqual(wrapped.name, "foo")
         cache_info = next(ast_nodes[2].infer())
-        self.assertIsInstance(cache_info, astroid.Instance)
+        self.assertIsInstance(cache_info, bases.NamedTuple)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This is the first step towards some improvements to the `NamedTuple` brain. One of the first things I thought we should fix is the fact that we currently lose the fact that something is a `NamedTuple`. We don't add it to the object's bases and they are undistinguishable from other instances.

I'm not sure if adding a new `Instance` is actually necessary. I thought it might make sense as `NamedTuple` behaves differently than `tuple` and can have default values for example. I have created the `T(opic): NamedTuple` label to identify some issues related to `NamedTuple`. I thought a new `Instance` type could be the basis for solving some of these.

Changes have been tested against current latest commit of `pytest`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue
