### PR TITLE
Bump CI cache version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
   DEFAULT_PYTHON: 3.8
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 


### PR DESCRIPTION
## Description
Preemptively bumping the cache version to prevent the issues seen in pylint.
https://github.com/PyCQA/pylint/pull/5602