### PR TITLE
Add ``is_dataclass`` attribute to ``ClassDef``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@ Release date: TBA
 
   Closes #1330
 
+* ``ClassDef`` now has the ``is_dataclass`` attribute.
+
 * Use ``sysconfig`` instead of ``distutils`` to determine the location of
   python stdlib files and packages.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ Release date: TBA
 
   Closes #1330
 
-* ``ClassDef`` now has the ``is_dataclass`` attribute.
+* Add ``is_dataclass`` attribute to ``ClassDef`` nodes.
 
 * Use ``sysconfig`` instead of ``distutils`` to determine the location of
   python stdlib files and packages.

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -67,6 +67,7 @@ def is_decorated_with_dataclass(node, decorator_names=DATACLASSES_DECORATORS):
 
 def dataclass_transform(node: ClassDef) -> None:
     """Rewrite a dataclass to be easily understood by pylint"""
+    node.is_dataclass = True
 
     for assign_node in _get_dataclass_attributes(node):
         name = assign_node.target.name

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2212,6 +2212,9 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         :type doc: str or None
         """
 
+        self.is_dataclass: bool = False
+        """Whether this class is a dataclass."""
+
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -2224,9 +2227,6 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         for local_name, node in self.implicit_locals():
             self.add_local_node(node, local_name)
-
-        self.is_dataclass: bool = False
-        """Whether this class is a dataclass."""
 
     def implicit_parameters(self):
         return 1

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2138,6 +2138,9 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     _other_other_fields = ("locals", "_newstyle")
     _newstyle = None
 
+    is_dataclass = False
+    """Whether this class is a dataclass."""
+
     def __init__(
         self,
         name=None,

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2225,7 +2225,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         for local_name, node in self.implicit_locals():
             self.add_local_node(node, local_name)
 
-        self.is_dataclass = False
+        self.is_dataclass: bool = False
         """Whether this class is a dataclass."""
 
     def implicit_parameters(self):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2134,12 +2134,9 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             ":type: str"
         ),
     )
-    _other_fields = ("name", "doc")
+    _other_fields = ("name", "doc", "is_dataclass")
     _other_other_fields = ("locals", "_newstyle")
     _newstyle = None
-
-    is_dataclass = False
-    """Whether this class is a dataclass."""
 
     def __init__(
         self,
@@ -2227,6 +2224,9 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         for local_name, node in self.implicit_locals():
             self.add_local_node(node, local_name)
+
+        self.is_dataclass = False
+        """Whether this class is a dataclass."""
 
     def implicit_parameters(self):
         return 1

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -692,7 +692,7 @@ def test_invalid_field_call(module: str) -> None:
 
 def test_non_dataclass_is_not_dataclass() -> None:
     """Test that something that isn't a dataclass has the correct attribute."""
-    ast_nodes = astroid.extract_node(
+    ast_nodes: List[nodes.NodeNG] = astroid.extract_node(  # type: ignore[assignment]
         """
     class A: #@
         val: field()

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -184,6 +184,7 @@ def test_inference_no_annotation(module: str):
     inferred = next(class_def.infer())
     assert isinstance(inferred, nodes.ClassDef)
     assert inferred.instance_attrs == {}
+    assert inferred.is_dataclass
 
     # Both the class and instance can still access the attribute
     for node in (klass, instance):
@@ -216,6 +217,7 @@ def test_inference_class_var(module: str):
     inferred = next(class_def.infer())
     assert isinstance(inferred, nodes.ClassDef)
     assert inferred.instance_attrs == {}
+    assert inferred.is_dataclass
 
     # Both the class and instance can still access the attribute
     for node in (klass, instance):
@@ -248,6 +250,7 @@ def test_inference_init_var(module: str):
     inferred = next(class_def.infer())
     assert isinstance(inferred, nodes.ClassDef)
     assert inferred.instance_attrs == {}
+    assert inferred.is_dataclass
 
     # Both the class and instance can still access the attribute
     for node in (klass, instance):
@@ -666,6 +669,7 @@ def test_annotated_enclosed_field_call(module: str):
     inferred = node.inferred()
     assert len(inferred) == 1 and isinstance(inferred[0], nodes.ClassDef)
     assert "attribute" in inferred[0].instance_attrs
+    assert inferred[0].is_dataclass
 
 
 @parametrize_module
@@ -683,3 +687,4 @@ def test_invalid_field_call(module: str) -> None:
     inferred = code.inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], nodes.ClassDef)
+    assert inferred[0].is_dataclass

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -692,20 +692,25 @@ def test_invalid_field_call(module: str) -> None:
 
 def test_non_dataclass_is_not_dataclass() -> None:
     """Test that something that isn't a dataclass has the correct attribute."""
-    ast_nodes: List[nodes.NodeNG] = astroid.extract_node(  # type: ignore[assignment]
+    module = astroid.parse(
         """
-    class A: #@
+    class A:
         val: field()
 
     def dataclass():
         return
 
     @dataclass
-    class B: #@
+    class B:
         val: field()
     """
     )
-    assert isinstance(ast_nodes[0], nodes.ClassDef)
-    assert not ast_nodes[0].is_dataclass
-    assert isinstance(ast_nodes[1], nodes.ClassDef)
-    assert not ast_nodes[1].is_dataclass
+    class_a = module.body[0].inferred()
+    assert len(class_a) == 1
+    assert isinstance(class_a[0], nodes.ClassDef)
+    assert not class_a[0].is_dataclass
+
+    class_b = module.body[2].inferred()
+    assert len(class_b) == 1
+    assert isinstance(class_b[0], nodes.ClassDef)
+    assert not class_b[0].is_dataclass

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -688,3 +688,17 @@ def test_invalid_field_call(module: str) -> None:
     assert len(inferred) == 1
     assert isinstance(inferred[0], nodes.ClassDef)
     assert inferred[0].is_dataclass
+
+
+def test_non_dataclass_is_not_dataclass() -> None:
+    """Test that something that isn't a dataclass has the correct attribute."""
+    code = astroid.extract_node(
+        """
+    class A:
+        val: field()
+    """
+    )
+    inferred = code.inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.ClassDef)
+    assert not inferred[0].is_dataclass

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -692,24 +692,20 @@ def test_invalid_field_call(module: str) -> None:
 
 def test_non_dataclass_is_not_dataclass() -> None:
     """Test that something that isn't a dataclass has the correct attribute."""
-    module = astroid.parse(
+    ast_nodes = astroid.extract_node(
         """
-    class A:
+    class A: #@
         val: field()
 
     def dataclass():
         return
 
     @dataclass
-    class B:
+    class B: #@
         val: field()
     """
     )
-    inferred = module.body[0].inferred()
-    assert len(inferred) == 1
-    assert isinstance(inferred[0], nodes.ClassDef)
-    assert not inferred[0].is_dataclass
-    inferred = module.body[2].inferred()
-    assert len(inferred) == 1
-    assert isinstance(inferred[0], nodes.ClassDef)
-    assert not inferred[0].is_dataclass
+    assert isinstance(ast_nodes[0], nodes.ClassDef)
+    assert not ast_nodes[0].is_dataclass
+    assert isinstance(ast_nodes[1], nodes.ClassDef)
+    assert not ast_nodes[1].is_dataclass

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -692,13 +692,24 @@ def test_invalid_field_call(module: str) -> None:
 
 def test_non_dataclass_is_not_dataclass() -> None:
     """Test that something that isn't a dataclass has the correct attribute."""
-    code = astroid.extract_node(
+    module = astroid.parse(
         """
     class A:
         val: field()
+
+    def dataclass():
+        return
+
+    @dataclass
+    class B:
+        val: field()
     """
     )
-    inferred = code.inferred()
+    inferred = module.body[0].inferred()
+    assert len(inferred) == 1
+    assert isinstance(inferred[0], nodes.ClassDef)
+    assert not inferred[0].is_dataclass
+    inferred = module.body[2].inferred()
     assert len(inferred) == 1
     assert isinstance(inferred[0], nodes.ClassDef)
     assert not inferred[0].is_dataclass


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This would solve the issue in https://github.com/PyCQA/pylint/pull/5544.

I explored three options for this:
1) My first idea was to create a new `Instance` for dataclasses. However, this is incorrect.
```python
@dataclass
class A(): ...
```
If you instantiate `A` it is not a `Dataclass`, it is an instance of `A` which happens to be a dataclass. Thus, a new `Instance` is incorrect.
2) I explored if there is any merit in using `is_decorated_with_dataclass` or exposing it as util. However, it uses `nodes` to do som stuff which became difficult because of cyclic imports really fast. I don't think there is a good way to extract it from the brain (I tried) so if we want to make a similar util we will need to maintain the same code in two places.
3) The current solution. Actually quite simple. If we make any changes to dataclass inference it will also be easily accessible to `pylint` without any changes.

Let me know what you think!

_One remaining issue is that this doesn't allow setting the `decorators` attribute to be non-optional (which it is for dataclasses). However, creating a new `DataclassDef` node seemed a bit overkill (for now)._

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

