### PR TITLE
Add `qname` attribute to `AssignAttr` to prevent crashes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,9 @@ Release date: TBA
 
   Closes #1330
 
+* Introduce `qname` method for `AssignAttr` nodes for cases where they are treated 
+  as Class definitions to fix a crash while inferring them as modules.
+
 What's New in astroid 2.9.4?
 ============================
 Release date: TBA

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@ Release date: TBA
 
   Closes #1330
 
-* Introduce `qname` method for `AssignAttr` nodes for cases where they are treated 
+* Introduce `qname` method for `AssignAttr` nodes for cases where they are treated
   as Class definitions to fix a crash while inferring them as modules.
 
 What's New in astroid 2.9.4?

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1076,8 +1076,9 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         while not isinstance(cur, Name):
             names.append(cur.attrname)
             cur = cur.expr
-        names.append(cur.name)
+        names.append(cur.name)  # pylint: disable=no-member
         return ".".join(reversed(names))
+
 
 class Assert(Statement):
     """Class representing an :class:`ast.Assert` node.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1070,6 +1070,14 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
     def get_children(self):
         yield self.expr
 
+    def qname(self):
+        cur = self
+        names = []
+        while not isinstance(cur, Name):
+            names.append(cur.attrname)
+            cur = cur.expr
+        names.append(cur.name)
+        return ".".join(reversed(names))
 
 class Assert(Statement):
     """Class representing an :class:`ast.Assert` node.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -621,8 +621,6 @@ class Module(LocalsDictNodeNG):
     def statement(self, *, future: Literal[None] = ...) -> "Module":
         ...
 
-    # pylint: disable-next=arguments-differ
-    # https://github.com/PyCQA/pylint/issues/5264
     @overload
     def statement(self, *, future: Literal[True]) -> NoReturn:
         ...


### PR DESCRIPTION
This change prevents a crash that occurs when reassigning module names and retrieving their
`qname`. In some constructions an `AssignAttr` is inferred and treated as a `ClassDef`.

## Steps

- [X] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [X] Write a good description on what the PR does.

## Description

The testing package [freezegun](https://github.com/spulec/freezegun/blob/master/freezegun/api.py) includes this construction, which overrides a module name. 

```
        datetime.datetime = FakeDatetime
        datetime.date = FakeDate
```

This can cause an `AssignAttr` to become part of an inference for a class definition and appear where we normally expect only `ClassDef`.

This causes the crash in the linked issue.


The below file also creates  a related crash in `pylint_django`.
```
from freezegun import freeze_time
import datetime

# Change the modules
datetime.datetime = FakeDatetime
datetime.date = FakeDate

with freeze_time():
# with freeze_time(localized_utcnow()):
    pass

from django.db.models.fields import DateField

from model_utils.fields import (
    AutoCreatedField,
)
# created = AutoCreatedField()
DateField()
```

```
  File "/code/open_source/astroid/astroid/transforms.py", line 45, in _transform
    if predicate is None or predicate(node):
  File "/code/open_source/license-manager/.venv/lib/python3.9/site-packages/pylint_django/transforms/foreignkey.py", line 17, in is_foreignkey_in_class
    is_in_django_model_class = node_is_subclass(node.parent.parent, "django.db.models.base.Model", ".Model")
  File "/code/open_source/license-manager/.venv/lib/python3.9/site-packages/pylint_django/utils.py", line 26, in node_is_subclass
    if inf.qname() in subclass_names:
```

The most straightforward fix is to give `AssignAttr` a `qname` method like `ClassDef` have. For the `AssignAttr` `datetime`, the second one, this would be `datetime.datetime`.

This fixes the crashes described above and passes the Astroid tests and Pylint tests on Python 3.9. 

I have not been able to create a concise reproduction example, so I am not sure how to test it. The examples we have seem to involve the intersection of Django and Freezegun. I have already spent a decent effort trying to figure out exactly what causes the crash without much headway, but the fix is so straightforward and seems safe enough that I wanted to just submit it and see what we think about merging it anyways.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes https://github.com/PyCQA/pylint/issues/5717
