### PR TITLE
Improve order of keyword-only args in argnames()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#5771
 
+* Improve location of keyword-only arguments in ``astroid.scoped_nodes.Lambda.argnames``.
+
+  Refs PyCQA/pylint#5771
+
 * Add support for [attrs v21.3.0](https://github.com/python-attrs/attrs/releases/tag/21.3.0) which
   added a new `attrs` module alongside the existing `attr`.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,10 +25,6 @@ Release date: TBA
 
   Closes PyCQA/pylint#5771
 
-* Improve location of keyword-only arguments in ``astroid.scoped_nodes.Lambda.argnames``.
-
-  Refs PyCQA/pylint#5771
-
 * Add support for [attrs v21.3.0](https://github.com/python-attrs/attrs/releases/tag/21.3.0) which
   added a new `attrs` module alongside the existing `attr`.
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1369,7 +1369,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
     def argnames(self) -> List[str]:
         """Get the names of each of the arguments, including that
         of the collections of variable-length arguments ("args", "kwargs",
-        etc.), as well as keyword-only arguments.
+        etc.), as well as positional-only and keyword-only arguments.
 
         :returns: The names of the arguments.
         :rtype: list(str)

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1378,9 +1378,9 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
             names = _rec_get_names(self.args.arguments)
         else:
             names = []
-        names += [elt.name for elt in self.args.kwonlyargs]
         if self.args.vararg:
             names.append(self.args.vararg)
+        names += [elt.name for elt in self.args.kwonlyargs]
         if self.args.kwarg:
             names.append(self.args.kwarg)
         return names

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -473,9 +473,15 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(code, __name__)
         self.assertEqual(astroid["f"].argnames(), ["a", "b", "c", "args", "kwargs"])
 
-        code_with_kwonly_args = "def f(a, b, *, c=None, d=None): pass"
+        code_with_kwonly_args = "def f(a, b, *args, c=None, d=None, **kwargs): pass"
         astroid = builder.parse(code_with_kwonly_args, __name__)
-        self.assertEqual(astroid["f"].argnames(), ["a", "b", "c", "d"])
+        self.assertEqual(astroid["f"].argnames(), ["a", "b", "args", "c", "d", "kwargs"])
+
+    @unittest.skipUnless(PY38_PLUS, "positional-only argument syntax")
+    def test_positional_only_argnames(self) -> None:
+        code = "def f(a, b, /, c=None, *args, d, **kwargs): pass"
+        astroid = builder.parse(code, __name__)
+        self.assertEqual(astroid["f"].argnames(), ["a", "b", "c", "args", "d", "kwargs"])
 
     def test_return_nothing(self) -> None:
         """test inferred value on a function with empty return"""

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -475,13 +475,17 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
 
         code_with_kwonly_args = "def f(a, b, *args, c=None, d=None, **kwargs): pass"
         astroid = builder.parse(code_with_kwonly_args, __name__)
-        self.assertEqual(astroid["f"].argnames(), ["a", "b", "args", "c", "d", "kwargs"])
+        self.assertEqual(
+            astroid["f"].argnames(), ["a", "b", "args", "c", "d", "kwargs"]
+        )
 
     @unittest.skipUnless(PY38_PLUS, "positional-only argument syntax")
     def test_positional_only_argnames(self) -> None:
         code = "def f(a, b, /, c=None, *args, d, **kwargs): pass"
         astroid = builder.parse(code, __name__)
-        self.assertEqual(astroid["f"].argnames(), ["a", "b", "c", "args", "d", "kwargs"])
+        self.assertEqual(
+            astroid["f"].argnames(), ["a", "b", "c", "args", "d", "kwargs"]
+        )
 
     def test_return_nothing(self) -> None:
         """test inferred value on a function with empty return"""


### PR DESCRIPTION
## Description
Follow up to https://github.com/PyCQA/astroid/pull/1382. The order of results is implied that it will be correct, so provide a correct order of argnames if there is a variadic argument name and some keyword-only arguments.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

