### PR TITLE
Add typing to the parent attribute of ExceptHandler

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2523,11 +2523,16 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
     _astroid_fields = ("type", "name", "body")
     _multi_line_block_fields = ("body",)
 
+    # TODO: Make parent non-optional
+    parent: Optional["nodes.TryExcept"]
+    """The parent node in the syntax tree."""
+
     def __init__(
         self,
         lineno: Optional[int] = None,
         col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        # TODO: Make parent non-optional
+        parent: Optional["nodes.TryExcept"] = None,
         *,
         end_lineno: Optional[int] = None,
         end_col_offset: Optional[int] = None,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -253,7 +253,7 @@ class TreeRebuilder:
 
         @overload
         def visit(
-            self, node: "ast.ExceptHandler", parent: NodeNG
+            self, node: "ast.ExceptHandler", parent: nodes.TryExcept
         ) -> nodes.ExceptHandler:
             ...
 
@@ -599,7 +599,7 @@ class TreeRebuilder:
 
         @overload
         def visit(
-            self, node: "ast.ExceptHandler", parent: NodeNG
+            self, node: "ast.ExceptHandler", parent: nodes.TryExcept
         ) -> nodes.ExceptHandler:
             ...
 
@@ -1387,7 +1387,7 @@ class TreeRebuilder:
         )
 
     def visit_excepthandler(
-        self, node: "ast.ExceptHandler", parent: NodeNG
+        self, node: "ast.ExceptHandler", parent: nodes.TryExcept
     ) -> nodes.ExceptHandler:
         """visit an ExceptHandler node by returning a fresh instance of it"""
         if sys.version_info >= (3, 8):


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

Inspired by the work of @jacobtylerwalls in https://github.com/PyCQA/pylint/pull/5764.

Is there a good way to make `parent` non-optional? 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue