### PR TITLE
Fix finding packages without an ``__init__.py``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,14 @@ What's New in astroid 2.10.0?
 Release date: TBA
 
 
+What's New in astroid 2.9.3?
+============================
+Release date: TBA
+
+* Fixed regression where packages without a ``__init__.py`` file were
+  not recognized or imported correctly.
+
+  Closes #1327
 
 What's New in astroid 2.9.2?
 ============================

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -297,6 +297,9 @@ def _get_relative_base_path(filename, path_to_check):
     if os.path.normcase(real_filename).startswith(path_to_check):
         importable_path = real_filename
 
+    # if "var" in path_to_check:
+    #     breakpoint()
+
     if importable_path:
         base_path = os.path.splitext(importable_path)[0]
         relative_base_path = base_path[len(path_to_check) :]
@@ -307,8 +310,11 @@ def _get_relative_base_path(filename, path_to_check):
 
 def modpath_from_file_with_callback(filename, path=None, is_package_cb=None):
     filename = os.path.expanduser(_path_from_filename(filename))
+    paths_to_check = sys.path.copy()
+    if path:
+        paths_to_check += path
     for pathname in itertools.chain(
-        path or [], sys.path, map(_cache_normalize_path, path or [], sys.path)
+        paths_to_check, map(_cache_normalize_path, paths_to_check)
     ):
         if not pathname:
             continue

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -308,7 +308,7 @@ def _get_relative_base_path(filename, path_to_check):
 def modpath_from_file_with_callback(filename, path=None, is_package_cb=None):
     filename = os.path.expanduser(_path_from_filename(filename))
     for pathname in itertools.chain(
-        path or [], map(_cache_normalize_path, sys.path), sys.path
+        path or [], sys.path, map(_cache_normalize_path, path or [], sys.path)
     ):
         if not pathname:
             continue

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -194,8 +194,11 @@ class ModPathFromFileTest(unittest.TestCase):
         """Test that we correctly find packages with an __init__.py file.
 
         Regression test for issue reported in:
+        https://github.com/PyCQA/astroid/issues/1327
         """
         tmp_dir = Path(tempfile.gettempdir())
+        self.addCleanup(os.chdir, os.curdir)
+        os.chdir(tmp_dir)
 
         self.addCleanup(shutil.rmtree, tmp_dir / "src")
         os.mkdir(tmp_dir / "src")
@@ -207,8 +210,8 @@ class ModPathFromFileTest(unittest.TestCase):
 
         # this should be equivalent to: import secret
         self.assertEqual(
-            modutils.modpath_from_file("src.package", [str(tmp_dir / "src")]),
-            ["package"],
+            modutils.modpath_from_file(str(Path("src") / "package"), ["."]),
+            ["src", "package"],
         )
 
 

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 import unittest
 import xml
+from pathlib import Path
 from xml import etree
 from xml.etree import ElementTree
 
@@ -188,6 +189,27 @@ class ModPathFromFileTest(unittest.TestCase):
 
         # this should be equivalent to: import secret
         self.assertEqual(modutils.modpath_from_file(symlink_secret_path), ["secret"])
+
+    def test_load_packages_without_init(self) -> None:
+        """Test that we correctly find packages with an __init__.py file.
+
+        Regression test for issue reported in:
+        """
+        tmp_dir = Path(tempfile.gettempdir())
+
+        self.addCleanup(shutil.rmtree, tmp_dir / "src")
+        os.mkdir(tmp_dir / "src")
+        os.mkdir(tmp_dir / "src" / "package")
+        with open(tmp_dir / "src" / "__init__.py", "w", encoding="utf-8"):
+            pass
+        with open(tmp_dir / "src" / "package" / "file.py", "w", encoding="utf-8"):
+            pass
+
+        # this should be equivalent to: import secret
+        self.assertEqual(
+            modutils.modpath_from_file("src.package", [str(tmp_dir / "src")]),
+            ["package"],
+        )
 
 
 class LoadModuleFromPathTest(resources.SysPathSetup, unittest.TestCase):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Closes #1327 

Had no time to write tests yet, so if somebody can come up with something good: please take over this PR, you're more than welcome to.
Just wanted to illustrate that this is what should be added again.

This regression was introduced in 2ee20cc

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

@Pierre-Sassoulas, this might warrant a `2.9.3` release.