### PR TITLE
Update requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-bugbear, flake8-typing-imports==1.11.0]
+        additional_dependencies: [flake8-bugbear, flake8-typing-imports==1.12.0]
         exclude: tests/testdata|doc/conf.py|astroid/__init__.py
   - repo: local
     hooks:

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,6 +1,6 @@
-black==21.7b0
+black==22.1.0
 pylint==2.12.2
-isort==5.9.2
+isort==5.10.1
 flake8==4.0.1
 flake8-typing-imports==1.11.0
 mypy==0.931

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -2,5 +2,5 @@ black==22.1.0
 pylint==2.12.2
 isort==5.10.1
 flake8==4.0.1
-flake8-typing-imports==1.11.0
+flake8-typing-imports==1.12.0
 mypy==0.931


### PR DESCRIPTION
## Description
* Match requirements from `pre-commit-config` in `requirements_test_pre_commit.txt`
* Bump `flake8-typing-import` to `1.12.0`
https://github.com/asottile/flake8-typing-imports/compare/v1.11.0...v1.12.0