### PR TITLE
Fix typing for `assigned_stmts`

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -44,7 +44,16 @@ import sys
 import typing
 import warnings
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, Generator, Optional, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Generator,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 from astroid import decorators, mixins, util
 from astroid.bases import Instance, _infer_stmts
@@ -478,7 +487,7 @@ class AssignName(
             parent=parent,
         )
 
-    assigned_stmts: AssignedStmtsCall["AssignName"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["AssignName"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -804,7 +813,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         if type_comment_posonlyargs is not None:
             self.type_comment_posonlyargs = type_comment_posonlyargs
 
-    assigned_stmts: AssignedStmtsCall["Arguments"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["Arguments"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1062,7 +1071,7 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         """
         self.expr = expr
 
-    assigned_stmts: AssignedStmtsCall["AssignAttr"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["AssignAttr"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1210,7 +1219,7 @@ class Assign(mixins.AssignTypeMixin, Statement):
         self.value = value
         self.type_annotation = type_annotation
 
-    assigned_stmts: AssignedStmtsCall["Assign"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["Assign"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1307,7 +1316,7 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         self.value = value
         self.simple = simple
 
-    assigned_stmts: AssignedStmtsCall["AnnAssign"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["AnnAssign"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1393,7 +1402,7 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         self.target = target
         self.value = value
 
-    assigned_stmts: AssignedStmtsCall["AugAssign"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["AugAssign"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1864,7 +1873,7 @@ class Comprehension(NodeNG):
             self.ifs = ifs
         self.is_async = is_async
 
-    assigned_stmts: AssignedStmtsCall["Comprehension"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["Comprehension"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -2556,7 +2565,7 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
             parent=parent,
         )
 
-    assigned_stmts: AssignedStmtsCall["ExceptHandler"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["ExceptHandler"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -2719,7 +2728,7 @@ class For(
             self.orelse = orelse
         self.type_annotation = type_annotation
 
-    assigned_stmts: AssignedStmtsCall["For"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["For"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -3424,7 +3433,7 @@ class List(BaseContainer):
             parent=parent,
         )
 
-    assigned_stmts: AssignedStmtsCall["List"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["List"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -3855,7 +3864,7 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
         """
         self.value = value
 
-    assigned_stmts: AssignedStmtsCall["Starred"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["Starred"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -4186,7 +4195,7 @@ class Tuple(BaseContainer):
             parent=parent,
         )
 
-    assigned_stmts: AssignedStmtsCall["Tuple"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["Tuple"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -4485,7 +4494,7 @@ class With(
             self.body = body
         self.type_annotation = type_annotation
 
-    assigned_stmts: AssignedStmtsCall["With"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["With"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -4793,7 +4802,7 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
         self.target = target
         self.value = value
 
-    assigned_stmts: AssignedStmtsCall["NamedExpr"]
+    assigned_stmts: ClassVar[AssignedStmtsCall["NamedExpr"]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -5160,14 +5169,16 @@ class MatchMapping(mixins.AssignTypeMixin, Pattern):
         self.patterns = patterns
         self.rest = rest
 
-    assigned_stmts: Callable[
-        [
-            "MatchMapping",
-            AssignName,
-            Optional[InferenceContext],
-            Literal[None],
-        ],
-        Generator[NodeNG, None, None],
+    assigned_stmts: ClassVar[
+        Callable[
+            [
+                "MatchMapping",
+                AssignName,
+                Optional[InferenceContext],
+                Literal[None],
+            ],
+            Generator[NodeNG, None, None],
+        ]
     ]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
@@ -5265,14 +5276,16 @@ class MatchStar(mixins.AssignTypeMixin, Pattern):
     def postinit(self, *, name: Optional[AssignName]) -> None:
         self.name = name
 
-    assigned_stmts: Callable[
-        [
-            "MatchStar",
-            AssignName,
-            Optional[InferenceContext],
-            Literal[None],
-        ],
-        Generator[NodeNG, None, None],
+    assigned_stmts: ClassVar[
+        Callable[
+            [
+                "MatchStar",
+                AssignName,
+                Optional[InferenceContext],
+                Literal[None],
+            ],
+            Generator[NodeNG, None, None],
+        ]
     ]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
@@ -5334,14 +5347,16 @@ class MatchAs(mixins.AssignTypeMixin, Pattern):
         self.pattern = pattern
         self.name = name
 
-    assigned_stmts: Callable[
-        [
-            "MatchAs",
-            AssignName,
-            Optional[InferenceContext],
-            Literal[None],
-        ],
-        Generator[NodeNG, None, None],
+    assigned_stmts: ClassVar[
+        Callable[
+            [
+                "MatchAs",
+                AssignName,
+                Optional[InferenceContext],
+                Literal[None],
+            ],
+            Generator[NodeNG, None, None],
+        ]
     ]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.


### PR DESCRIPTION
## Description
Methods are attributes of the class and should therefore be typed as ClassVar.
https://docs.python.org/3/library/typing.html#typing.ClassVar

This isn't recognized by mypy yet. I had a similar issue with Home Assistant when someone mentioned `ClassVar`.


/CC @DanielNoord