### PR TITLE
Add some typing to ``astroid.inference``

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -34,7 +34,7 @@ import ast
 import functools
 import itertools
 import operator
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
 
 import wrapt
 
@@ -824,7 +824,7 @@ def _to_literal(node: nodes.NodeNG) -> Any:
 
 def _do_compare(
     left_iter: Iterable[nodes.NodeNG], op: str, right_iter: Iterable[nodes.NodeNG]
-) -> "bool | type[util.Uninferable]":
+) -> Union[bool, util.Uninferable]:
     """
     If all possible combinations are either True or False, return that:
     >>> _do_compare([1, 2], '<=', [3, 4])
@@ -839,17 +839,17 @@ def _do_compare(
     """
     retval = None
     if op in UNINFERABLE_OPS:
-        return util.Uninferable
+        return util.Uninferable  # type: ignore[return-value]
     op_func = COMPARE_OPS[op]
 
     for left, right in itertools.product(left_iter, right_iter):
         if left is util.Uninferable or right is util.Uninferable:
-            return util.Uninferable
+            return util.Uninferable  # type: ignore[return-value]
 
         try:
             left, right = _to_literal(left), _to_literal(right)
         except (SyntaxError, ValueError, AttributeError):
-            return util.Uninferable
+            return util.Uninferable  # type: ignore[return-value]
 
         try:
             expr = op_func(left, right)
@@ -859,17 +859,18 @@ def _do_compare(
         if retval is None:
             retval = expr
         elif retval != expr:
-            return util.Uninferable
+            return util.Uninferable  # type: ignore[return-value]
             # (or both, but "True | False" is basically the same)
 
+    assert retval
     return retval  # it was all the same value
 
 
 def _infer_compare(
     self: nodes.Compare, context: Optional[InferenceContext] = None
-) -> Any:
+) -> Iterator[Union[nodes.Const, util.Uninferable]]:
     """Chained comparison inference logic."""
-    retval = True
+    retval: Union[bool, util.Uninferable] = True
 
     ops = self.ops
     left_node = self.left
@@ -881,13 +882,13 @@ def _infer_compare(
         try:
             retval = _do_compare(lhs, op, rhs)
         except AstroidTypeError:
-            retval = util.Uninferable
+            retval = util.Uninferable  # type: ignore[assignment]
             break
         if retval is not True:
             break  # short-circuit
         lhs = rhs  # continue
     if retval is util.Uninferable:
-        yield retval
+        yield retval  # type: ignore[misc]
     else:
         yield nodes.Const(retval)
 

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -34,6 +34,7 @@ import ast
 import functools
 import itertools
 import operator
+import sys
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Type, Union
 
 import wrapt
@@ -57,6 +58,11 @@ from astroid.exceptions import (
 )
 from astroid.interpreter import dunder_lookup
 from astroid.manager import AstroidManager
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 # Prevents circular imports
 objects = util.lazy_import("objects")
@@ -837,7 +843,7 @@ def _do_compare(
     >>> _do_compare([1, 3], '<=', [2, 4])
     util.Uninferable
     """
-    retval = None
+    retval: Union[Literal[None], bool, Type[util.util.Uninferable]] = None
     if op in UNINFERABLE_OPS:
         return util.Uninferable
     op_func = COMPARE_OPS[op]

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -862,7 +862,7 @@ def _do_compare(
             return util.Uninferable  # type: ignore[return-value]
             # (or both, but "True | False" is basically the same)
 
-    assert retval
+    assert retval is not None
     return retval  # it was all the same value
 
 

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -34,7 +34,6 @@ import ast
 import functools
 import itertools
 import operator
-import sys
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Type, Union
 
 import wrapt
@@ -58,11 +57,6 @@ from astroid.exceptions import (
 )
 from astroid.interpreter import dunder_lookup
 from astroid.manager import AstroidManager
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 # Prevents circular imports
 objects = util.lazy_import("objects")
@@ -843,7 +837,7 @@ def _do_compare(
     >>> _do_compare([1, 3], '<=', [2, 4])
     util.Uninferable
     """
-    retval: Union[Literal[None], bool, Type[util.Uninferable]] = None
+    retval: Union[None, bool] = None
     if op in UNINFERABLE_OPS:
         return util.Uninferable
     op_func = COMPARE_OPS[op]

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -34,7 +34,7 @@ import ast
 import functools
 import itertools
 import operator
-from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Type, Union
 
 import wrapt
 
@@ -868,9 +868,9 @@ def _do_compare(
 
 def _infer_compare(
     self: nodes.Compare, context: Optional[InferenceContext] = None
-) -> Iterator[Union[nodes.Const, util.Uninferable]]:
+) -> Iterator[Union[nodes.Const, Type[util.Uninferable]]]:
     """Chained comparison inference logic."""
-    retval: Union[bool, util.Uninferable] = True
+    retval: Union[bool, Type[util.Uninferable]] = True
 
     ops = self.ops
     left_node = self.left
@@ -882,13 +882,13 @@ def _infer_compare(
         try:
             retval = _do_compare(lhs, op, rhs)
         except AstroidTypeError:
-            retval = util.Uninferable  # type: ignore[assignment]
+            retval = util.Uninferable
             break
         if retval is not True:
             break  # short-circuit
         lhs = rhs  # continue
     if retval is util.Uninferable:
-        yield retval  # type: ignore[misc]
+        yield retval
     else:
         yield nodes.Const(retval)
 

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -843,7 +843,7 @@ def _do_compare(
     >>> _do_compare([1, 3], '<=', [2, 4])
     util.Uninferable
     """
-    retval: Union[Literal[None], bool, Type[util.util.Uninferable]] = None
+    retval: Union[Literal[None], bool, Type[util.Uninferable]] = None
     if op in UNINFERABLE_OPS:
         return util.Uninferable
     op_func = COMPARE_OPS[op]

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -824,7 +824,7 @@ def _to_literal(node: nodes.NodeNG) -> Any:
 
 def _do_compare(
     left_iter: Iterable[nodes.NodeNG], op: str, right_iter: Iterable[nodes.NodeNG]
-) -> Union[bool, util.Uninferable]:
+) -> "bool | type[util.Uninferable]":
     """
     If all possible combinations are either True or False, return that:
     >>> _do_compare([1, 2], '<=', [3, 4])
@@ -839,17 +839,17 @@ def _do_compare(
     """
     retval = None
     if op in UNINFERABLE_OPS:
-        return util.Uninferable  # type: ignore[return-value]
+        return util.Uninferable
     op_func = COMPARE_OPS[op]
 
     for left, right in itertools.product(left_iter, right_iter):
         if left is util.Uninferable or right is util.Uninferable:
-            return util.Uninferable  # type: ignore[return-value]
+            return util.Uninferable
 
         try:
             left, right = _to_literal(left), _to_literal(right)
         except (SyntaxError, ValueError, AttributeError):
-            return util.Uninferable  # type: ignore[return-value]
+            return util.Uninferable
 
         try:
             expr = op_func(left, right)
@@ -859,7 +859,7 @@ def _do_compare(
         if retval is None:
             retval = expr
         elif retval != expr:
-            return util.Uninferable  # type: ignore[return-value]
+            return util.Uninferable
             # (or both, but "True | False" is basically the same)
 
     assert retval is not None

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -894,7 +894,7 @@ def _infer_compare(
             break  # short-circuit
         lhs = rhs  # continue
     if retval is util.Uninferable:
-        yield retval
+        yield retval  # type: ignore[misc]
     else:
         yield nodes.Const(retval)
 


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

The typing on this is incorrect I believe.

https://github.com/PyCQA/astroid/blob/c0d2e5c89a1525e9f500c43b04529628a70e070f/astroid/util.py#L33-L34

I don't think `mypy` recognises that the decorator on `Uninferable` makes `util.Uninferable` an instance instead of the type. I checked the issue tracker and there is no issue about this yet, so I am slightly doubting whether I am in correct in this, but I think this is the correct fix.

Edit: Seeing as `pyright` does get this right I opened https://github.com/python/mypy/issues/12265.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue