### PR TITLE
Add support for attrs v21.3.0+

### DIFF
--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -10,16 +10,22 @@ from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
 
-ATTRIB_NAMES = frozenset(("attr.ib", "attrib", "attr.attrib", "attr.field", "field"))
+ATTRIB_NAMES = frozenset(
+    ("attr.ib", "attrib", "attr.attrib", "attr.field", "attrs.field", "field")
+)
 ATTRS_NAMES = frozenset(
     (
         "attr.s",
         "attrs",
+        "define",
         "attr.attrs",
         "attr.attributes",
         "attr.define",
         "attr.mutable",
         "attr.frozen",
+        "attrs.define",
+        "attrs.mutable",
+        "attrs.frozen",
     )
 )
 

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -11,7 +11,7 @@ from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unkn
 from astroid.nodes.scoped_nodes import ClassDef
 
 ATTRIB_NAMES = frozenset(
-    ("attr.ib", "attrib", "attr.attrib", "attr.field", "attrs.field", "field")
+    ("attr.ib", "attr.attrib", "attr.field", "attrs.field")
 )
 ATTRS_NAMES = frozenset(
     (

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -10,9 +10,7 @@ from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
 
-ATTRIB_NAMES = frozenset(
-    ("attr.ib", "attr.attrib", "attr.field", "attrs.field")
-)
+ATTRIB_NAMES = frozenset(("attr.ib", "attr.attrib", "attr.field", "attrs.field"))
 ATTRS_NAMES = frozenset(
     (
         "attr.s",

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -10,7 +10,9 @@ from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
 
-ATTRIB_NAMES = frozenset( ("attr.ib", "attrib", "attr.attrib", "attr.field", "attrs.field", "field"))
+ATTRIB_NAMES = frozenset(
+    ("attr.ib", "attrib", "attr.attrib", "attr.field", "attrs.field", "field")
+)
 ATTRS_NAMES = frozenset(
     (
         "attr.s",

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -10,7 +10,7 @@ from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import AnnAssign, Assign, AssignName, Call, Unknown
 from astroid.nodes.scoped_nodes import ClassDef
 
-ATTRIB_NAMES = frozenset(("attr.ib", "attr.attrib", "attr.field", "attrs.field"))
+ATTRIB_NAMES = frozenset( ("attr.ib", "attrib", "attr.attrib", "attr.field", "attrs.field", "field"))
 ATTRS_NAMES = frozenset(
     (
         "attr.s",

--- a/astroid/brain/brain_attrs.py
+++ b/astroid/brain/brain_attrs.py
@@ -17,7 +17,6 @@ ATTRS_NAMES = frozenset(
     (
         "attr.s",
         "attrs",
-        "define",
         "attr.attrs",
         "attr.attributes",
         "attr.define",

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1346,11 +1346,7 @@ class CollectionsBrain(unittest.TestCase):
         inferred = next(right_node.infer())
         check_metaclass_is_abc(inferred)
         assertEqualMro(
-            inferred,
-            [
-                "_collections_abc.Hashable",
-                "builtins.object",
-            ],
+            inferred, ["_collections_abc.Hashable", "builtins.object",],
         )
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
@@ -1882,11 +1878,7 @@ class TypingBrain(unittest.TestCase):
         inferred = next(right_node.infer())
         assertEqualMro(
             inferred,
-            [
-                "typing.Hashable",
-                "_collections_abc.Hashable",
-                "builtins.object",
-            ],
+            ["typing.Hashable", "_collections_abc.Hashable", "builtins.object",],
         )
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
@@ -2215,7 +2207,7 @@ class AttrsTest(unittest.TestCase):
         module = astroid.parse(
             """
         import attrs
-        from attrs import define, field, mutable, frozen
+        from attrs import field, mutable, frozen
 
         @attrs.define
         class Foo:
@@ -2225,7 +2217,7 @@ class AttrsTest(unittest.TestCase):
         f = Foo()
         f.d['answer'] = 42
 
-        @define(slots=True)
+        @attrs.define(slots=True)
         class Bar:
             d = field(attrs.Factory(dict))
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -2212,6 +2212,11 @@ class AttrsTest(unittest.TestCase):
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
     def test_attrs_transform(self) -> None:
+        """Test brain for decorators of the 'attrs' package.
+        
+        Package added support for 'attrs' a long side 'attr' in v21.3.0.
+        See: https://github.com/python-attrs/attrs/releases/tag/21.3.0
+        """
         module = astroid.parse(
             """
         import attrs

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1346,7 +1346,11 @@ class CollectionsBrain(unittest.TestCase):
         inferred = next(right_node.infer())
         check_metaclass_is_abc(inferred)
         assertEqualMro(
-            inferred, ["_collections_abc.Hashable", "builtins.object",],
+            inferred,
+            [
+                "_collections_abc.Hashable",
+                "builtins.object",
+            ],
         )
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
@@ -1878,7 +1882,11 @@ class TypingBrain(unittest.TestCase):
         inferred = next(right_node.infer())
         assertEqualMro(
             inferred,
-            ["typing.Hashable", "_collections_abc.Hashable", "builtins.object",],
+            [
+                "typing.Hashable",
+                "_collections_abc.Hashable",
+                "builtins.object",
+            ],
         )
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -2213,7 +2213,7 @@ class AttrsTest(unittest.TestCase):
 
     def test_attrs_transform(self) -> None:
         """Test brain for decorators of the 'attrs' package.
-        
+
         Package added support for 'attrs' a long side 'attr' in v21.3.0.
         See: https://github.com/python-attrs/attrs/releases/tag/21.3.0
         """

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -2211,6 +2211,68 @@ class AttrsTest(unittest.TestCase):
             should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
             self.assertIsInstance(should_be_unknown, astroid.Unknown)
 
+    def test_attrs_transform(self) -> None:
+        module = astroid.parse(
+            """
+        import attrs
+        from attrs import define, field, mutable, frozen
+
+        @attrs.define
+        class Foo:
+
+            d = attrs.field(attrs.Factory(dict))
+
+        f = Foo()
+        f.d['answer'] = 42
+
+        @define(slots=True)
+        class Bar:
+            d = field(attrs.Factory(dict))
+
+        g = Bar()
+        g.d['answer'] = 42
+
+        @attrs.mutable
+        class Bah:
+            d = field(attrs.Factory(dict))
+
+        h = Bah()
+        h.d['answer'] = 42
+
+        @attrs.frozen
+        class Bai:
+            d = attrs.field(attrs.Factory(dict))
+
+        i = Bai()
+        i.d['answer'] = 42
+
+        @attrs.define
+        class Spam:
+            d = field(default=attrs.Factory(dict))
+
+        j = Spam(d=1)
+        j.d['answer'] = 42
+
+        @attrs.mutable
+        class Eggs:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        k = Eggs(d=1)
+        k.d['answer'] = 42
+
+        @attrs.frozen
+        class Eggs:
+            d = attrs.field(default=attrs.Factory(dict))
+
+        l = Eggs(d=1)
+        l.d['answer'] = 42
+        """
+        )
+
+        for name in ("f", "g", "h", "i", "j", "k", "l"):
+            should_be_unknown = next(module.getattr(name)[0].infer()).getattr("d")[0]
+            self.assertIsInstance(should_be_unknown, astroid.Unknown)
+
     def test_special_attributes(self) -> None:
         """Make sure special attrs attributes exist"""
 


### PR DESCRIPTION
## Description

Since version [21.3.0](https://github.com/python-attrs/attrs/releases/tag/21.3.0)
you can now `import attrs` instead of just `import attr`.

This patch adds support so that astroid doesn't barf on classes created using `@attrs.define`.

NOTE: Not not all names, most notably `attr.ib` and `attr.s` are available in `attrs`.

```py
>>> import attrs
>>> [name for name in dir(attrs) if not name.startswith("_")]
['Attribute', 'Factory', 'NOTHING', 'asdict', 'assoc', 'astuple', 'cmp_using', 'converters', 'defi
ne', 'evolve', 'exceptions', 'field', 'fields', 'fields_dict', 'filters', 'frozen', 'has', 'make_c
lass', 'mutable', 'resolve_types', 'setters', 'validate', 'validators']
```

The only decorators in that list are `@frozen`, `@mutable` and `@define`. The rest are classes or functions for interacting with attrs classes.

I added support for `@define` because the first example from the release notes has it,

```py
from attrs import define

@define
class HelloWorld:
    modern: bool = True
```

but was unsure about whether `@mutable` and `@frozen` should be done too.

## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes #1330
