### PR TITLE
Restore custom `distutils` handling for resolving paths to submodules.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -434,5 +434,6 @@ jobs:
           python -m pip install -e .
       - name: Test distutils edge case
         run: |
+          . venv2\scripts\activate
           echo "import distutils.util  # pylint: disable=unused-import" > test.py
-          python -m pylint test.py
+          pylint test.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -406,38 +406,3 @@ jobs:
         run: |
           . venv/bin/activate
           pytest tests/
-
-  specific-virtualenv-test:
-    name: Regression test for virtualenv==15.1.0 on Windows
-    runs-on: windows-latest
-    timeout-minutes: 5
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v2.3.4
-      - name: Set up Python ${{ matrix.python-version }}
-        id: python
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Restore Python virtual environment
-        id: cache-virtualenv15
-        uses: actions/cache@v2.1.4
-        with:
-          path: venv2
-          key: >-
-            ${{ runner.os }}-virtualenv15
-          restore-keys: |
-            ${{ runner.os }}-virtualenv15-${{ env.CACHE_VERSION }}
-      - name: Create Python virtual environment with virtualenv==15.1.0
-        if: steps.cache-virtualenv15_1_0.outputs.cache-hit != 'true'
-        run: |
-          python -m pip install virtualenv==15.1.0
-          python -m virtualenv venv2
-          . venv2\scripts\activate
-          python -m pip install pylint
-          python -m pip install -e .
-      - name: Test distutils edge case
-        run: |
-          . venv2\scripts\activate
-          echo "import distutils.util  # pylint: disable=unused-import" > test.py
-          pylint test.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -420,15 +420,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Restore Python virtual environment
-        id: cache-virtualenv15_1_0
+        id: cache-virtualenv15
         uses: actions/cache@v2.1.4
         with:
           path: venv2
           key: >-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            steps.generate-python-key.outputs.key }}
+            ${{ runner.os }}-virtualenv15
           restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-virtualenv15_1_0-${{ env.CACHE_VERSION }}-
+            ${{ runner.os }}-virtualenv15-${{ env.CACHE_VERSION }}
       - name: Create Python virtual environment with virtualenv==15.1.0
         if: steps.cache-virtualenv15_1_0.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -407,28 +407,32 @@ jobs:
           . venv/bin/activate
           pytest tests/
 
-  extra-special-test-case:
-    name: Test case that requires specific virtualenv
+  specific-virtualenv-test:
+    name: Regression test for virtualenv==15.1.0 on Windows
     runs-on: windows-latest
     timeout-minutes: 5
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2.3.4
+      - name: Restore Python virtual environment
+        id: cache-virtualenv15.1.0
+        uses: actions/cache@v2.1.4
         with:
-          fetch-depth: 0
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Create venv and run test case
+          path: venv2
+          key: >-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            steps.generate-python-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-virtualenv15.1.0-${{ env.CACHE_VERSION }}-
+      - name: Create Python virtual environment with virtualenv==15.1.0
+        if: steps.cache-virtualenv15.1.0.outputs.cache-hit != 'true'
         run: |
           python -m pip install virtualenv==15.1.0
           python -m virtualenv venv2
           . venv2\scripts\activate
-          which python
           python -m pip install pylint
           python -m pip install -e .
+      - name: Test distutils edge case
+        run: |
           echo "import distutils.util  # pylint: disable=unused-import" > test.py
-          cat test.py
           pylint test.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -415,7 +415,7 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@v2.3.4
       - name: Restore Python virtual environment
-        id: cache-virtualenv15.1.0
+        id: cache-virtualenv15_1_0
         uses: actions/cache@v2.1.4
         with:
           path: venv2
