### PR TITLE
Change site packages look up to use sysconfig instead of distutils

### DIFF
--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -46,6 +46,7 @@ import itertools
 import os
 import platform
 import sys
+import sysconfig
 import types
 from distutils.errors import DistutilsPlatformError  # pylint: disable=import-error
 from distutils.sysconfig import get_python_lib  # pylint: disable=import-error
@@ -146,7 +147,7 @@ if os.name == "posix":
         # https://github.com/PyCQA/pylint/issues/712#issuecomment-163178753
         STD_LIB_DIRS.add(_posix_path("lib64"))
 
-EXT_LIB_DIRS = {get_python_lib(), get_python_lib(True)}
+EXT_LIB_DIRS = {sysconfig.get_path("purelib"), sysconfig.get_path("platlib")}
 IS_JYTHON = platform.python_implementation() == "Jython"
 BUILTIN_MODULES = dict.fromkeys(sys.builtin_module_names, True)
 


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

While is was reading up on `distutils` etc I thought I would try and see if we can remove all calls to it.

There are three calls to `distutils`, which should all be done in separate PRs because of the complexity and risk of errors. If you agree I think we should try and put them in `2.9.1` as well (I know, another delay) so we can combine all fixes to the YOLO-option and removal of `distutils` at the same time. (YOLO-option from #1321, that is.)

For the change in this PR:
[`get_python_lib`](https://docs.python.org/3/distutils/apiref.html#distutils.sysconfig.get_python_lib) returns the directory of `site-packages`. "Return the directory for either the general or platform-dependent library installation. If plat_specific is true, the platform-dependent include directory is returned; if false or omitted, the platform-independent directory is returned."
This functionality is "replaced" by [`sysconfig.get_path`](https://docs.python.org/3/library/sysconfig.html#sysconfig.get_path). By using both `purelib` and `platlib` we got both of them again.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
