### PR TITLE
Create `AssignName` nodes for `ClassDef` and `FunctionDef`

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -175,7 +175,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
             module = self._manager.visit_transforms(module)
         return module
 
-    def _data_build(self, data, modname, path):
+    def _data_build(self, data: str, modname, path):
         """Build tree node from data and add some information"""
         try:
             node, parser_module = _parse_string(data, type_comments=True)
@@ -200,7 +200,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
                 path is not None
                 and os.path.splitext(os.path.basename(path))[0] == "__init__"
             )
-        builder = rebuilder.TreeRebuilder(self._manager, parser_module)
+        builder = rebuilder.TreeRebuilder(self._manager, parser_module, data)
         module = builder.visit_module(node, modname, node_file, package)
         module._import_from_nodes = builder._import_from_nodes
         module._delayed_assattr = builder._delayed_assattr

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1546,6 +1546,8 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         :type doc: str or None
         """
 
+        self.name_node: Optional[node_classes.AssignName] = None
+
         self.instance_attrs = {}
         super().__init__(
             lineno=lineno,
@@ -1567,6 +1569,8 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         returns=None,
         type_comment_returns=None,
         type_comment_args=None,
+        *,
+        name_node: Optional[node_classes.AssignName] = None,
     ):
         """Do some setup after initialisation.
 
@@ -1589,6 +1593,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         self.returns = returns
         self.type_comment_returns = type_comment_returns
         self.type_comment_args = type_comment_args
+        self.name_node = name_node
 
     @decorators_mod.cachedproperty
     def extra_decorators(self) -> List[node_classes.Call]:
@@ -2212,6 +2217,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         :type doc: str or None
         """
 
+        self.name_node: Optional[node_classes.AssignName] = None
+
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -2241,7 +2248,15 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
     # pylint: disable=redefined-outer-name
     def postinit(
-        self, bases, body, decorators, newstyle=None, metaclass=None, keywords=None
+        self,
+        bases,
+        body,
+        decorators,
+        newstyle=None,
+        metaclass=None,
+        keywords=None,
+        *,
+        name_node: Optional[node_classes.AssignName] = None,
     ):
         """Do some setup after initialisation.
 
@@ -2272,6 +2287,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             self._newstyle = newstyle
         if metaclass is not None:
             self._metaclass = metaclass
+        self.name_node = name_node
 
     def _newstyle_impl(self, context=None):
         if context is None:

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -169,6 +169,7 @@ class TreeRebuilder:
         else:
             return None
 
+        # pylint: disable=undefined-loop-variable
         return nodes.AssignName(
             name=t.string,
             lineno=node.lineno - 1 + t.start[0],


### PR DESCRIPTION
## Description

A first attempt to add better position information for names in `ClassDef` and `FunctionDef`.
Could be used to resolve: https://github.com/PyCQA/pylint/issues/5466

**At the moment, this is only a proof of concept!**

During my last comments I suggested replacing the `name` attribute with a dedicated (`AssignName`) node. This would be a large breaking change. @DanielNoord Helped convince me that backwards compatible solutions would be better and much easier to implement in pylint. So instead of changing an existing attribute, I've added a new one `name_node`.

To get the actual position within the source code, I've used the `tokenize` module. The code itself works already. The required change in pylint would be to replace the `ClassDef` and `FunctionDef` nodes in error messages with the new `name_node`.

An example how it will look, here with the `missing-docstring` error.

![Screen Shot 2022-02-11 at 01 13 11](https://user-images.githubusercontent.com/30130371/153518443-95400358-0051-4034-84cd-817f09dcb4f6.png)

While looking at that, I was wondering if it would be better to highlight a bit more, i.e. include `class` / `def`? After all, in general those are errors on the class / function and not the name itself. The parsing is already in place, so it would be quite easy to modify.

If we decide to that, it's probably better to store the position information inside an attribute instead of a dedicated node.

We could also think about the implementation in `pylint` again. My initial idea to replace all nodes in `add_message` calls might not be the best way to do things after all. I think @DanielNoord suggested it (maybe in a different context), we could probably modify the `add_message` function itself to use the new position attribute for `ClassDef` and `FunctionDef` nodes.

/CC: @Pierre-Sassoulas @DanielNoord

**Edit**
The alternative:

![Screen Shot 2022-02-11 at 02 04 22](https://user-images.githubusercontent.com/30130371/153522534-da0e80ff-cb24-4171-ac42-15c1396d29f4.png)



## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |