### PR TITLE
Fix ``ClassDef.fromlineno`` for Python < 3.8

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,9 @@ Release date: TBA
 
   Closes #1085
 
+* Fix ``ClassDef.fromlineno``. Only in Python 3.7 the ``lineno`` attribute includes decorators.
+  ``fromlineno`` should return the line of the ``class`` statement itself.
+
 What's New in astroid 2.9.4?
 ============================
 Release date: TBA

--- a/ChangeLog
+++ b/ChangeLog
@@ -42,7 +42,7 @@ Release date: TBA
 
   Closes #1085
 
-* Fix ``ClassDef.fromlineno``. Only in Python 3.7 the ``lineno`` attribute includes decorators.
+* Fix ``ClassDef.fromlineno``. For Python < 3.8 the ``lineno`` attribute includes decorators.
   ``fromlineno`` should return the line of the ``class`` statement itself.
 
 What's New in astroid 2.9.4?

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -1,7 +1,6 @@
 import enum
 import sys
 
-PY37 = sys.version_info[:2] == (3, 7)
 PY38 = sys.version_info[:2] == (3, 8)
 PY37_PLUS = sys.version_info >= (3, 7)
 PY38_PLUS = sys.version_info >= (3, 8)

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -1,6 +1,7 @@
 import enum
 import sys
 
+PY37 = sys.version_info[:2] == (3, 7)
 PY38 = sys.version_info[:2] == (3, 8)
 PY37_PLUS = sys.version_info >= (3, 7)
 PY38_PLUS = sys.version_info >= (3, 8)

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1706,13 +1706,10 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         return type_name
 
     @decorators_mod.cachedproperty
-    def fromlineno(self):
-        """The first line that this node appears on in the source code.
-
-        :type: int or None
-        """
+    def fromlineno(self) -> Optional[int]:
+        """The first line that this node appears on in the source code."""
         # lineno is the line number of the first decorator, we want the def
-        # statement lineno
+        # statement lineno. Similar to 'ClassDef.fromlineno'
         lineno = self.lineno
         if self.decorators is not None:
             lineno += sum(
@@ -2298,11 +2295,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     )
 
     @decorators_mod.cachedproperty
-    def fromlineno(self):
-        """The first line that this node appears on in the source code.
-
-        :type: int or None
-        """
+    def fromlineno(self) -> Optional[int]:
+        """The first line that this node appears on in the source code."""
         if not PY38_PLUS:
             # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -55,7 +55,7 @@ from typing import Dict, List, Optional, Set, TypeVar, Union, overload
 from astroid import bases
 from astroid import decorators as decorators_mod
 from astroid import mixins, util
-from astroid.const import PY37, PY39_PLUS
+from astroid.const import PY38_PLUS, PY39_PLUS
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2303,8 +2303,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         :type: int or None
         """
-        if PY37:
-            # Only in Python 3.7 is the lineno the line number of the first decorator.
+        if not PY38_PLUS:
+            # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
             lineno = self.lineno
             if self.decorators is not None:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -55,7 +55,7 @@ from typing import Dict, List, Optional, Set, TypeVar, Union, overload
 from astroid import bases
 from astroid import decorators as decorators_mod
 from astroid import mixins, util
-from astroid.const import PY39_PLUS
+from astroid.const import PY37, PY39_PLUS
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2296,6 +2296,24 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         _newstyle_impl,
         doc=("Whether this is a new style class or not\n\n" ":type: bool or None"),
     )
+
+    @decorators_mod.cachedproperty
+    def fromlineno(self):
+        """The first line that this node appears on in the source code.
+
+        :type: int or None
+        """
+        if PY37:
+            # Only in Python 3.7 is the lineno the line number of the first decorator.
+            # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
+            lineno = self.lineno
+            if self.decorators is not None:
+                lineno += sum(
+                    node.tolineno - node.lineno + 1 for node in self.decorators.nodes
+                )
+
+            return lineno
+        return super().fromlineno
 
     @decorators_mod.cachedproperty
     def blockstart_tolineno(self):

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -32,8 +32,8 @@ import pathlib
 import py_compile
 import socket
 import sys
-import textwrap
 import tempfile
+import textwrap
 import unittest
 
 import pytest

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -35,7 +35,7 @@ import unittest
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import PY37, PY38_PLUS
+from astroid.const import PY38_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -174,7 +174,7 @@ class FromToLineNoTest(unittest.TestCase):
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.ClassDef)
-        if PY37:
+        if not PY38_PLUS:
             # Not perfect, but best we can do for Python 3.7
             # Can't detect closing bracket on new line.
             assert c.fromlineno == 12

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -161,7 +161,6 @@ class FromToLineNoTest(unittest.TestCase):
 
         ast_module: nodes.Module = builder.parse(code)  # type: ignore[assignment]
 
-        # XXX discussable, but that's what is expected by pylint right now, similar to FunctionDef
         a = ast_module.body[0]
         assert isinstance(a, nodes.ClassDef)
         assert a.fromlineno == 2


### PR DESCRIPTION
## Description

Another unexpected AST change. For Python < 3.8 the `lineno` for `ClassDef` nodes also includes decorator nodes. @DanielNoord noticed that one while working with `builder.extract_node` in #1391. I encountered the same issue in #1393.

The fix isn't perfect unfortunately. Multiline decorators without dedicated AST nodes on the last line don't quite work. That however is consistent with `FunctionDef.fromlineno` which has already been modified.

```py
@decorator(
    var=42
)
class A:
    ...

# Here the reported line would be ')' instead of 'class A'.
# We can't use 'end_lineno', since it was only added in Python 3.8
```

--
The current property for `FunctionDef`:

https://github.com/PyCQA/astroid/blob/552f1c19aab0719e7b30bb02e032d4bfe655f343/astroid/nodes/scoped_nodes/scoped_nodes.py#L1708-L1722


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |