### PR TITLE
Provide actual literal_eval() function. Adapted from standard library's.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ What's New in astroid 2.10.0?
 =============================
 Release date: TBA
 
+* Provide `astroid.helpers.literal_eval` adapted from `ast.literal_eval`.
 
 What's New in astroid 2.9.4?
 ============================

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -113,6 +113,7 @@ class TooManyLevelsError(AstroidImportError):
 
 class AstroidSyntaxError(AstroidBuildingError):
     """Exception class used when a module can't be parsed."""
+    # this should probably be a SyntaxError subclass.
 
 
 class NoDefault(AstroidError):

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -336,7 +336,8 @@ def literal_eval(node_or_string: Union[str, nodes.NodeNG]) -> Any:
         node_or_string = node_or_string.value
     def _raise_malformed_node(node):
         msg = "malformed node or string"
-        if lno := getattr(node, 'lineno', None):
+        lno = getattr(node, 'lineno', None)
+        if lno:
             msg += f' on line {lno}'
         raise ValueError(msg + f': {node!r}')
     def _convert_num(node):

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -339,10 +339,11 @@ def literal_eval(node_or_string: Union[str, nodes.NodeNG]) -> Any:
 
     def _raise_malformed_node(node):
         msg = "malformed node or string"
-        lno = getattr(node, 'lineno', None)
+        lno = getattr(node, "lineno", None)
         if lno:
-            msg += f' on line {lno}'
-        raise ValueError(msg + f': {node!r}')
+            msg += f" on line {lno}"
+        raise ValueError(msg + f": {node!r}")
+
     def _convert_num(node):
         if not isinstance(node, nodes.Const) or type(node.value) not in (
             int,

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -21,7 +21,8 @@ Various helper utilities.
 """
 
 
-from astroid import bases, manager, nodes, raw_building, util
+from typing import Any, Union
+from astroid import bases, manager, nodes, raw_building, util, builder
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -314,3 +315,63 @@ def object_len(node, context=None):
     raise AstroidTypeError(
         f"'{result_of_len}' object cannot be interpreted as an integer"
     )
+
+def literal_eval(node_or_string: Union[str, nodes.NodeNG]) -> Any:
+    """
+    Safely evaluate an expression node or a string containing a Python
+    expression.  The string or node provided may only consist of the following
+    Python literal structures: strings, bytes, numbers, tuples, lists, dicts,
+    sets, booleans, and None.
+
+    Can raise `AstroidSyntaxError` or `ValueError`. 
+
+    Adapted from `ast.literal_eval`.
+    """
+    if isinstance(node_or_string, str):
+        _node = builder.parse(node_or_string.lstrip(" \t")).body
+        if len(_node) != 1:
+            raise ValueError(f'expected only one expression, found {len(_node)}')
+        node_or_string = _node[0]
+    if isinstance(node_or_string, nodes.Expr):
+        node_or_string = node_or_string.value
+    def _raise_malformed_node(node):
+        msg = "malformed node or string"
+        if lno := getattr(node, 'lineno', None):
+            msg += f' on line {lno}'
+        raise ValueError(msg + f': {node!r}')
+    def _convert_num(node):
+        if not isinstance(node, nodes.Const) or type(node.value) not in (int, float, complex):
+            _raise_malformed_node(node)
+        return node.value
+    def _convert_signed_num(node):
+        if isinstance(node, nodes.UnaryOp) and node.op in ("+", "-"):
+            operand = _convert_num(node.operand)
+            if node.op == "+":
+                return + operand
+            else:
+                return - operand
+        return _convert_num(node)
+    def _convert(node):
+        if isinstance(node, nodes.Const):
+            return node.value
+        elif isinstance(node, nodes.Tuple):
+            return tuple(map(_convert, node.elts))
+        elif isinstance(node, nodes.List):
+            return list(map(_convert, node.elts))
+        elif isinstance(node, nodes.Set):
+            return set(map(_convert, node.elts))
+        elif (isinstance(node, nodes.Call) and isinstance(node.func, nodes.Name) and
+              node.func.name == 'set' and node.args == node.keywords == []):
+            return set()
+        elif isinstance(node, nodes.Dict):
+            return {_convert(k):_convert(v) for k,v in node.items}
+        elif isinstance(node, nodes.BinOp) and node.op in ("+", "-"):
+            left = _convert_signed_num(node.left)
+            right = _convert_num(node.right)
+            if isinstance(left, (int, float)) and isinstance(right, complex):
+                if node.op == "+":
+                    return left + right
+                else:
+                    return left - right
+        return _convert_signed_num(node)
+    return _convert(node_or_string)

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -53,6 +53,7 @@ from astroid.exceptions import (
     InferenceError,
     NameInferenceError,
     _NonDeducibleTypeHierarchy,
+    AstroidSyntaxError,
 )
 from astroid.interpreter import dunder_lookup
 from astroid.manager import AstroidManager
@@ -812,13 +813,6 @@ UNINFERABLE_OPS = {
 }
 
 
-def _to_literal(node: nodes.NodeNG) -> Any:
-    # Can raise SyntaxError or ValueError from ast.literal_eval
-    # Can raise AttributeError from node.as_string() as not all nodes have a visitor
-    # Is this the stupidest idea or the simplest idea?
-    return ast.literal_eval(node.as_string())
-
-
 def _do_compare(
     left_iter: Iterable[nodes.NodeNG], op: str, right_iter: Iterable[nodes.NodeNG]
 ) -> "bool | type[util.Uninferable]":
@@ -844,8 +838,8 @@ def _do_compare(
             return util.Uninferable
 
         try:
-            left, right = _to_literal(left), _to_literal(right)
-        except (SyntaxError, ValueError, AttributeError):
+            left, right = helpers.literal_eval(left), helpers.literal_eval(right)
+        except (AstroidSyntaxError, ValueError):
             return util.Uninferable
 
         try:

--- a/tests/unittest_helpers.py
+++ b/tests/unittest_helpers.py
@@ -268,6 +268,9 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(helpers.literal_eval("{1, 2, 3}"), {1, 2, 3})
         self.assertEqual(helpers.literal_eval('b"hi"'), b"hi")
         self.assertEqual(helpers.literal_eval("set()"), set())
+        self.assertEqual(helpers.literal_eval("dict()"), dict())
+        self.assertEqual(helpers.literal_eval("list()"), list())
+        self.assertEqual(helpers.literal_eval("tuple()"), tuple())
         self.assertRaises(ValueError, helpers.literal_eval, "foo()")
         self.assertEqual(helpers.literal_eval("6"), 6)
         self.assertEqual(helpers.literal_eval("+6"), 6)
@@ -307,7 +310,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(helpers.literal_eval("\t\t-1"), -1)
         self.assertEqual(helpers.literal_eval(" \t -1"), -1)
 
-    def test_literal_eval_malformed_lineno(self):
+    def test_literal_eval_malformed(self):
         msg = r"malformed node or string on line 3:"
         with self.assertRaisesRegex(ValueError, msg):
             helpers.literal_eval("{'a': 1,\n'b':2,\n'c':++3,\n'd':4}")
@@ -317,11 +320,15 @@ class TestHelpers(unittest.TestCase):
         node = nodes.UnaryOp("+")
         node.postinit(operand=op)
 
-        self.assertIsNone(getattr(node, "lineno", None))
+        self.assertIsNone(node.lineno)
         msg = r"malformed node or string:"
         with self.assertRaisesRegex(ValueError, msg):
             helpers.literal_eval(node)
 
+    def test_literal_eval_multiple_expr(self):
+        msg = r"Expected only one expression, got 2"
+        with self.assertRaisesRegex(ValueError, msg):
+            helpers.literal_eval("a=1;b=2")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest_helpers.py
+++ b/tests/unittest_helpers.py
@@ -259,6 +259,66 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(helpers.is_supertype(builtin_type, cls_a))
         self.assertTrue(helpers.is_subtype(cls_a, builtin_type))
 
+    def test_literal_eval(self):
+        self.assertEqual(helpers.literal_eval('[1, 2, 3]'), [1, 2, 3])
+        self.assertEqual(helpers.literal_eval('{"foo": 42}'), {"foo": 42})
+        self.assertEqual(helpers.literal_eval('(True, False, None)'), (True, False, None))
+        self.assertEqual(helpers.literal_eval('{1, 2, 3}'), {1, 2, 3})
+        self.assertEqual(helpers.literal_eval('b"hi"'), b"hi")
+        self.assertEqual(helpers.literal_eval('set()'), set())
+        self.assertRaises(ValueError, helpers.literal_eval, 'foo()')
+        self.assertEqual(helpers.literal_eval('6'), 6)
+        self.assertEqual(helpers.literal_eval('+6'), 6)
+        self.assertEqual(helpers.literal_eval('-6'), -6)
+        self.assertEqual(helpers.literal_eval('3.25'), 3.25)
+        self.assertEqual(helpers.literal_eval('+3.25'), 3.25)
+        self.assertEqual(helpers.literal_eval('-3.25'), -3.25)
+        self.assertEqual(repr(helpers.literal_eval('-0.0')), '-0.0')
+        self.assertRaises(ValueError, helpers.literal_eval, '++6')
+        self.assertRaises(ValueError, helpers.literal_eval, '+True')
+        self.assertRaises(ValueError, helpers.literal_eval, '2+3')
+
+    def test_literal_eval_complex(self):
+        # Issue #4907
+        self.assertEqual(helpers.literal_eval('6j'), 6j)
+        self.assertEqual(helpers.literal_eval('-6j'), -6j)
+        self.assertEqual(helpers.literal_eval('6.75j'), 6.75j)
+        self.assertEqual(helpers.literal_eval('-6.75j'), -6.75j)
+        self.assertEqual(helpers.literal_eval('3+6j'), 3+6j)
+        self.assertEqual(helpers.literal_eval('-3+6j'), -3+6j)
+        self.assertEqual(helpers.literal_eval('3-6j'), 3-6j)
+        self.assertEqual(helpers.literal_eval('-3-6j'), -3-6j)
+        self.assertEqual(helpers.literal_eval('3.25+6.75j'), 3.25+6.75j)
+        self.assertEqual(helpers.literal_eval('-3.25+6.75j'), -3.25+6.75j)
+        self.assertEqual(helpers.literal_eval('3.25-6.75j'), 3.25-6.75j)
+        self.assertEqual(helpers.literal_eval('-3.25-6.75j'), -3.25-6.75j)
+        self.assertEqual(helpers.literal_eval('(3+6j)'), 3+6j)
+        self.assertRaises(ValueError, helpers.literal_eval, '-6j+3')
+        self.assertRaises(ValueError, helpers.literal_eval, '-6j+3j')
+        self.assertRaises(ValueError, helpers.literal_eval, '3+-6j')
+        self.assertRaises(ValueError, helpers.literal_eval, '3+(0+6j)')
+        self.assertRaises(ValueError, helpers.literal_eval, '-(3+6j)')
+        self.assertRaises(ValueError, helpers.literal_eval, 'random()')
+
+    def test_literal_eval_trailing_ws(self):
+        self.assertEqual(helpers.literal_eval("    -1"), -1)
+        self.assertEqual(helpers.literal_eval("\t\t-1"), -1)
+        self.assertEqual(helpers.literal_eval(" \t -1"), -1)
+
+    def test_literal_eval_malformed_lineno(self):
+        msg = r'malformed node or string on line 3:'
+        with self.assertRaisesRegex(ValueError, msg):
+            helpers.literal_eval("{'a': 1,\n'b':2,\n'c':++3,\n'd':4}")
+
+        op = nodes.UnaryOp("+")
+        op.postinit(operand=nodes.Const(6))
+        node = nodes.UnaryOp("+")
+        node.postinit(operand=op)
+
+        self.assertIsNone(getattr(node, 'lineno', None))
+        msg = r'malformed node or string:'
+        with self.assertRaisesRegex(ValueError, msg):
+            helpers.literal_eval(node)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Provide actual `literal_eval()` function. Adapted from standard library's.
Use that function in `inference.py` instead of the dummy `_to_literal()` function.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring (tiny bit)  |