@@ -423,9 +423,9 @@ jobs:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             steps.generate-python-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-virtualenv15.1.0-${{ env.CACHE_VERSION }}-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-virtualenv15_1_0-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment with virtualenv==15.1.0
-        if: steps.cache-virtualenv15.1.0.outputs.cache-hit != 'true'
+        if: steps.cache-virtualenv15_1_0.outputs.cache-hit != 'true'
         run: |
           python -m pip install virtualenv==15.1.0
           python -m virtualenv venv2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -406,3 +406,38 @@ jobs:
         run: |
           . venv/bin/activate
           pytest tests/
+
+  specific-virtualenv-test:
+    name: Regression test for virtualenv==15.1.0 on Windows
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Restore Python virtual environment
+        id: cache-virtualenv15
+        uses: actions/cache@v2.1.4
+        with:
+          path: venv2
+          key: >-
+            ${{ runner.os }}-virtualenv15
+          restore-keys: |
+            ${{ runner.os }}-virtualenv15-${{ env.CACHE_VERSION }}
+      - name: Create Python virtual environment with virtualenv==15.1.0
+        if: steps.cache-virtualenv15_1_0.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install virtualenv==15.1.0
+          python -m virtualenv venv2
+          . venv2\scripts\activate
+          python -m pip install pylint
+          python -m pip install -e .
+      - name: Test distutils edge case
+        run: |
+          . venv2\scripts\activate
+          echo "import distutils.util  # pylint: disable=unused-import" > test.py
+          pylint test.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -406,3 +406,29 @@ jobs:
         run: |
           . venv/bin/activate
           pytest tests/
+
+  extra-special-test-case:
+    name: Test case that requires specific virtualenv
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Create venv and run test case
+        run: |
+          python -m pip install virtualenv==15.1.0
+          python -m virtualenv venv2
+          . venv2\scripts\activate
+          which python
+          python -m pip install pylint
+          python -m pip install -e .
+          echo "import distutils.util  # pylint: disable=unused-import" > test.py
+          cat test.py
+          pylint test.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,6 +414,11 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2.3.4
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Restore Python virtual environment
         id: cache-virtualenv15_1_0
         uses: actions/cache@v2.1.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -435,4 +435,4 @@ jobs:
       - name: Test distutils edge case
         run: |
           echo "import distutils.util  # pylint: disable=unused-import" > test.py
-          pylint test.py
+          python -m pylint test.py

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -6,6 +6,7 @@ env:
   DEFAULT_PYTHON: 3.8
 
 jobs:
+  # Regression test added in https://github.com/PyCQA/astroid/pull/1386
   virtualenv-15-windows-test:
     name: Regression test for virtualenv==15.1.0 on Windows
     runs-on: windows-latest

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -6,8 +6,8 @@ env:
   DEFAULT_PYTHON: 3.8
 
 jobs:
-  # Regression test added in https://github.com/PyCQA/astroid/pull/1386
   virtualenv-15-windows-test:
+    # Regression test added in https://github.com/PyCQA/astroid/pull/1386
     name: Regression test for virtualenv==15.1.0 on Windows
     runs-on: windows-latest
     timeout-minutes: 5

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,0 +1,32 @@
+name: Release tests
+
+on: workflow_dispatch
+
+env:
+  DEFAULT_PYTHON: 3.8
+
+jobs:
+  virtualenv-15-windows-test:
+    name: Regression test for virtualenv==15.1.0 on Windows
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.3.4
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Create Python virtual environment with virtualenv==15.1.0
+        run: |
+          python -m pip install virtualenv==15.1.0
+          python -m virtualenv venv2
+          . venv2\scripts\activate
+          python -m pip install pylint
+          python -m pip install -e .
+      - name: Test no import-error from distutils.util
+        run: |
+          . venv2\scripts\activate
+          echo "import distutils.util  # pylint: disable=unused-import" > test.py
+          pylint test.py

--- a/ChangeLog
+++ b/ChangeLog
@@ -86,6 +86,10 @@ Release date: 2021-12-31
 
   Ref #1321
 
+* Restore custom ``distutils`` handling for resolving paths to submodules.
+
+  Closes PyCQA/pylint#5645
+
 * Fix ``deque.insert()`` signature in ``collections`` brain.
 
   Closes #1260

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -19,6 +19,7 @@ import abc
 import collections
 import enum
 import importlib.machinery
+import importlib.util
 import os
 import sys
 import zipimport
@@ -169,7 +170,7 @@ class ImportlibFinder(Finder):
             # A regression test to create this scenario exists in release-tests.yml
             # and can be triggered manually from GitHub Actions
             distutils_spec = importlib.util.find_spec("distutils")
-            if distutils_spec:
+            if distutils_spec and distutils_spec.origin:
                 origin_path = Path(
                     distutils_spec.origin
                 )  # e.g. .../distutils/__init__.py

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -165,6 +165,7 @@ class ImportlibFinder(Finder):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be
             # imported to avoid spurious import-error messages
+            # https://github.com/PyCQA/pylint/issues/5645
             # A regression test to create this scenario exists in release-tests.yml
             # and can be triggered manually from GitHub Actions
             distutils_spec = importlib.util.find_spec("distutils")

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -168,7 +168,9 @@ class ImportlibFinder(Finder):
             # imported to avoid spurious import-error messages
             distutils_spec = find_spec("distutils")
             if distutils_spec:
-                origin_path = Path(distutils_spec.origin)  # e.g. .../distutils/__init__.py
+                origin_path = Path(
+                    distutils_spec.origin
+                )  # e.g. .../distutils/__init__.py
                 path = [str(origin_path.parent)]  # e.g. .../distutils
             else:
                 path = [spec.location]

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -165,6 +165,8 @@ class ImportlibFinder(Finder):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be
             # imported to avoid spurious import-error messages
+            # A regression test to create this scenario exists in release-tests.yml
+            # and can be triggered manually from GitHub Actions
             distutils_spec = importlib.util.find_spec("distutils")
             if distutils_spec:
                 origin_path = Path(

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -23,6 +23,8 @@ import os
 import sys
 import zipimport
 from functools import lru_cache
+from importlib.util import find_spec
+from pathlib import Path
 
 from . import util
 
@@ -160,6 +162,16 @@ class ImportlibFinder(Finder):
                 for p in sys.path
                 if os.path.isdir(os.path.join(p, *processed))
             ]
+        elif spec.name == "distutils":
+            # virtualenv below 20.0 patches distutils in an unexpected way
+            # so we just find the location of distutils that will be
+            # imported to avoid spurious import-error messages
+            distutils_spec = find_spec("distutils")
+            if distutils_spec:
+                origin_path = Path(distutils_spec.origin)  # e.g. .../distutils/__init__.py
+                path = [str(origin_path.parent)]  # e.g. .../distutils
+            else:
+                path = [spec.location]
         else:
             path = [spec.location]
         return path

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -23,7 +23,6 @@ import os
 import sys
 import zipimport
 from functools import lru_cache
-from importlib.util import find_spec
 from pathlib import Path
 
 from . import util
@@ -166,7 +165,7 @@ class ImportlibFinder(Finder):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be
             # imported to avoid spurious import-error messages
-            distutils_spec = find_spec("distutils")
+            distutils_spec = importlib.util.find_spec("distutils")
             if distutils_spec:
                 origin_path = Path(
                     distutils_spec.origin

--- a/doc/release.md
+++ b/doc/release.md
@@ -4,6 +4,8 @@ So, you want to release the `X.Y.Z` version of astroid ?
 
 ## Process
 
+(Consider triggering the "release tests" workflow in GitHub Actions first.)
+
 1. Check if the dependencies of the package are correct
 2. Check the result (Do `git diff vX.Y.Z-1 ChangeLog` in particular).
 3. Install the release dependencies `pip3 install pre-commit tbump`


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
I understand @DanielNoord wants to bisect before evaluating a path forward. But this test case fails without these changes, so it could be a sufficient way forward.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Refs https://github.com/PyCQA/pylint/issues/5645
