### PR TITLE
Add `tree_rev` attribute to `TreeRebuilder`

### DIFF
--- a/astroid/const.py
+++ b/astroid/const.py
@@ -6,6 +6,11 @@ import enum
 import sys
 from pathlib import Path
 
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
+
 PY38 = sys.version_info[:2] == (3, 8)
 PY38_PLUS = sys.version_info >= (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)
@@ -33,3 +38,6 @@ Del = Context.Del
 
 ASTROID_INSTALL_DIRECTORY = Path(__file__).parent
 BRAIN_MODULES_DIRECTORY = ASTROID_INSTALL_DIRECTORY / "brain"
+
+TREE_REV: Final = 1
+"""Default AST tree revision. Any update here is a breaking change!"""

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -15,7 +15,7 @@ import zipimport
 from importlib.util import find_spec, module_from_spec
 from typing import TYPE_CHECKING, ClassVar
 
-from astroid.const import BRAIN_MODULES_DIRECTORY
+from astroid.const import BRAIN_MODULES_DIRECTORY, TREE_REV
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import spec
 from astroid.modutils import (
@@ -62,6 +62,7 @@ class AstroidManager:
         "_transform": TransformVisitor(),
     }
     max_inferable_values: ClassVar[int] = 100
+    tree_rev: ClassVar[int] = TREE_REV
 
     def __init__(self):
         # NOTE: cache entries are added by the [re]builder

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -18,7 +18,7 @@ from typing import TypeVar, Union, cast, overload
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, Context
+from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, TREE_REV, Context
 from astroid.manager import AstroidManager
 from astroid.nodes import NodeNG
 from astroid.nodes.utils import Position
@@ -61,9 +61,12 @@ class TreeRebuilder:
         manager: AstroidManager,
         parser_module: ParserModule | None = None,
         data: str | None = None,
+        *,
+        tree_rev: int = TREE_REV,
     ) -> None:
         self._manager = manager
         self._data = data.split("\n") if data else None
+        self._tree_rev = tree_rev
         self._global_names: list[dict[str, list[nodes.Global]]] = []
         self._import_from_nodes: list[nodes.ImportFrom] = []
         self._delayed_assattr: list[nodes.AssignAttr] = []


### PR DESCRIPTION
## Description

First step for https://github.com/PyCQA/pylint/issues/5466#issuecomment-1033211018
Although it should work like I describe below, I'm certainly open for ideas how to make it better. Especially with regards to the "global" state for `tree_rev`. Let me know what you think @Pierre-Sassoulas @DanielNoord.

### Important changes
* A new `tree_rev` attribute is added to `TreeRebuilder`. Usually a value should be passed with `__init__`, but it defaults to `TREE_REV` defined in `const.py`.
* Each call to `TreeRebuilder.visit` requires one more attribute -> `tree_rev`. This might seem redundant, since the value is already stored as instance variable `self.tree_rev`. Unfortunately, it isn't possible to defined overloads based on instance variables though. The goal is to be able say: `"For tree_rev = 1, visit of AST node x returns instance of A, for tree_rev = 2, it returns instance of B."` Fortunately for us, to archive that it is not necessary to add the argument to each `visit_xxx` function.
* A new `tree_rev` class variable is added to `AstroidManager`. It's basically used to store a "global" state for the selected revision. See below on how it should be use.
* A `tree_rev` attribute has been added to `parse`. Passing it would temporarily override `AstroidManager.parse`.
**Note:** This is only intended for experimenting. In production the whole tree should be generated with only one revision.

### Rational
We are at a point were multiple issues require updates to the `TreeRebuilder`. At the moment, it isn't really possible to do them in a backwards compatible manner. With this change, libraries like `pylint` which use `astroid` can choose how they would want the Python AST to be parsed by `astroid`. Thus we will enable a more granular upgrade path. In the end that allows us to iterate on tree changes before bundling them all together into a new major version.

### Intended use
Libraries may either choose to stick with the default revision provided by astroid or override the class variable `AstroidManager.tree_rev`. Changing the revision should be done **before** any astroid AST is build. For pylint the required change would be right after the imports in `pylinter.py`.
```py
AstroidManager.tree_rev = 2
```

### Impact for plugins
Each update to the tree should essentially be consider a breaking change for all plugins. `pylint` probably more so than `astroid` once. That's just the nature of it, unfortunately. The stability policy this PR uses only extends to libraries which generate the AST themselves (eg. pylint).
After a new revision is release, each plugin should be updated to make sure it's compatible. It's important to remember that plugins don't choose the revision themselves. Meaning if they support a large enough version range with multiple revisions, they need to make sure all work as expected. That can, for example, be done with revision guards by accessing `AstroidManager.tree_rev`. (Only important to remember **not** to do that on import as the version might not have been set yet. (?) )

That section also applies to astroids builtin brain modules and as a whole. We need to make sure `astroid` works with all currently supported revisions, regardless of the tree output.

### Open Challenges
* A bit surprisingly, although the brain modules are imported **before** the `AstroidManager` and thus before the global revision is set, almost all actions are only done later during inference. All, except for one which needs to be fixed separately.
https://github.com/PyCQA/astroid/blob/1cf4bf7f3f4491ddda76662a6c57206d10d990b0/astroid/brain/brain_builtin_inference.py#L142-L147
Instead of on import, the method should be run as part of `_post_build` before any transforms are called.
https://github.com/PyCQA/astroid/blob/1cf4bf7f3f4491ddda76662a6c57206d10d990b0/astroid/builder.py#L173-L175
The are existing testes for that, so it should be fairly easy to make sure it still works as intended.
* As `astroid` will end up supporting multiple revision at the same time, we also need to make sure to test the whole test suite against each one. That will end up multiplying the time spend on these. In cases where different revisions change unrelated parts, it might be possible to do one tests for the before and after instead of each individually.
The good new, that doesn't apply to pylint as it should only ever support one at a time.


### Open Questions
* **How do we want to handle revision changes in pylint?**
Increasing the major version feels wrong, since this isn't directly a user facing change. However as written currently, some things might as well break. So just a minor version bump might be misleading as well.
Just an idea, we could require plugins to specific their supported revisions (lower / upper bound). If the one used by pylint is outside the supported range, the plugin is disabled with a warning. If no bounds are set we would assume the current revision **1**. With that in place, updates wouldn't be breaking once any longer and thus it could be possible to include them in `minor` releases as long as we make sure to highlight them in the release notes.
The downside here is that we'll probably end up introducing fragmentation into the plugin ecosystem.
* ???

### Todos
- [ ] Changelog entry
- [ ] Documentation
- [ ] Rewrite reference change to the `TreeRebuilder` using that change. Test impact on pylint.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |