### PR TITLE
Pass ``doc_node`` to postinit of all ``Property`` constructors

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -23,9 +23,11 @@
 """Astroid hooks for various builtins."""
 
 from functools import partial
+from typing import Optional
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder
+from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
     AttributeInferenceError,
@@ -548,7 +550,9 @@ def infer_callable(node, context=None):
     return nodes.Const(inferred.callable())
 
 
-def infer_property(node, context=None):
+def infer_property(
+    node: nodes.Call, context: Optional[InferenceContext] = None
+) -> objects.Property:
     """Understand `property` class
 
     This only infers the output of `property`
@@ -570,12 +574,16 @@ def infer_property(node, context=None):
     prop_func = objects.Property(
         function=inferred,
         name=inferred.name,
-        doc=getattr(inferred, "doc", None),
+        doc=getattr(inferred, "doc_node.value", None),
         lineno=node.lineno,
         parent=node,
         col_offset=node.col_offset,
     )
-    prop_func.postinit(body=[], args=inferred.args)
+    prop_func.postinit(
+        body=[],
+        args=inferred.args,
+        doc_node=getattr(inferred, "doc_node", None),
+    )
     return prop_func
 
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6146,6 +6146,26 @@ def test_property_callable_inference() -> None:
     assert inferred.value == 42
 
 
+def test_property_docstring() -> None:
+    code = """
+    class A:
+        @property
+        def test(self):
+            '''Docstring'''
+            return 42
+
+    A.test #@
+    """
+    node = extract_node(code)
+    inferred = next(node.infer())
+    assert isinstance(inferred, objects.Property)
+    assert inferred.doc_node
+    assert inferred.doc_node.value == "Docstring"
+    with pytest.warns(DeprecationWarning) as records:
+        assert inferred.doc == "Docstring"
+        assert len(records) == 1
+
+
 def test_recursion_error_inferring_builtin_containers() -> None:
     node = extract_node(
         """


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

Partial step 2 as discussed in https://github.com/PyCQA/astroid/pull/1432#pullrequestreview-898319366.

Blocked by #1434 as there is a test that depends on the deprecation.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

