### PR TITLE
Include names of keyword-only arguments in `argnames()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#5679
 
+* Inlcude names of keyword-only arguments in ``astroid.scoped_nodes.Lambda.argnames``.
+
+  Closes PyCQA/pylint#5771
+
 * Add support for [attrs v21.3.0](https://github.com/python-attrs/attrs/releases/tag/21.3.0) which
   added a new `attrs` module alongside the existing `attr`.
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1376,6 +1376,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
             names = _rec_get_names(self.args.arguments)
         else:
             names = []
+        names += [elt.name for elt in self.args.kwonlyargs]
         if self.args.vararg:
             names.append(self.args.vararg)
         if self.args.kwarg:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1366,8 +1366,10 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         """
         return True
 
-    def argnames(self):
-        """Get the names of each of the arguments.
+    def argnames(self) -> List[str]:
+        """Get the names of each of the arguments, including that
+        of the collections of variable-length arguments ("args", "kwargs",
+        etc.), as well as keyword-only arguments.
 
         :returns: The names of the arguments.
         :rtype: list(str)
@@ -1992,7 +1994,7 @@ class AsyncFunctionDef(FunctionDef):
     """
 
 
-def _rec_get_names(args, names=None):
+def _rec_get_names(args, names: Optional[List[str]] = None) -> List[str]:
     """return a list of all argument names"""
     if names is None:
         names = []

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -473,6 +473,10 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(code, __name__)
         self.assertEqual(astroid["f"].argnames(), ["a", "b", "c", "args", "kwargs"])
 
+        code_with_kwonly_args = "def f(a, b, *, c=None, d=None): pass"
+        astroid = builder.parse(code_with_kwonly_args, __name__)
+        self.assertEqual(astroid["f"].argnames(), ["a", "b", "c", "d"])
+
     def test_return_nothing(self) -> None:
         """test inferred value on a function with empty return"""
         data = """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Before, `astroid.scoped_nodes.Lambda.argnames()` left out the names of keyword-only arguments. This caused a false positive in a Pylint checker.

Of course, it's possible confusion could continue in the future if we continue to let `Arguments.arguments()` skip these. 🤔 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Ref. PyCQA/pylint#5771
