### PR TITLE
Fix ``distutils`` path patching for setuptools >= 60.0.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,8 @@ Release date: TBA
 
 * Removed custom ``distutils`` handling for resolving paths to submodules.
 
+  Ref #1321
+
 * Fix ``deque.insert()`` signature in ``collections`` brain.
 
   Closes #1260

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,7 +24,7 @@ Release date: TBA
 
 * Require Python 3.6.2 to use astroid.
 
-* Removed custom ``distutils`` handling for resolving paths to submodules
+* Removed custom ``distutils`` handling for resolving paths to submodules.
 
 * Fix ``deque.insert()`` signature in ``collections`` brain.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ Release date: TBA
 
 * Require Python 3.6.2 to use astroid.
 
+* Removed custom ``distutils`` handling for resolving paths to submodules
+
 * Fix ``deque.insert()`` signature in ``collections`` brain.
 
   Closes #1260

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -17,18 +17,12 @@
 
 import abc
 import collections
-import distutils
 import enum
 import importlib.machinery
 import os
 import sys
 import zipimport
 from functools import lru_cache
-
-try:
-    from setuptools import _distutils
-except ImportError:
-    _distutils = None
 
 from . import util
 
@@ -167,14 +161,6 @@ class ImportlibFinder(Finder):
                 if os.path.isdir(os.path.join(p, *processed))
             ]
         # We already import distutils elsewhere in astroid,
-        # so if it is the same module, we can use it directly.
-        elif spec.name == "distutils" and spec.location in distutils.__path__:
-            # distutils is patched inside virtualenvs to pick up submodules
-            # from the original Python, not from the virtualenv itself.
-            path = list(distutils.__path__)
-        elif spec.name == "distutils" and _distutils:
-            # distutils is patched in setuptools >= 60.0.0 to _distutils
-            path = list(_distutils.__path__)
         else:
             path = [spec.location]
         return path

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -25,6 +25,11 @@ import sys
 import zipimport
 from functools import lru_cache
 
+try:
+    from setuptools import _distutils
+except ImportError:
+    _distutils = None
+
 from . import util
 
 ModuleType = enum.Enum(
@@ -167,6 +172,9 @@ class ImportlibFinder(Finder):
             # distutils is patched inside virtualenvs to pick up submodules
             # from the original Python, not from the virtualenv itself.
             path = list(distutils.__path__)
+        elif spec.name == "distutils" and _distutils:
+            # distutils is patched in setuptools >= 60.0.0 to _distutils
+            path = list(_distutils.__path__)
         else:
             path = [spec.location]
         return path

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -22,7 +22,6 @@
 """
 unit tests for module modutils (module manipulation utilities)
 """
-import distutils.version
 import email
 import os
 import shutil
@@ -71,10 +70,6 @@ class ModuleFileTest(unittest.TestCase):
             found_spec.location.split(os.sep)[-3:],
             ["data", "MyPyPa-0.1.0-py2.5.egg", self.package],
         )
-
-    def test_find_distutils_submodules_in_virtualenv(self) -> None:
-        found_spec = spec.find_spec(["distutils", "version"])
-        self.assertEqual(found_spec.location, distutils.version.__file__)
 
 
 class LoadModuleFromNameTest(unittest.TestCase):


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

This passed locally. I wonder if this works here as well 😄 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

For future reference, see the original commit that added path patching for `distutils` here: https://github.com/PyCQA/astroid/commit/6ca01e0e1c691f08fbed9fab6c76339751c83b0b

Closes #1313 