### PR TITLE
Fix typing issues in ``brain_typing``.

### DIFF
--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -150,7 +150,7 @@ def infer_typing_attr(
 ) -> typing.Iterator[ClassDef]:
     """Infer a typing.X[...] subscript"""
     try:
-        value = next(node.value.infer())
+        value = next(node.value.infer())  # type: ignore[union-attr] # value shouldn't be None for Subscript.
     except (InferenceError, StopIteration) as exc:
         raise UseInferenceDefault from exc
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -17,6 +17,7 @@ import typing
 from functools import partial
 
 from astroid import context, extract_node, inference_tip
+from astroid.builder import _extract_single_node
 from astroid.const import PY37_PLUS, PY38_PLUS, PY39_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
@@ -171,7 +172,7 @@ def infer_typing_attr(
         # With PY37+ typing.Generic and typing.Annotated (PY39) are subscriptable
         # through __class_getitem__. Since astroid can't easily
         # infer the native methods, replace them for an easy inference tip
-        func_to_add = extract_node(CLASS_GETITEM_TEMPLATE)
+        func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
         value.locals["__class_getitem__"] = [func_to_add]
         if (
             isinstance(node.parent, ClassDef)
@@ -199,7 +200,7 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
 def infer_old_typedDict(  # pylint: disable=invalid-name
     node: ClassDef, ctx: typing.Optional[context.InferenceContext] = None
 ) -> typing.Iterator[ClassDef]:
-    func_to_add = extract_node("dict")
+    func_to_add = _extract_single_node("dict")
     node.locals["__call__"] = [func_to_add]
     return iter([node])
 
@@ -215,7 +216,7 @@ def infer_typedDict(  # pylint: disable=invalid-name
         parent=node.parent,
     )
     class_def.postinit(bases=[extract_node("dict")], body=[], decorators=None)
-    func_to_add = extract_node("dict")
+    func_to_add = _extract_single_node("dict")
     class_def.locals["__call__"] = [func_to_add]
     return iter([class_def])
 
@@ -308,7 +309,7 @@ def infer_typing_alias(
         and maybe_type_var.value > 0
     ):
         # If typing alias is subscriptable, add `__class_getitem__` to ClassDef
-        func_to_add = extract_node(CLASS_GETITEM_TEMPLATE)
+        func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
         class_def.locals["__class_getitem__"] = [func_to_add]
     else:
         # If not, make sure that `__class_getitem__` access is forbidden.
@@ -373,7 +374,7 @@ def infer_special_alias(
         parent=node.parent,
     )
     class_def.postinit(bases=[res], body=[], decorators=None)
-    func_to_add = extract_node(CLASS_GETITEM_TEMPLATE)
+    func_to_add = _extract_single_node(CLASS_GETITEM_TEMPLATE)
     class_def.locals["__class_getitem__"] = [func_to_add]
     return iter([class_def])
 

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -455,6 +455,14 @@ def extract_node(code: str, module_name: str = "") -> Union[NodeNG, List[NodeNG]
     return extracted
 
 
+def _extract_single_node(code: str, module_name: str = "") -> NodeNG:
+    """Call extract_node while making sure that only one value is returned."""
+    ret = extract_node(code, module_name)
+    if isinstance(ret, list):
+        return ret[0]
+    return ret
+
+
 def _parse_string(data, type_comments=True):
     parser_module = get_parser_module(type_comments=type_comments)
     try:


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

**These changes shouldn't be squashed.**

The helper method can be used in other places internally as well. Sadly the original function is called `extract_node` which would have been a good name for this one as well.. 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue