### PR TITLE
Fix builtin inference on property not including function arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in astroid 2.10.0?
 =============================
 Release date: TBA
 
+* Fixed builtin inferenence on `property` calls not calling the `postinit` of the new node, which 
+  resulted in instance arguments missing on these nodes.
 
 What's New in astroid 2.9.4?
 ============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,7 @@ What's New in astroid 2.10.0?
 =============================
 Release date: TBA
 
-* Fixed builtin inferenence on `property` calls not calling the `postinit` of the new node, which 
+* Fixed builtin inferenence on `property` calls not calling the `postinit` of the new node, which
   resulted in instance arguments missing on these nodes.
 
 What's New in astroid 2.9.4?

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -566,7 +566,7 @@ def infer_property(node, context=None):
     if not isinstance(inferred, (nodes.FunctionDef, nodes.Lambda)):
         raise UseInferenceDefault
 
-    return objects.Property(
+    prop_func = objects.Property(
         function=inferred,
         name=inferred.name,
         doc=getattr(inferred, "doc", None),
@@ -574,6 +574,8 @@ def infer_property(node, context=None):
         parent=node,
         col_offset=node.col_offset,
     )
+    prop_func.postinit(body=[], args=inferred.args)
+    return prop_func
 
 
 def infer_bool(node, context=None):

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -1,0 +1,21 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+"""Unit Tests for the builtins brain module."""
+
+import unittest
+
+from astroid import extract_node, objects
+
+class BuiltinsTest(unittest.TestCase):
+    def test_infer_property(self):
+        class_with_property = extract_node(
+        """
+        class Something:
+            def getter():
+                return 5
+            asd = property(getter) #@
+        """
+        )
+        inferred_property = list(class_with_property.value.infer())[0]
+        assert isinstance(inferred_property, objects.Property)
+        assert hasattr(inferred_property, "args")

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -6,10 +6,11 @@ import unittest
 
 from astroid import extract_node, objects
 
+
 class BuiltinsTest(unittest.TestCase):
     def test_infer_property(self):
         class_with_property = extract_node(
-        """
+            """
         class Something:
             def getter():
                 return 5
@@ -17,5 +18,5 @@ class BuiltinsTest(unittest.TestCase):
         """
         )
         inferred_property = list(class_with_property.value.infer())[0]
-        assert isinstance(inferred_property, objects.Property)
-        assert hasattr(inferred_property, "args")
+        self.assertTrue(isinstance(inferred_property, objects.Property))
+        self.assertTrue(hasattr(inferred_property, "args"))


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

This ensures that when we transform a call to the builtin `property` into an `objects.Property`, we correctly postinitialize its function arguments.

Not doing so leads to a crash in https://github.com/PyCQA/pylint/pull/5610. 

This PR can be merged, but testing it is dependent on #1365 because this code is not being called consistently so we can't write a test for it.

But sometimes the code is called, which is why it is needed for the Pylint issue above.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
