### PR TITLE
Fix distutils tests following setuptools 60.0.0 release

### DIFF
--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -33,6 +33,8 @@ import xml
 from xml import etree
 from xml.etree import ElementTree
 
+import pytest
+
 import astroid
 from astroid import modutils
 from astroid.interpreter._import import spec
@@ -72,6 +74,13 @@ class ModuleFileTest(unittest.TestCase):
             ["data", "MyPyPa-0.1.0-py2.5.egg", self.package],
         )
 
+    # TODO: Fix when removing distutils dependency
+    # https://github.com/pypa/setuptools/pull/2896
+    @pytest.mark.xfail(
+        sys.version_info > (3, 7),
+        sys.version_info < (3, 11),
+        reason="setuptools v60.0.0 starts using local copy of distutils",
+    )
     def test_find_distutils_submodules_in_virtualenv(self) -> None:
         found_spec = spec.find_spec(["distutils", "version"])
         self.assertEqual(found_spec.location, distutils.version.__file__)

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -20,9 +20,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 """
-unit tests for module modutils (module manipulation utilities)
+Unit tests for module modutils (module manipulation utilities)
 """
-import distutils.version
 import email
 import os
 import shutil
@@ -33,7 +32,7 @@ import xml
 from xml import etree
 from xml.etree import ElementTree
 
-import pytest
+import wrapt
 
 import astroid
 from astroid import modutils
@@ -74,16 +73,9 @@ class ModuleFileTest(unittest.TestCase):
             ["data", "MyPyPa-0.1.0-py2.5.egg", self.package],
         )
 
-    # TODO: Fix when removing distutils dependency
-    # https://github.com/pypa/setuptools/pull/2896
-    @pytest.mark.xfail(
-        sys.version_info > (3, 7),
-        sys.version_info < (3, 11),
-        reason="setuptools v60.0.0 starts using local copy of distutils",
-    )
-    def test_find_distutils_submodules_in_virtualenv(self) -> None:
-        found_spec = spec.find_spec(["distutils", "version"])
-        self.assertEqual(found_spec.location, distutils.version.__file__)
+    def test_find_wrapt_submodules_in_virtualenv(self) -> None:
+        found_spec = spec.find_spec(["wrapt", "decorators"])
+        self.assertEqual(found_spec.location, wrapt.decorators.__file__)
 
 
 class LoadModuleFromNameTest(unittest.TestCase):

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -22,6 +22,7 @@
 """
 Unit tests for module modutils (module manipulation utilities)
 """
+import distutils.version
 import email
 import os
 import shutil
@@ -32,7 +33,7 @@ import xml
 from xml import etree
 from xml.etree import ElementTree
 
-import wrapt
+import pytest
 
 import astroid
 from astroid import modutils
@@ -73,9 +74,16 @@ class ModuleFileTest(unittest.TestCase):
             ["data", "MyPyPa-0.1.0-py2.5.egg", self.package],
         )
 
-    def test_find_wrapt_submodules_in_virtualenv(self) -> None:
-        found_spec = spec.find_spec(["wrapt", "decorators"])
-        self.assertEqual(found_spec.location, wrapt.decorators.__file__)
+    # TODO: Fix when removing distutils dependency
+    # https://github.com/pypa/setuptools/pull/2896
+    @pytest.mark.xfail(
+        sys.version_info > (3, 7),
+        sys.version_info < (3, 11),
+        reason="setuptools v60.0.0 starts using local copy of distutils",
+    )
+    def test_find_distutils_submodules_in_virtualenv(self) -> None:
+        found_spec = spec.find_spec(["distutils", "version"])
+        self.assertEqual(found_spec.location, distutils.version.__file__)
 
 
 class LoadModuleFromNameTest(unittest.TestCase):


### PR DESCRIPTION
With v60.0.0 setuptools started monkeypatching the distuils module
to use their own vendored version. Longterm any uses of distuils
should be replaced or removed.

https://github.com/pypa/setuptools/pull/2896
https://setuptools.pypa.io/en/latest/history.html#v60-0-0

--
This change isn't ideal as it might hide an error, but for now it will unblock the CI pipeline.
Furthermore, at least for now, the setuptools copy should be identically with the stdlib one.

Closes #1313

References:
* #1282
* #1103
