### PR TITLE
Revert "Remove useless NoReturn in NodeNG.statement's typing (#1304)"

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -32,6 +32,11 @@ from astroid.nodes.const import OP_PRECEDENCE
 if TYPE_CHECKING:
     from astroid import nodes
 
+    if sys.version_info >= (3, 6, 2):
+        from typing import NoReturn
+    else:
+        from typing_extensions import NoReturn
+
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
@@ -284,7 +289,7 @@ class NodeNG:
 
     def statement(
         self, *, future: Literal[None, True] = None
-    ) -> Union["nodes.Statement", "nodes.Module"]:
+    ) -> Union["nodes.Statement", "nodes.Module", "NoReturn"]:
         """The first parent node, including self, marked as statement node.
 
         TODO: Deprecate the future parameter and only raise StatementMissing and return


### PR DESCRIPTION
As mentioned in https://github.com/PyCQA/astroid/pull/1304#issuecomment-999115235, this is actually a false-negative in mypy and not an error.
Pyright / pylance correctly detects it (in `strict` mode).