### PR TITLE
Use ``sysconfig.get_path`` instead of ``distutils`` to find ``stdlib``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,13 @@ Release date: TBA
 
   Closes #1330
 
+* Use ``sysconfig`` instead of ``distutils`` to determine the location of python files
+  and packages.
+
+  Related pull requests: #1322, #1323, #1324
+  Closes #1282
+  Ref #1103
+
 What's New in astroid 2.9.4?
 ============================
 Release date: TBA

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,8 +20,8 @@ Release date: TBA
 
   Closes #1330
 
-* Use ``sysconfig`` instead of ``distutils`` to determine the location of python files
-  and packages.
+* Use ``sysconfig`` instead of ``distutils`` to determine the location of
+  python stdlib files and packages.
 
   Related pull requests: #1322, #1323, #1324
   Closes #1282

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -46,8 +46,8 @@ import itertools
 import os
 import platform
 import sys
+import sysconfig
 import types
-from distutils.errors import DistutilsPlatformError  # pylint: disable=import-error
 from distutils.sysconfig import get_python_lib  # pylint: disable=import-error
 from typing import Dict, Set
 
@@ -66,22 +66,7 @@ else:
     PY_COMPILED_EXTS = ("so",)
 
 
-try:
-    # The explicit sys.prefix is to work around a patch in virtualenv that
-    # replaces the 'real' sys.prefix (i.e. the location of the binary)
-    # with the prefix from which the virtualenv was created. This throws
-    # off the detection logic for standard library modules, thus the
-    # workaround.
-    STD_LIB_DIRS = {
-        get_python_lib(standard_lib=True, prefix=sys.prefix),
-        # Take care of installations where exec_prefix != prefix.
-        get_python_lib(standard_lib=True, prefix=sys.exec_prefix),
-        get_python_lib(standard_lib=True),
-    }
-# get_python_lib(standard_lib=1) is not available on pypy, set STD_LIB_DIR to
-# non-valid path, see https://bugs.pypy.org/issue1164
-except DistutilsPlatformError:
-    STD_LIB_DIRS = set()
+STD_LIB_DIRS = {sysconfig.get_path("stdlib")}
 
 if os.name == "nt":
     STD_LIB_DIRS.add(os.path.join(sys.prefix, "dlls"))

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -53,7 +53,6 @@ from typing import Dict, Set
 
 from astroid.interpreter._import import spec, util
 
-
 if sys.platform.startswith("win"):
     PY_SOURCE_EXTS = ("py", "pyw")
     PY_COMPILED_EXTS = ("dll", "pyd")

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -53,6 +53,7 @@ from typing import Dict, Set
 
 from astroid.interpreter._import import spec, util
 
+
 if sys.platform.startswith("win"):
     PY_SOURCE_EXTS = ("py", "pyw")
     PY_COMPILED_EXTS = ("dll", "pyd")

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -39,8 +39,6 @@
 :var BUILTIN_MODULES: dictionary with builtin module names has key
 """
 
-# We disable the import-error so pylint can work without distutils installed.
-# pylint: disable=no-name-in-module,useless-suppression
 
 import importlib
 import importlib.machinery
@@ -51,16 +49,10 @@ import platform
 import sys
 import sysconfig
 import types
-from distutils.sysconfig import get_python_lib  # pylint: disable=import-error
 from pathlib import Path
 from typing import Dict, Set
 
 from astroid.interpreter._import import spec, util
-
-# distutils is replaced by virtualenv with a module that does
-# weird path manipulations in order to get to the
-# real distutils module.
-
 
 if sys.platform.startswith("win"):
     PY_SOURCE_EXTS = ("py", "pyw")
@@ -69,8 +61,9 @@ else:
     PY_SOURCE_EXTS = ("py",)
     PY_COMPILED_EXTS = ("so",)
 
-
-STD_LIB_DIRS = {sysconfig.get_path("stdlib")}
+# TODO: Adding `platstdlib` is a fix for a workaround in virtualenv. At some point we should
+# revisit whether this is still necessary. See https://github.com/PyCQA/astroid/pull/1323.
+STD_LIB_DIRS = {sysconfig.get_path("stdlib"), sysconfig.get_path("platstdlib")}
 
 if os.name == "nt":
     STD_LIB_DIRS.add(os.path.join(sys.prefix, "dlls"))

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -39,7 +39,6 @@
 :var BUILTIN_MODULES: dictionary with builtin module names has key
 """
 
-
 import importlib
 import importlib.machinery
 import importlib.util
@@ -60,6 +59,7 @@ if sys.platform.startswith("win"):
 else:
     PY_SOURCE_EXTS = ("py",)
     PY_COMPILED_EXTS = ("so",)
+
 
 # TODO: Adding `platstdlib` is a fix for a workaround in virtualenv. At some point we should
 # revisit whether this is still necessary. See https://github.com/PyCQA/astroid/pull/1323.


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

2/3 of PRs mentioned in #1322

For the change in this PR:
[`get_python_lib`](https://docs.python.org/3/distutils/apiref.html#distutils.sysconfig.get_python_lib) will "If standard_lib is true, the directory for the standard library is returned rather than the directory for the installation of third-party extensions."
This is thus the parent directory of `site-packages`.
This functionality is "replaced" by [`sysconfig.get_path`](https://docs.python.org/3/library/sysconfig.html#sysconfig.get_path) with `stdlib`.

The commit that added this particular fix was https://github.com/PyCQA/astroid/commit/70b7afc4e70de165b4770bd9abda6a9b5440fdef

I have looked around but the closest I got to finding any information on the presumed bug was https://bugs.python.org/issue11320. I also found a number of older Python 2 and 3.6 < issues about `virtualenv` and `distutils`. I couldn't find the actual issue here..
However, I think `sysconfig` in combination with newer versions of `virtualenv` have fixed these underlying issues. The tests seems to pass anyway, so I would argue to go for the YOLO-option here as well: we need to get rid of `distutils` someday anyway 😅 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue
