### PR TITLE
Use ``functools.cached_property`` on 3.8+ and for ``TYPE_CHECKING``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Release date: TBA
 
   Closes #1410
 
+
 What's New in astroid 2.10.1?
 =============================
 Release date: TBA

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Release date: TBA
   and ``nodes.FunctionDef``.
 
 * On Python 3.8+ we now use ``functools.cached_property`` instead of our own implementation.
+  At the same time, ``cachedproperty`` has been deprecated for Python 3.8+.
 
   Closes #1410
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -136,7 +136,8 @@ Release date: 2021-12-31
 
 * Fix typing and update explanation for ``Arguments.args`` being ``None``.
 
-* Fix crash if a variable named ``type`` is subscribed in a generator expression.
+* Fix crash if a variable named ``type`` is accessed with an index operator (``[]``)
+  in a generator expression.
 
   Closes PyCQA/pylint#5461
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,8 +9,8 @@ Release date: TBA
 * Add new (optional) ``doc_node`` attribute to ``nodes.Module``, ``nodes.ClassDef``,
   and ``nodes.FunctionDef``.
 
-* On Python 3.8+ we now use ``functools.cached_property`` instead of our own implementation.
-  At the same time, ``cachedproperty`` has been deprecated for Python 3.8+.
+* Replace custom ``cachedproperty`` with ``functools.cached_property`` and deprecate it
+  for Python 3.8+.
 
   Closes #1410
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,9 @@ Release date: TBA
 * Add new (optional) ``doc_node`` attribute to ``nodes.Module``, ``nodes.ClassDef``,
   and ``nodes.FunctionDef``.
 
+* On Python 3.8+ we now use ``functools.cached_property`` instead of our own implementation.
+
+  Closes #1410
 
 What's New in astroid 2.10.1?
 =============================

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -53,6 +53,7 @@ def cached(func, instance, args, kwargs):
 
 
 # TODO: Remove when support for 3.7 is dropped
+# TODO: astroid 3.0 -> move class behind sys.version_info < (3, 8) guard
 class cachedproperty:
     """Provides a cached property equivalent to the stacking of
     @cached and @property, but more efficient.

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -52,6 +52,7 @@ def cached(func, instance, args, kwargs):
         return result
 
 
+# TODO: Remove when support for 3.7 is dropped
 class cachedproperty:
     """Provides a cached property equivalent to the stacking of
     @cached and @property, but more efficient.
@@ -72,9 +73,8 @@ class cachedproperty:
     def __init__(self, wrapped):
         if sys.version_info >= (3, 8):
             warnings.warn(
-                "The cachedproperty class is functionally the same as functools.cached_property "
-                "and will be removed after support for Python < 3.8 has been dropped. "
-                "Consider importing the functools variant on >= 3.8.",
+                "cachedproperty has been deprecated and will be removed in astroid 3.0 for Python 3.8+. "
+                "Use functools.cached_property instead.",
                 DeprecationWarning,
             )
         try:

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -18,6 +18,7 @@
 """This module contains some mixins for the different nodes.
 """
 import itertools
+import sys
 from typing import TYPE_CHECKING, Optional
 
 from astroid import decorators
@@ -26,11 +27,16 @@ from astroid.exceptions import AttributeInferenceError
 if TYPE_CHECKING:
     from astroid import nodes
 
+if sys.version_info >= (3, 8) or TYPE_CHECKING:
+    from functools import cached_property
+else:
+    from astroid.decorators import cachedproperty as cached_property
+
 
 class BlockRangeMixIn:
     """override block range"""
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         return self.lineno
 
@@ -135,7 +141,7 @@ class MultiLineBlockMixin:
     Assign nodes, etc.
     """
 
-    @decorators.cachedproperty
+    @cached_property
     def _multi_line_blocks(self):
         return tuple(getattr(self, field) for field in self._multi_line_block_fields)
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -80,6 +80,11 @@ if TYPE_CHECKING:
     from astroid import nodes
     from astroid.nodes import LocalsDictNodeNG
 
+if sys.version_info >= (3, 8) or TYPE_CHECKING:
+    from functools import cached_property  # pylint: disable=ungrouped-imports
+else:
+    from astroid.decorators import cachedproperty as cached_property
+
 
 def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
@@ -824,7 +829,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
             return name
         return None
 
-    @decorators.cachedproperty
+    @cached_property
     def fromlineno(self):
         """The first line that this node appears on in the source code.
 
