### PR TITLE
Limit concurrent jobs [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -250,6 +250,7 @@ jobs:
     name: Prepare tests for Python ${{ matrix.python-version }} (Windows)
     runs-on: windows-latest
     timeout-minutes: 5
+    needs: pytest-linux
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
@@ -333,6 +334,7 @@ jobs:
     name: Prepare tests for Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: pytest-linux
     strategy:
       matrix:
         python-version: ["pypy-3.6"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,7 +249,7 @@ jobs:
   prepare-tests-windows:
     name: Prepare tests for Python ${{ matrix.python-version }} (Windows)
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: pytest-linux
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -334,7 +334,6 @@ jobs:
     name: Prepare tests for Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: pytest-linux
     strategy:
       matrix:
         python-version: ["pypy-3.6"]


### PR DESCRIPTION
## Description
We had a lot of failed CI runs recently. I would like to try if we could improve that by limiting how many concurrent test jobs are run. As a first step, I've added `needs: pytest-linux` to ~both~ the `prepare-tests` jobs for windows ~and pypy~.

That would limit the max concurrent test jobs from 11 down to 6. It also means a slight increase in runtime as they are no longer executed concurrently, but I think that wouldn't matter too much. The astroid tests are quite fast and if it can improve overall reliability, it's worth it IMO.

It also has the benefit that we don't even run the windows tests if linux failed already.

**Update:** It might make sense to run `linux` and `pypy` together as these are different Python implementations.
If we run pypy only if linux succeed, we might not know about pypy specific failures ahead of time.

The test graph: https://github.com/PyCQA/astroid/actions/runs/1936025227