### PR TITLE
Fix crash on inference of ``__dict__.items()`` of an imported module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@ What's New in astroid 2.10.0?
 Release date: TBA
 
 
+* Fixed crash when trying to infer ``items()`` on the ``__dict__``
+  attribute of an imported module.
+
+  Closes #1085
+
 What's New in astroid 2.9.4?
 ============================
 Release date: TBA

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -317,6 +317,8 @@ def infer_attribute(self, context=None):
 
         if not context:
             context = InferenceContext()
+        else:
+            context = copy_context(context)
 
         old_boundnode = context.boundnode
         try:

--- a/tests/testdata/python3/data/module_dict_items_call/models.py
+++ b/tests/testdata/python3/data/module_dict_items_call/models.py
@@ -1,0 +1,5 @@
+import re
+
+
+class MyModel:
+    class_attribute = 1

--- a/tests/testdata/python3/data/module_dict_items_call/test.py
+++ b/tests/testdata/python3/data/module_dict_items_call/test.py
@@ -1,0 +1,7 @@
+import models
+
+
+def func():
+    for _, value in models.__dict__.items():
+        if isinstance(value, type):
+            value.class_attribute += 1

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -48,6 +48,7 @@ import textwrap
 import unittest
 from abc import ABCMeta
 from functools import partial
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple, Union
 from unittest.mock import patch
 
@@ -88,6 +89,7 @@ builder = AstroidBuilder()
 
 EXC_MODULE = "builtins"
 BOOL_SPECIAL_METHOD = "__bool__"
+DATA_DIR = Path(__file__).parent / "testdata" / "python3" / "data"
 
 
 class InferenceUtilsTest(unittest.TestCase):
@@ -1732,8 +1734,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         ast = extract_node(code, __name__)
         expr = ast.func.expr
-        with pytest.raises(InferenceError):
-            next(expr.infer())
+        self.assertIs(next(expr.infer()), util.Uninferable)
 
     def test_tuple_builtin_inference(self) -> None:
         code = """
@@ -6582,6 +6583,14 @@ def test_relative_imports_init_package() -> None:
     resources.build_file(
         "data/beyond_top_level_three/module/sub_module/sub_sub_module/main.py"
     )
+
+
+def test_inference_of_items_on_module_dict() -> None:
+    """Crash test for the inference of items() on a module's dict attribute.
+
+    Originally reported in https://github.com/PyCQA/astroid/issues/1085
+    """
+    builder.file_build(str(DATA_DIR / "module_dict_items_call" / "test.py"), "models")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Closes #1085.

The issue was that if a previous `context` was provided it was not correctly copied. This is problematic as the `localname` will be set in this function, altering the `context` object for other inference functions that later on use or copy the same `context` object.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

