### PR TITLE
Changed NodeNG.tolineno to use end_lineno when it is available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,11 @@ Release date: TBA
 
   Closes #1330
 
+* Use the ``end_lineno`` attribute for the ``NodeNG.toline`` property
+  when it is available.
+
+  Closes #1350
+
 * Add ``is_dataclass`` attribute to ``ClassDef`` nodes.
 
 * Use ``sysconfig`` instead of ``distutils`` to determine the location of

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ Release date: TBA
 
   Closes #1330
 
-* Use the ``end_lineno`` attribute for the ``NodeNG.toline`` property
+* Use the ``end_lineno`` attribute for the ``NodeNG.tolineno`` property
   when it is available.
 
   Closes #1350

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -436,6 +436,8 @@ class NodeNG:
     @decorators.cachedproperty
     def tolineno(self) -> Optional[int]:
         """The last line that this node appears on in the source code."""
+        if self.end_lineno is not None:
+            return self.end_lineno
         if not self._astroid_fields:
             # can't have children
             last_child = None

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -2128,22 +2128,18 @@ class TreeRebuilder:
             # TryExcept excludes the 'finally' but that will be included in the
             # end_lineno from 'node'. Therefore, we check all non 'finally'
             # children to find the correct end_lineno and column.
-            last_child_end_lineno: Optional[int] = node.lineno
-            last_child_end_col_offset = node.end_col_offset
-            if node.orelse:
-                last_child_end_lineno = node.orelse[-1].end_lineno
-                last_child_end_col_offset = node.orelse[-1].end_col_offset
-            elif node.handlers:
-                last_child_end_lineno = node.handlers[-1].end_lineno
-                last_child_end_col_offset = node.handlers[-1].end_col_offset
-            elif node.body:
-                last_child_end_lineno = node.body[-1].end_lineno
-                last_child_end_col_offset = node.body[-1].end_col_offset
+            end_lineno = node.end_lineno
+            end_col_offset = node.end_col_offset
+            all_children: List["ast.AST"] = [*node.body, *node.handlers, *node.orelse]
+            for child in reversed(all_children):
+                end_lineno = child.end_lineno
+                end_col_offset = child.end_col_offset
+                break
             newnode = nodes.TryExcept(
                 lineno=node.lineno,
                 col_offset=node.col_offset,
-                end_lineno=last_child_end_lineno,
-                end_col_offset=last_child_end_col_offset,
+                end_lineno=end_lineno,
+                end_col_offset=end_col_offset,
                 parent=parent,
             )
         else:

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -2126,14 +2126,19 @@ class TreeRebuilder:
         """visit a TryExcept node by returning a fresh instance of it"""
         if sys.version_info >= (3, 8):
             # TryExcept excludes the 'finally' but that will be included in the
-            # end_lineno from 'node'. Therefore, we iterate over all non 'finally'
+            # end_lineno from 'node'. Therefore, we check all non 'finally'
             # children to find the correct end_lineno and column.
-            last_child_end_lineno = node.lineno
+            last_child_end_lineno: Optional[int] = node.lineno
             last_child_end_col_offset = node.end_col_offset
-            for child in node.body + node.handlers + node.orelse:
-                if child.end_lineno > last_child_end_lineno:
-                    last_child_end_lineno = child.end_lineno
-                    last_child_end_col_offset = child.end_col_offset
+            if node.orelse:
+                last_child_end_lineno = node.orelse[-1].end_lineno
+                last_child_end_col_offset = node.orelse[-1].end_col_offset
+            elif node.handlers:
+                last_child_end_lineno = node.handlers[-1].end_lineno
+                last_child_end_col_offset = node.handlers[-1].end_col_offset
+            elif node.body:
+                last_child_end_lineno = node.body[-1].end_lineno
+                last_child_end_col_offset = node.body[-1].end_col_offset
             newnode = nodes.TryExcept(
                 lineno=node.lineno,
                 col_offset=node.col_offset,

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -70,11 +70,14 @@ class FromToLineNoTest(unittest.TestCase):
         self.assertEqual(name.tolineno, 4)
         strarg = callfunc.args[0]
         self.assertIsInstance(strarg, nodes.Const)
-        if hasattr(sys, "pypy_version_info") or not PY38_PLUS:
+        if hasattr(sys, "pypy_version_info"):
             self.assertEqual(strarg.fromlineno, 4)
             self.assertEqual(strarg.tolineno, 4)
         else:
-            self.assertEqual(strarg.fromlineno, 4)
+            if not PY38_PLUS:
+                self.assertEqual(strarg.fromlineno, 5)
+            else:
+                self.assertEqual(strarg.fromlineno, 4)
             self.assertEqual(strarg.tolineno, 5)
         namearg = callfunc.args[1]
         self.assertIsInstance(namearg, nodes.Name)

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -70,12 +70,12 @@ class FromToLineNoTest(unittest.TestCase):
         self.assertEqual(name.tolineno, 4)
         strarg = callfunc.args[0]
         self.assertIsInstance(strarg, nodes.Const)
-        if hasattr(sys, "pypy_version_info"):
-            lineno = 4
+        if hasattr(sys, "pypy_version_info") or not PY38_PLUS:
+            self.assertEqual(strarg.fromlineno, 4)
+            self.assertEqual(strarg.tolineno, 4)
         else:
-            lineno = 5 if not PY38_PLUS else 4
-        self.assertEqual(strarg.fromlineno, lineno)
-        self.assertEqual(strarg.tolineno, lineno)
+            self.assertEqual(strarg.fromlineno, 4)
+            self.assertEqual(strarg.tolineno, 5)
         namearg = callfunc.args[1]
         self.assertIsInstance(namearg, nodes.Name)
         self.assertEqual(namearg.fromlineno, 5)

--- a/tests/unittest_nodes_lineno.py
+++ b/tests/unittest_nodes_lineno.py
@@ -784,7 +784,7 @@ class TestLinenoColOffset:
         assert (t3.lineno, t3.col_offset) == (10, 0)
         assert (t3.end_lineno, t3.end_col_offset) == (17, 8)
         assert (t3.body[0].lineno, t3.body[0].col_offset) == (10, 0)
-        assert (t3.body[0].end_lineno, t3.body[0].end_col_offset) == (17, 8)
+        assert (t3.body[0].end_lineno, t3.body[0].end_col_offset) == (15, 8)
         assert (t3.finalbody[0].lineno, t3.finalbody[0].col_offset) == (17, 4)
         assert (t3.finalbody[0].end_lineno, t3.finalbody[0].end_col_offset) == (17, 8)
 

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1100,7 +1100,10 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(data)
         self.assertEqual(astroid["g1"].fromlineno, 4)
         self.assertEqual(astroid["g1"].tolineno, 5)
-        self.assertEqual(astroid["g2"].fromlineno, 10)
+        if not PY38_PLUS:
+            self.assertEqual(astroid["g2"].fromlineno, 9)
+        else:
+            self.assertEqual(astroid["g2"].fromlineno, 10)
         self.assertEqual(astroid["g2"].tolineno, 11)
 
     def test_metaclass_error(self) -> None:

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1078,15 +1078,16 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
                 print(x)
 
             @f(a=2,
-               b=3)
+               b=3,
+            )
             def g2():
                 pass
         """
         astroid = builder.parse(data)
         self.assertEqual(astroid["g1"].fromlineno, 4)
         self.assertEqual(astroid["g1"].tolineno, 5)
-        self.assertEqual(astroid["g2"].fromlineno, 9)
-        self.assertEqual(astroid["g2"].tolineno, 10)
+        self.assertEqual(astroid["g2"].fromlineno, 10)
+        self.assertEqual(astroid["g2"].tolineno, 11)
 
     def test_metaclass_error(self) -> None:
         astroid = builder.parse(


### PR DESCRIPTION
## Steps

TODO: Update ChangeLog.

## Description

astroid currently relies on heuristics for computing node ranges. This was necessary prior to 
Python 3.8, because the `ast` module did not report `end_lineno` (nor `end_col_offset`) for 
the parsed nodes. 

This PR changes `NodeNG.toline` to prefer `end_lineno` coming from the `ast` module,
if available, to the one computed heuristically.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

Closes #1350.
