### PR TITLE
Fix crash inferring on NewType named with f-string

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#5771
 
+* Fixed a crash inferring on a ``NewType`` named with an f-string.
+
+  Closes PyCQA/pylint#5770
+
 * Add support for [attrs v21.3.0](https://github.com/python-attrs/attrs/releases/tag/21.3.0) which
   added a new `attrs` module alongside the existing `attr`.
 

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -31,6 +31,7 @@ from astroid.nodes.node_classes import (
     Attribute,
     Call,
     Const,
+    JoinedStr,
     Name,
     NodeNG,
     Subscript,
@@ -127,6 +128,9 @@ def infer_typing_typevar_or_newtype(node, context_itton=None):
     if func.qname() not in TYPING_TYPEVARS_QUALIFIED:
         raise UseInferenceDefault
     if not node.args:
+        raise UseInferenceDefault
+    # Cannot infer from a dynamic class name (f-string)
+    if isinstance(node.args[0], JoinedStr):
         raise UseInferenceDefault
 
     typename = node.args[0].as_string().strip("'")


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
The f-string here:
```python
new_type = NewType(f'IntRange_{t}', t)
```
was altered by astroid here to remove its final `'`:

```python
typename = node.args[0].as_string().strip("'")
```
That caused a string parsing error, since there was an unterminated f-string.
Solution in this PR is to short circuit, rather than cope with a string formatted at runtime.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
Refs [PyCQA/pylint/#5770](https://github.com/PyCQA/pylint/issues/5770)