### PR TITLE
Add tests for position attributes of definitions with only docstrings

### DIFF
--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -221,28 +221,28 @@ class FromToLineNoTest(unittest.TestCase):
 
         a = ast_module.body[0]
         assert isinstance(a, nodes.ClassDef)
-        assert a.fromlineno == 2
-        assert a.tolineno == 4
+        assert a.fromlineno == 1
+        assert a.tolineno == 3
 
         b = ast_module.body[1]
         assert isinstance(b, nodes.ClassDef)
-        assert b.fromlineno == 6
-        assert b.tolineno == 7
+        assert b.fromlineno == 5
+        assert b.tolineno == 6
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.ClassDef)
-        assert c.fromlineno == 9
-        assert c.tolineno == 11
+        assert c.fromlineno == 8
+        assert c.tolineno == 10
 
         d = ast_module.body[3]
         assert isinstance(d, nodes.ClassDef)
-        assert d.fromlineno == 13
-        assert d.tolineno == 16
+        assert d.fromlineno == 12
+        assert d.tolineno == 15
 
         e = ast_module.body[4]
         assert isinstance(d, nodes.ClassDef)
-        assert e.fromlineno == 18
-        assert e.tolineno == 19
+        assert e.fromlineno == 17
+        assert e.tolineno == 18
 
     @staticmethod
     def test_function_with_docstring() -> None:
@@ -276,28 +276,28 @@ class FromToLineNoTest(unittest.TestCase):
 
         a = ast_module.body[0]
         assert isinstance(a, nodes.FunctionDef)
-        assert a.fromlineno == 2
-        assert a.tolineno == 4
+        assert a.fromlineno == 1
+        assert a.tolineno == 3
 
         b = ast_module.body[1]
         assert isinstance(b, nodes.FunctionDef)
-        assert b.fromlineno == 6
-        assert b.tolineno == 7
+        assert b.fromlineno == 5
+        assert b.tolineno == 6
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.FunctionDef)
-        assert c.fromlineno == 9
-        assert c.tolineno == 11
+        assert c.fromlineno == 8
+        assert c.tolineno == 10
 
         d = ast_module.body[3]
         assert isinstance(d, nodes.FunctionDef)
-        assert d.fromlineno == 13
-        assert d.tolineno == 16
+        assert d.fromlineno == 12
+        assert d.tolineno == 15
 
         e = ast_module.body[4]
         assert isinstance(e, nodes.FunctionDef)
-        assert e.fromlineno == 18
-        assert e.tolineno == 21
+        assert e.fromlineno == 17
+        assert e.tolineno == 20
 
     def test_class_lineno(self) -> None:
         stmts = self.astroid.body

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -191,6 +191,114 @@ class FromToLineNoTest(unittest.TestCase):
             assert c.fromlineno == 13
         assert c.tolineno == 14
 
+    @staticmethod
+    def test_class_with_docstring() -> None:
+        """Test class nodes which only have docstrings."""
+        code = textwrap.dedent(
+            '''
+        class A:
+            """My docstring"""
+            var = 1
+
+        class B:
+            """My docstring"""
+
+        class C:
+            """My docstring
+            is long."""
+
+        class D:
+            """My docstring
+            is long.
+            """
+
+        class E:
+            ...
+        '''
+        )
+
+        ast_module: nodes.Module = builder.parse(code)  # type: ignore[assignment]
+
+        a = ast_module.body[0]
+        assert isinstance(a, nodes.ClassDef)
+        assert a.fromlineno == 2
+        assert a.tolineno == 4
+
+        b = ast_module.body[1]
+        assert isinstance(b, nodes.ClassDef)
+        assert b.fromlineno == 6
+        assert b.tolineno == 7
+
+        c = ast_module.body[2]
+        assert isinstance(c, nodes.ClassDef)
+        assert c.fromlineno == 9
+        assert c.tolineno == 11
+
+        d = ast_module.body[3]
+        assert isinstance(d, nodes.ClassDef)
+        assert d.fromlineno == 13
+        assert d.tolineno == 16
+
+        e = ast_module.body[4]
+        assert isinstance(d, nodes.ClassDef)
+        assert e.fromlineno == 18
+        assert e.tolineno == 19
+
+    @staticmethod
+    def test_function_with_docstring() -> None:
+        """Test function defintions with only docstrings."""
+        code = textwrap.dedent(
+            '''
+        def a():
+            """My docstring"""
+            var = 1
+
+        def b():
+            """My docstring"""
+
+        def c():
+            """My docstring
+            is long."""
+
+        def d():
+            """My docstring
+            is long.
+            """
+
+        def e(a, b):
+            """My docstring
+            is long.
+            """
+        '''
+        )
+
+        ast_module: nodes.Module = builder.parse(code)  # type: ignore[assignment]
+
+        a = ast_module.body[0]
+        assert isinstance(a, nodes.FunctionDef)
+        assert a.fromlineno == 2
+        assert a.tolineno == 4
+
+        b = ast_module.body[1]
+        assert isinstance(b, nodes.FunctionDef)
+        assert b.fromlineno == 6
+        assert b.tolineno == 7
+
+        c = ast_module.body[2]
+        assert isinstance(c, nodes.FunctionDef)
+        assert c.fromlineno == 9
+        assert c.tolineno == 11
+
+        d = ast_module.body[3]
+        assert isinstance(d, nodes.FunctionDef)
+        assert d.fromlineno == 13
+        assert d.tolineno == 16
+
+        e = ast_module.body[4]
+        assert isinstance(e, nodes.FunctionDef)
+        assert e.fromlineno == 18
+        assert e.tolineno == 21
+
     def test_class_lineno(self) -> None:
         stmts = self.astroid.body
         # on line 20:

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -195,7 +195,7 @@ class FromToLineNoTest(unittest.TestCase):
     def test_class_with_docstring() -> None:
         """Test class nodes which only have docstrings."""
         code = textwrap.dedent(
-            '''
+            '''\
         class A:
             """My docstring"""
             var = 1
@@ -217,7 +217,7 @@ class FromToLineNoTest(unittest.TestCase):
         '''
         )
 
-        ast_module: nodes.Module = builder.parse(code)  # type: ignore[assignment]
+        ast_module = builder.parse(code)
 
         a = ast_module.body[0]
         assert isinstance(a, nodes.ClassDef)
@@ -248,7 +248,7 @@ class FromToLineNoTest(unittest.TestCase):
     def test_function_with_docstring() -> None:
         """Test function defintions with only docstrings."""
         code = textwrap.dedent(
-            '''
+            '''\
         def a():
             """My docstring"""
             var = 1
@@ -272,7 +272,7 @@ class FromToLineNoTest(unittest.TestCase):
         '''
         )
 
-        ast_module: nodes.Module = builder.parse(code)  # type: ignore[assignment]
+        ast_module = builder.parse(code)
 
         a = ast_module.body[0]
         assert isinstance(a, nodes.FunctionDef)


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

I think this should fix the issue identified in https://github.com/PyCQA/pylint/pull/5802

If not, this is a nice change either way 😄 

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Related Issue