@@ -833,7 +838,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         lineno = super().fromlineno
         return max(lineno, self.parent.fromlineno or 0)
 
-    @decorators.cachedproperty
+    @cached_property
     def arguments(self):
         """Get all the arguments for this node, including positional only and positional and keyword"""
         return list(itertools.chain((self.posonlyargs or ()), self.args or ()))
@@ -2601,7 +2606,7 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
         if body is not None:
             self.body = body
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -2734,7 +2739,7 @@ class For(
     See astroid/protocols.py for actual implementation.
     """
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -3093,7 +3098,7 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         if isinstance(self.parent, If) and self in self.parent.orelse:
             self.is_orelse = True
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -3762,7 +3767,7 @@ class Slice(NodeNG):
             return const
         return attr
 
-    @decorators.cachedproperty
+    @cached_property
     def _proxied(self):
         builtins = AstroidManager().builtins_module
         return builtins.getattr("slice")[0]
@@ -4384,7 +4389,7 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         if orelse is not None:
             self.orelse = orelse
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -4500,7 +4505,7 @@ class With(
     See astroid/protocols.py for actual implementation.
     """
 
-    @decorators.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -81,7 +81,8 @@ if TYPE_CHECKING:
     from astroid.nodes import LocalsDictNodeNG
 
 if sys.version_info >= (3, 8) or TYPE_CHECKING:
-    from functools import cached_property  # pylint: disable=ungrouped-imports
+    # pylint: disable-next=ungrouped-imports
+    from functools import cached_property
 else:
     from astroid.decorators import cachedproperty as cached_property
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -39,7 +39,8 @@ else:
     from typing_extensions import Literal
 
 if sys.version_info >= (3, 8) or TYPE_CHECKING:
-    from functools import cached_property  # pylint: disable=ungrouped-imports
+    # pylint: disable-next=ungrouped-imports
+    from functools import cached_property
 else:
     # pylint: disable-next=ungrouped-imports
     from astroid.decorators import cachedproperty as cached_property

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -38,6 +38,11 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
+if sys.version_info >= (3, 8) or TYPE_CHECKING:
+    from functools import cached_property  # pylint: disable=ungrouped-imports
+else:
+    # pylint: disable-next=ungrouped-imports
+    from astroid.decorators import cachedproperty as cached_property
 
 # Types for 'NodeNG.nodes_of_class()'
 T_Nodes = TypeVar("T_Nodes", bound="NodeNG")
@@ -435,14 +440,14 @@ class NodeNG:
     # these are lazy because they're relatively expensive to compute for every
     # single node, and they rarely get looked at
 
-    @decorators.cachedproperty
+    @cached_property
     def fromlineno(self) -> Optional[int]:
         """The first line that this node appears on in the source code."""
         if self.lineno is None:
             return self._fixed_source_line()
         return self.lineno
 
-    @decorators.cachedproperty
+    @cached_property
     def tolineno(self) -> Optional[int]:
         """The last line that this node appears on in the source code."""
         if self.end_lineno is not None:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -52,7 +52,7 @@ import os
 import sys
 import typing
 import warnings
-from typing import Dict, List, Optional, Set, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, TypeVar, Union, overload
 
 from astroid import bases
 from astroid import decorators as decorators_mod
@@ -92,6 +92,12 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+if sys.version_info >= (3, 8) or TYPE_CHECKING:
+    from functools import cached_property
+else:
+    # pylint: disable-next=ungrouped-imports
+    from astroid.decorators import cachedproperty as cached_property
 
 
 ITER_METHODS = ("__iter__", "__getitem__")
@@ -1611,7 +1617,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         self.position = position
         self.doc_node = doc_node
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def extra_decorators(self) -> List[node_classes.Call]:
         """The extra decorators that this function can have.
 
@@ -1652,7 +1658,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                             decorators.append(assign.value)
         return decorators
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def type(
         self,
     ):  # pylint: disable=invalid-overridden-method,too-many-return-statements
@@ -1726,7 +1732,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                 pass
         return type_name
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def fromlineno(self) -> Optional[int]:
         """The first line that this node appears on in the source code."""
         # lineno is the line number of the first decorator, we want the def
@@ -1739,7 +1745,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
 
         return lineno
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 
@@ -2337,7 +2343,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         doc=("Whether this is a new style class or not\n\n" ":type: bool or None"),
     )
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def fromlineno(self) -> Optional[int]:
         """The first line that this node appears on in the source code."""
         if not PY38_PLUS:
@@ -2352,7 +2358,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             return lineno
         return super().fromlineno
 
-    @decorators_mod.cachedproperty
+    @cached_property
     def blockstart_tolineno(self):
         """The line on which the beginning of this block ends.
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -22,8 +22,10 @@ leads to an inferred FrozenSet:
     Call(func=Name('frozenset'), args=Tuple(...))
 """
 
+import sys
+from typing import TYPE_CHECKING
 
-from astroid import bases, decorators, util
+from astroid import bases, util
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -35,6 +37,11 @@ from astroid.nodes import node_classes, scoped_nodes
 
 objectmodel = util.lazy_import("interpreter.objectmodel")
 
+if sys.version_info >= (3, 8) or TYPE_CHECKING:
+    from functools import cached_property
+else:
+    from astroid.decorators import cachedproperty as cached_property
+
 
 class FrozenSet(node_classes.BaseContainer):
     """class representing a FrozenSet composite node"""
@@ -45,7 +52,7 @@ class FrozenSet(node_classes.BaseContainer):
     def _infer(self, context=None):
         yield self
 
-    @decorators.cachedproperty
+    @cached_property
     def _proxied(self):  # pylint: disable=method-hidden
         ast_builtins = AstroidManager().builtins_module
         return ast_builtins.getattr("frozenset")[0]
@@ -114,7 +121,7 @@ class Super(node_classes.NodeNG):
         index = mro.index(self.mro_pointer)
         return mro[index + 1 :]
 
-    @decorators.cachedproperty
+    @cached_property
     def _proxied(self):
         ast_builtins = AstroidManager().builtins_module
         return ast_builtins.getattr("super")[0]
@@ -218,7 +225,7 @@ class ExceptionInstance(bases.Instance):
     the case of .args.
     """
 
-    @decorators.cachedproperty
+    @cached_property
     def special_attributes(self):
         qname = self.qname()
         instance = objectmodel.BUILTIN_EXCEPTIONS.get(

--- a/tests/unittest_decorators.py
+++ b/tests/unittest_decorators.py
@@ -1,8 +1,7 @@
-import sys
-
 import pytest
 from _pytest.recwarn import WarningsRecorder
 
+from astroid.const import PY38_PLUS
 from astroid.decorators import cachedproperty, deprecate_default_argument_values
 
 
@@ -101,7 +100,7 @@ class TestDeprecationDecorators:
         assert len(recwarn) == 0
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or higher")
+@pytest.mark.skipif(not PY38_PLUS, reason="Requires Python 3.8 or higher")
 def test_deprecation_warning_on_cachedproperty() -> None:
     """Check the DeprecationWarning on cachedproperty."""
 

--- a/tests/unittest_decorators.py
+++ b/tests/unittest_decorators.py
@@ -1,7 +1,9 @@
+import sys
+
 import pytest
 from _pytest.recwarn import WarningsRecorder
 
-from astroid.decorators import deprecate_default_argument_values
+from astroid.decorators import cachedproperty, deprecate_default_argument_values
 
 
 class SomeClass:
@@ -97,3 +99,18 @@ class TestDeprecationDecorators:
         instance = SomeClass(name="some_name")
         instance.func(name="", var=42)
         assert len(recwarn) == 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or higher")
+def test_deprecation_warning_on_cachedproperty() -> None:
+    """Check the DeprecationWarning on cachedproperty."""
+
+    with pytest.warns(DeprecationWarning) as records:
+
+        class MyClass:  # pylint: disable=unused-variable
+            @cachedproperty
+            def my_property(self):
+                return 1
+
+        assert len(records) == 1
+        assert "functools.cached_property" in records[0].message.args[0]


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This closes #1410. I guess the deprecation introduced in #1243 can wait a bit.

@cdce8p This is what I meant with redefining `cachedproperty`. I'm not sure if this is something you would want to do, but I tested and this does help `mypy` recognise the types of these properties correctly.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Related Issue
