### PR TITLE
Fix node.statement overload typing - default argument

### DIFF
--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -278,7 +278,9 @@ class NodeNG:
         return any(self is parent for parent in node.node_ancestors())
 
     @overload
-    def statement(self) -> Union["nodes.Statement", "nodes.Module"]:
+    def statement(
+        self, *, future: Literal[None] = ...
+    ) -> Union["nodes.Statement", "nodes.Module"]:
         ...
 
     @overload

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -658,7 +658,7 @@ class Module(LocalsDictNodeNG):
         return self.file is not None and self.file.endswith(".py")
 
     @overload
-    def statement(self) -> "Module":
+    def statement(self, *, future: Literal[None] = ...) -> "Module":
         ...
 
     # pylint: disable-next=arguments-differ


### PR DESCRIPTION
## Description

As it turns out, the default arg is needed for astroid itself. We pass the future argument unconditionally to the parent call for which `future` can be `None`.
```py
...
return self.parent.statement(future=future)
```

/CC: @DanielNoord