### PR TITLE
Fix node.statement overload typing

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -273,9 +273,7 @@ class NodeNG:
         return any(self is parent for parent in node.node_ancestors())
 
     @overload
-    def statement(
-        self, *, future: Literal[None] = ...
-    ) -> Union["nodes.Statement", "nodes.Module"]:
+    def statement(self) -> Union["nodes.Statement", "nodes.Module"]:
         ...
 
     @overload

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -661,6 +661,8 @@ class Module(LocalsDictNodeNG):
     def statement(self) -> "Module":
         ...
 
+    # pylint: disable-next=arguments-differ
+    # https://github.com/PyCQA/pylint/issues/5264
     @overload
     def statement(self, *, future: Literal[True]) -> NoReturn:
         ...

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -658,7 +658,7 @@ class Module(LocalsDictNodeNG):
         return self.file is not None and self.file.endswith(".py")
 
     @overload
-    def statement(self, *, future: Literal[None] = ...) -> "Module":
+    def statement(self) -> "Module":
         ...
 
     @overload


### PR DESCRIPTION
## Description

Based on https://github.com/PyCQA/astroid/pull/1263#discussion_r773461677

The `node.statement()` overloads should only allow two different call signatures:
* `node.statement()`
* `node.statement(future=True)`

Without this change, `node.statement(future=None)` would also be valid.

--
_Pylint issue for false-positive with `arguments-differ` and overloads_: https://github.com/PyCQA/pylint/issues/5264 