### PR TITLE
Correct documentation, nodes classes do not exend python's ones

### DIFF
--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -23,8 +23,8 @@ pylint... Well, actually the development of this library is essentially
 governed by pylint's needs.
 
 It mimics the class defined in the python's _ast module with some
-additional methods and attributes. New nodes instances are not fully 
-compatible with python's _ast. 
+additional methods and attributes. New nodes instances are not fully
+compatible with python's _ast.
 
 Instance attributes are added by a
 builder object, which can either generate extended ast (let's call

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -22,8 +22,11 @@ python source code for projects such as pychecker, pyreverse,
 pylint... Well, actually the development of this library is essentially
 governed by pylint's needs.
 
-It extends class defined in the python's _ast module with some
-additional methods and attributes. Instance attributes are added by a
+It mimics the class defined in the python's _ast module with some
+additional methods and attributes. New nodes instances are not fully 
+compatible with python's _ast. 
+
+Instance attributes are added by a
 builder object, which can either generate extended ast (let's call
 them astroid ;) by visiting an existent ast tree or by inspecting living
 object. Methods are added by monkey patching ast classes.


### PR DESCRIPTION
## Description

Correct documentation, nodes classes do not exend python standard library ones

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Related Issue

Fixes #1336

