### PR TITLE
Use ``warnings.simplefilter`` instead of ``filterwarnings``

### DIFF
--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -340,7 +340,7 @@ class InspectBuilder:
         for name in dir(obj):
             try:
                 with warnings.catch_warnings():
-                    warnings.filterwarnings("error")
+                    warnings.simplefilter("error")
                     member = getattr(obj, name)
             except (AttributeError, DeprecationWarning):
                 # damned ExtensionClass.Base, I know you're there !


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

See documentation for [warnings](https://docs.python.org/3/library/warnings.html).
This was added in https://github.com/PyCQA/astroid/pull/785/files. However, a little profiling of `pylint` shows that this function is actually quite "expensive", accounting for 1.75% of runtime on a empty file.
You can that a smaller share of `object_build` is spent in `warnings` in the screenshot:
`(1,74/36,77) > (1,119/35,27)`.

The gain is minor but when I found out it didn't make sense not to make a little PR.


<img width="839" alt="Schermafbeelding 2022-01-16 om 17 07 10" src="https://user-images.githubusercontent.com/13665637/149667834-0c99ea72-7056-484e-9738-86b3e42c1516.png">
<img width="940" alt="Schermafbeelding 2022-01-16 om 17 10 12" src="https://user-images.githubusercontent.com/13665637/149667930-e288d542-75b1-427a-a9df-72241bd0574c.png">


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

