### PR TITLE
Update mypy requirement to 0.931

### DIFF
--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -3,4 +3,4 @@ pylint==2.12.2
 isort==5.9.2
 flake8==4.0.1
 flake8-typing-imports==1.11.0
-mypy==0.930
+mypy==0.931


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Description

pre-commit uses `0.931` already. Update the requirement file to match that.
https://github.com/PyCQA/astroid/blob/42b5b4021727eeba64664691ddb1d07b4a328a76/.pre-commit-config.yaml#L65-L66