### PR TITLE
Fix typing in ``arguments.py``

### DIFF
--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -11,11 +11,10 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
-from typing import Optional
+from typing import Optional, Set
 
 from astroid import nodes
 from astroid.bases import Instance
-from astroid.const import Context
 from astroid.context import CallContext, InferenceContext
 from astroid.exceptions import InferenceError, NoDefault
 from astroid.util import Uninferable
@@ -46,7 +45,7 @@ class CallSite:
         self.argument_context_map = argument_context_map
         args = callcontext.args
         keywords = callcontext.keywords
-        self.duplicated_keywords = set()
+        self.duplicated_keywords: Set[str] = set()
         self._unpacked_args = self._unpack_args(args, context=context)
         self._unpacked_kwargs = self._unpack_keywords(keywords, context=context)
 
@@ -60,7 +59,7 @@ class CallSite:
         }
 
     @classmethod
-    def from_call(cls, call_node, context: Optional[Context] = None):
+    def from_call(cls, call_node, context: Optional[InferenceContext] = None):
         """Get a CallSite object from the given Call node.
 
         context will be used to force a single inference path.


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

@Pierre-Sassoulas, you added the typing for `Context` in https://github.com/PyCQA/astroid/commit/b7fe6a391fa6852825f24a3dbeb8c87904a4a86d. Are you sure it is correct? It seems weird considering the assignment a couple of lines below.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue