### PR TITLE
Replace sys.version_info checks with getattr [rebuilder]

### DIFF
--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1030,16 +1030,14 @@ class TreeRebuilder:
 
     def visit_assert(self, node: "ast.Assert", parent: NodeNG) -> nodes.Assert:
         """visit a Assert node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Assert(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Assert(node.lineno, node.col_offset, parent)
+        newnode = nodes.Assert(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         msg: Optional[NodeNG] = None
         if node.msg:
             msg = self.visit(node.msg, newnode)
@@ -1115,16 +1113,14 @@ class TreeRebuilder:
         return self._visit_for(nodes.AsyncFor, node, parent)
 
     def visit_await(self, node: "ast.Await", parent: NodeNG) -> nodes.Await:
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Await(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Await(node.lineno, node.col_offset, parent)
+        newnode = nodes.Await(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(value=self.visit(node.value, newnode))
         return newnode
 
@@ -1133,16 +1129,14 @@ class TreeRebuilder:
 
     def visit_assign(self, node: "ast.Assign", parent: NodeNG) -> nodes.Assign:
         """visit a Assign node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Assign(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Assign(node.lineno, node.col_offset, parent)
+        newnode = nodes.Assign(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         type_annotation = self.check_type_comment(node, parent=newnode)
         newnode.postinit(
             targets=[self.visit(child, newnode) for child in node.targets],
@@ -1153,16 +1147,14 @@ class TreeRebuilder:
 
     def visit_annassign(self, node: "ast.AnnAssign", parent: NodeNG) -> nodes.AnnAssign:
         """visit an AnnAssign node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.AnnAssign(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.AnnAssign(node.lineno, node.col_offset, parent)
+        newnode = nodes.AnnAssign(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             target=self.visit(node.target, newnode),
             annotation=self.visit(node.annotation, newnode),
@@ -1192,43 +1184,29 @@ class TreeRebuilder:
         """
         if node_name is None:
             return None
-        if sys.version_info >= (3, 8):
-            newnode = nodes.AssignName(
-                name=node_name,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.AssignName(
-                node_name,
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.AssignName(
+            name=node_name,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         self._save_assignment(newnode)
         return newnode
 
     def visit_augassign(self, node: "ast.AugAssign", parent: NodeNG) -> nodes.AugAssign:
         """visit a AugAssign node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.AugAssign(
-                op=self._parser_module.bin_op_classes[type(node.op)] + "=",
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.AugAssign(
-                self._parser_module.bin_op_classes[type(node.op)] + "=",
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.AugAssign(
+            op=self._parser_module.bin_op_classes[type(node.op)] + "=",
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.target, newnode), self.visit(node.value, newnode)
         )
@@ -1236,22 +1214,15 @@ class TreeRebuilder:
 
     def visit_binop(self, node: "ast.BinOp", parent: NodeNG) -> nodes.BinOp:
         """visit a BinOp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.BinOp(
-                op=self._parser_module.bin_op_classes[type(node.op)],
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.BinOp(
-                self._parser_module.bin_op_classes[type(node.op)],
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.BinOp(
+            op=self._parser_module.bin_op_classes[type(node.op)],
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.left, newnode), self.visit(node.right, newnode)
         )
@@ -1259,49 +1230,39 @@ class TreeRebuilder:
 
     def visit_boolop(self, node: "ast.BoolOp", parent: NodeNG) -> nodes.BoolOp:
         """visit a BoolOp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.BoolOp(
-                op=self._parser_module.bool_op_classes[type(node.op)],
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.BoolOp(
-                self._parser_module.bool_op_classes[type(node.op)],
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.BoolOp(
+            op=self._parser_module.bool_op_classes[type(node.op)],
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.values])
         return newnode
 
     def visit_break(self, node: "ast.Break", parent: NodeNG) -> nodes.Break:
         """visit a Break node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            return nodes.Break(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        return nodes.Break(node.lineno, node.col_offset, parent)
+        return nodes.Break(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
 
     def visit_call(self, node: "ast.Call", parent: NodeNG) -> nodes.Call:
         """visit a CallFunc node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Call(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Call(node.lineno, node.col_offset, parent)
+        newnode = nodes.Call(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             func=self.visit(node.func, newnode),
             args=[self.visit(child, newnode) for child in node.args],
@@ -1314,20 +1275,16 @@ class TreeRebuilder:
     ) -> nodes.ClassDef:
         """visit a ClassDef node to become astroid"""
         node, doc_ast_node, doc = self._get_doc(node)
-        if sys.version_info >= (3, 8):
-            newnode = nodes.ClassDef(
-                name=node.name,
-                doc=doc,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.ClassDef(
-                node.name, doc, node.lineno, node.col_offset, parent
-            )
+        newnode = nodes.ClassDef(
+            name=node.name,
+            doc=doc,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         metaclass = None
         for keyword in node.keywords:
             if keyword.arg == "metaclass":
@@ -1353,28 +1310,25 @@ class TreeRebuilder:
 
     def visit_continue(self, node: "ast.Continue", parent: NodeNG) -> nodes.Continue:
         """visit a Continue node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            return nodes.Continue(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        return nodes.Continue(node.lineno, node.col_offset, parent)
+        return nodes.Continue(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
 
     def visit_compare(self, node: "ast.Compare", parent: NodeNG) -> nodes.Compare:
         """visit a Compare node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Compare(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Compare(node.lineno, node.col_offset, parent)
+        newnode = nodes.Compare(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.left, newnode),
             [
@@ -1434,16 +1388,14 @@ class TreeRebuilder:
 
     def visit_delete(self, node: "ast.Delete", parent: NodeNG) -> nodes.Delete:
         """visit a Delete node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Delete(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Delete(node.lineno, node.col_offset, parent)
+        newnode = nodes.Delete(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.targets])
         return newnode
 
@@ -1455,50 +1407,42 @@ class TreeRebuilder:
             rebuilt_value = self.visit(value, newnode)
             if not key:
                 # Extended unpacking
-                if sys.version_info >= (3, 8):
-                    rebuilt_key = nodes.DictUnpack(
-                        lineno=rebuilt_value.lineno,
-                        col_offset=rebuilt_value.col_offset,
-                        end_lineno=rebuilt_value.end_lineno,
-                        end_col_offset=rebuilt_value.end_col_offset,
-                        parent=parent,
-                    )
-                else:
-                    rebuilt_key = nodes.DictUnpack(
-                        rebuilt_value.lineno, rebuilt_value.col_offset, parent
-                    )
+                rebuilt_key = nodes.DictUnpack(
+                    lineno=rebuilt_value.lineno,
+                    col_offset=rebuilt_value.col_offset,
+                    # end_lineno and end_col_offset added in 3.8
+                    end_lineno=getattr(rebuilt_value, "end_lineno", None),
+                    end_col_offset=getattr(rebuilt_value, "end_col_offset", None),
+                    parent=parent,
+                )
             else:
                 rebuilt_key = self.visit(key, newnode)
             yield rebuilt_key, rebuilt_value
 
     def visit_dict(self, node: "ast.Dict", parent: NodeNG) -> nodes.Dict:
         """visit a Dict node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Dict(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Dict(node.lineno, node.col_offset, parent)
+        newnode = nodes.Dict(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         items = list(self._visit_dict_items(node, parent, newnode))
         newnode.postinit(items)
         return newnode
 
     def visit_dictcomp(self, node: "ast.DictComp", parent: NodeNG) -> nodes.DictComp:
         """visit a DictComp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.DictComp(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.DictComp(node.lineno, node.col_offset, parent)
+        newnode = nodes.DictComp(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.key, newnode),
             self.visit(node.value, newnode),
@@ -1508,16 +1452,14 @@ class TreeRebuilder:
 
     def visit_expr(self, node: "ast.Expr", parent: NodeNG) -> nodes.Expr:
         """visit a Expr node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Expr(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Expr(node.lineno, node.col_offset, parent)
+        newnode = nodes.Expr(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
@@ -1535,16 +1477,14 @@ class TreeRebuilder:
         self, node: "ast.ExceptHandler", parent: NodeNG
     ) -> nodes.ExceptHandler:
         """visit an ExceptHandler node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.ExceptHandler(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.ExceptHandler(node.lineno, node.col_offset, parent)
+        newnode = nodes.ExceptHandler(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.type, newnode),
             self.visit_assignname(node, newnode, node.name),
@@ -1578,16 +1518,14 @@ class TreeRebuilder:
         self, cls: Type[T_For], node: Union["ast.For", "ast.AsyncFor"], parent: NodeNG
     ) -> T_For:
         """visit a For node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = cls(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = cls(node.lineno, node.col_offset, parent)
+        newnode = cls(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         type_annotation = self.check_type_comment(node, parent=newnode)
         newnode.postinit(
             target=self.visit(node.target, newnode),
@@ -1606,26 +1544,17 @@ class TreeRebuilder:
     ) -> nodes.ImportFrom:
         """visit an ImportFrom node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        if sys.version_info >= (3, 8):
-            newnode = nodes.ImportFrom(
-                fromname=node.module or "",
-                names=names,
-                level=node.level or None,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.ImportFrom(
-                node.module or "",
-                names,
-                node.level or None,
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.ImportFrom(
+            fromname=node.module or "",
+            names=names,
+            level=node.level or None,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         # store From names to add them to locals after building
         self._import_from_nodes.append(newnode)
         return newnode
@@ -1666,18 +1595,16 @@ class TreeRebuilder:
             # the framework for *years*.
             lineno = node.decorator_list[0].lineno
 
-        if sys.version_info >= (3, 8):
-            newnode = cls(
-                name=node.name,
-                doc=doc,
-                lineno=lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = cls(node.name, doc, lineno, node.col_offset, parent)
+        newnode = cls(
+            name=node.name,
+            doc=doc,
+            lineno=lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         decorators = self.visit_decorators(node, newnode)
         returns: Optional[NodeNG]
         if node.returns:
@@ -1712,16 +1639,14 @@ class TreeRebuilder:
         self, node: "ast.GeneratorExp", parent: NodeNG
     ) -> nodes.GeneratorExp:
         """visit a GeneratorExp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.GeneratorExp(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.GeneratorExp(node.lineno, node.col_offset, parent)
+        newnode = nodes.GeneratorExp(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.elt, newnode),
             [self.visit(child, newnode) for child in node.generators],
@@ -1737,74 +1662,55 @@ class TreeRebuilder:
         if context == Context.Del:
             # FIXME : maybe we should reintroduce and visit_delattr ?
             # for instance, deactivating assign_ctx
-            if sys.version_info >= (3, 8):
-                newnode = nodes.DelAttr(
-                    attrname=node.attr,
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.DelAttr(node.attr, node.lineno, node.col_offset, parent)
+            newnode = nodes.DelAttr(
+                attrname=node.attr,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
         elif context == Context.Store:
-            if sys.version_info >= (3, 8):
-                # pylint: disable=redefined-variable-type
-                newnode = nodes.AssignAttr(
-                    attrname=node.attr,
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.AssignAttr(
-                    node.attr, node.lineno, node.col_offset, parent
-                )
+            # pylint: disable=redefined-variable-type
+            newnode = nodes.AssignAttr(
+                attrname=node.attr,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
             # Prohibit a local save if we are in an ExceptHandler.
             if not isinstance(parent, nodes.ExceptHandler):
                 # mypy doesn't recognize that newnode has to be AssignAttr because it doesn't support ParamSpec
                 # See https://github.com/python/mypy/issues/8645
                 self._delayed_assattr.append(newnode)  # type: ignore[arg-type]
         else:
-            # pylint: disable-next=else-if-used
-            # Preserve symmetry with other cases
-            if sys.version_info >= (3, 8):
-                newnode = nodes.Attribute(
-                    attrname=node.attr,
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.Attribute(
-                    node.attr, node.lineno, node.col_offset, parent
-                )
+            newnode = nodes.Attribute(
+                attrname=node.attr,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_global(self, node: "ast.Global", parent: NodeNG) -> nodes.Global:
         """visit a Global node to become astroid"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Global(
-                names=node.names,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Global(
-                node.names,
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.Global(
+            names=node.names,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         if self._global_names:  # global at the module level, no effect
             for name in node.names:
                 self._global_names[-1].setdefault(name, []).append(newnode)
@@ -1812,16 +1718,14 @@ class TreeRebuilder:
 
     def visit_if(self, node: "ast.If", parent: NodeNG) -> nodes.If:
         """visit an If node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.If(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.If(node.lineno, node.col_offset, parent)
+        newnode = nodes.If(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.test, newnode),
             [self.visit(child, newnode) for child in node.body],
@@ -1831,16 +1735,14 @@ class TreeRebuilder:
 
     def visit_ifexp(self, node: "ast.IfExp", parent: NodeNG) -> nodes.IfExp:
         """visit a IfExp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.IfExp(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.IfExp(node.lineno, node.col_offset, parent)
+        newnode = nodes.IfExp(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.test, newnode),
             self.visit(node.body, newnode),
@@ -1851,22 +1753,15 @@ class TreeRebuilder:
     def visit_import(self, node: "ast.Import", parent: NodeNG) -> nodes.Import:
         """visit a Import node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Import(
-                names=names,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Import(
-                names,
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.Import(
+            names=names,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         # save import names in parent's locals:
         for (name, asname) in newnode.names:
             name = asname or name
@@ -1874,32 +1769,28 @@ class TreeRebuilder:
         return newnode
 
     def visit_joinedstr(self, node: "ast.JoinedStr", parent: NodeNG) -> nodes.JoinedStr:
-        if sys.version_info >= (3, 8):
-            newnode = nodes.JoinedStr(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.JoinedStr(node.lineno, node.col_offset, parent)
+        newnode = nodes.JoinedStr(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.values])
         return newnode
 
     def visit_formattedvalue(
         self, node: "ast.FormattedValue", parent: NodeNG
     ) -> nodes.FormattedValue:
-        if sys.version_info >= (3, 8):
-            newnode = nodes.FormattedValue(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.FormattedValue(node.lineno, node.col_offset, parent)
+        newnode = nodes.FormattedValue(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.value, newnode),
             node.conversion,
@@ -1908,16 +1799,14 @@ class TreeRebuilder:
         return newnode
 
     def visit_namedexpr(self, node: "ast.NamedExpr", parent: NodeNG) -> nodes.NamedExpr:
-        if sys.version_info >= (3, 8):
-            newnode = nodes.NamedExpr(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.NamedExpr(node.lineno, node.col_offset, parent)
+        newnode = nodes.NamedExpr(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.target, newnode), self.visit(node.value, newnode)
         )
@@ -1930,69 +1819,56 @@ class TreeRebuilder:
 
     def visit_keyword(self, node: "ast.keyword", parent: NodeNG) -> nodes.Keyword:
         """visit a Keyword node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 9):
-            newnode = nodes.Keyword(
-                arg=node.arg,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Keyword(node.arg, parent=parent)
+        newnode = nodes.Keyword(
+            arg=node.arg,
+            # position attributes added in 3.9
+            lineno=getattr(node, "lineno", None),
+            col_offset=getattr(node, "col_offset", None),
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_lambda(self, node: "ast.Lambda", parent: NodeNG) -> nodes.Lambda:
         """visit a Lambda node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Lambda(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Lambda(node.lineno, node.col_offset, parent)
+        newnode = nodes.Lambda(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(self.visit(node.args, newnode), self.visit(node.body, newnode))
         return newnode
 
     def visit_list(self, node: "ast.List", parent: NodeNG) -> nodes.List:
         """visit a List node by returning a fresh instance of it"""
         context = self._get_context(node)
-        if sys.version_info >= (3, 8):
-            newnode = nodes.List(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.List(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                parent=parent,
-            )
+        newnode = nodes.List(
+            ctx=context,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
     def visit_listcomp(self, node: "ast.ListComp", parent: NodeNG) -> nodes.ListComp:
         """visit a ListComp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.ListComp(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.ListComp(node.lineno, node.col_offset, parent)
+        newnode = nodes.ListComp(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.elt, newnode),
             [self.visit(child, newnode) for child in node.generators],
@@ -2006,46 +1882,36 @@ class TreeRebuilder:
         context = self._get_context(node)
         newnode: Union[nodes.Name, nodes.AssignName, nodes.DelName]
         if context == Context.Del:
-            if sys.version_info >= (3, 8):
-                newnode = nodes.DelName(
-                    name=node.id,
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.DelName(node.id, node.lineno, node.col_offset, parent)
+            newnode = nodes.DelName(
+                name=node.id,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
         elif context == Context.Store:
-            if sys.version_info >= (3, 8):
-                # pylint: disable=redefined-variable-type
-                newnode = nodes.AssignName(
-                    name=node.id,
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.AssignName(
-                    node.id, node.lineno, node.col_offset, parent
-                )
+            # pylint: disable=redefined-variable-type
+            newnode = nodes.AssignName(
+                name=node.id,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
         else:
-            # pylint: disable-next=else-if-used
-            # Preserve symmetry with other cases
-            if sys.version_info >= (3, 8):
-                newnode = nodes.Name(
-                    name=node.id,
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.Name(node.id, node.lineno, node.col_offset, parent)
+            newnode = nodes.Name(
+                name=node.id,
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
         # XXX REMOVE me :
         if context in (Context.Del, Context.Store):  # 'Aug' ??
             newnode = cast(Union[nodes.AssignName, nodes.DelName], newnode)
@@ -2066,40 +1932,27 @@ class TreeRebuilder:
 
     def visit_nonlocal(self, node: "ast.Nonlocal", parent: NodeNG) -> nodes.Nonlocal:
         """visit a Nonlocal node and return a new instance of it"""
-        if sys.version_info >= (3, 8):
-            return nodes.Nonlocal(
-                names=node.names,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
         return nodes.Nonlocal(
-            node.names,
-            node.lineno,
-            node.col_offset,
-            parent,
+            names=node.names,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
         )
 
     def visit_constant(self, node: "ast.Constant", parent: NodeNG) -> nodes.Const:
         """visit a Constant node by returning a fresh instance of Const"""
-        if sys.version_info >= (3, 8):
-            return nodes.Const(
-                value=node.value,
-                kind=node.kind,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
         return nodes.Const(
-            node.value,
-            node.lineno,
-            node.col_offset,
-            parent,
-            node.kind,
+            value=node.value,
+            kind=node.kind,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
         )
 
     # Not used in Python 3.8+.
@@ -2129,28 +1982,25 @@ class TreeRebuilder:
 
     def visit_pass(self, node: "ast.Pass", parent: NodeNG) -> nodes.Pass:
         """visit a Pass node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            return nodes.Pass(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        return nodes.Pass(node.lineno, node.col_offset, parent)
+        return nodes.Pass(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
 
     def visit_raise(self, node: "ast.Raise", parent: NodeNG) -> nodes.Raise:
         """visit a Raise node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Raise(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Raise(node.lineno, node.col_offset, parent)
+        newnode = nodes.Raise(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         # no traceback; anyway it is not used in Pylint
         newnode.postinit(
             exc=self.visit(node.exc, newnode),
@@ -2160,47 +2010,41 @@ class TreeRebuilder:
 
     def visit_return(self, node: "ast.Return", parent: NodeNG) -> nodes.Return:
         """visit a Return node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Return(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Return(node.lineno, node.col_offset, parent)
+        newnode = nodes.Return(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         if node.value is not None:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_set(self, node: "ast.Set", parent: NodeNG) -> nodes.Set:
         """visit a Set node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Set(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Set(node.lineno, node.col_offset, parent)
+        newnode = nodes.Set(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
     def visit_setcomp(self, node: "ast.SetComp", parent: NodeNG) -> nodes.SetComp:
         """visit a SetComp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.SetComp(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.SetComp(node.lineno, node.col_offset, parent)
+        newnode = nodes.SetComp(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.elt, newnode),
             [self.visit(child, newnode) for child in node.generators],
@@ -2209,16 +2053,14 @@ class TreeRebuilder:
 
     def visit_slice(self, node: "ast.Slice", parent: nodes.Subscript) -> nodes.Slice:
         """visit a Slice node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 9):
-            newnode = nodes.Slice(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Slice(parent=parent)
+        newnode = nodes.Slice(
+            # position attributes added in 3.9
+            lineno=getattr(node, "lineno", None),
+            col_offset=getattr(node, "col_offset", None),
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             lower=self.visit(node.lower, newnode),
             upper=self.visit(node.upper, newnode),
@@ -2229,22 +2071,15 @@ class TreeRebuilder:
     def visit_subscript(self, node: "ast.Subscript", parent: NodeNG) -> nodes.Subscript:
         """visit a Subscript node by returning a fresh instance of it"""
         context = self._get_context(node)
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Subscript(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Subscript(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                parent=parent,
-            )
+        newnode = nodes.Subscript(
+            ctx=context,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.value, newnode), self.visit(node.slice, newnode)
         )
@@ -2253,22 +2088,15 @@ class TreeRebuilder:
     def visit_starred(self, node: "ast.Starred", parent: NodeNG) -> nodes.Starred:
         """visit a Starred node and return a new instance of it"""
         context = self._get_context(node)
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Starred(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Starred(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                parent=parent,
-            )
+        newnode = nodes.Starred(
+            ctx=context,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
@@ -2307,16 +2135,14 @@ class TreeRebuilder:
         # python 3.3 introduce a new Try node replacing
         # TryFinally/TryExcept nodes
         if node.finalbody:
-            if sys.version_info >= (3, 8):
-                newnode = nodes.TryFinally(
-                    lineno=node.lineno,
-                    col_offset=node.col_offset,
-                    end_lineno=node.end_lineno,
-                    end_col_offset=node.end_col_offset,
-                    parent=parent,
-                )
-            else:
-                newnode = nodes.TryFinally(node.lineno, node.col_offset, parent)
+            newnode = nodes.TryFinally(
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+                # end_lineno and end_col_offset added in 3.8
+                end_lineno=getattr(node, "end_lineno", None),
+                end_col_offset=getattr(node, "end_col_offset", None),
+                parent=parent,
+            )
             body: List[Union[NodeNG, nodes.TryExcept]]
             if node.handlers:
                 body = [self.visit_tryexcept(node, newnode)]
@@ -2331,58 +2157,42 @@ class TreeRebuilder:
     def visit_tuple(self, node: "ast.Tuple", parent: NodeNG) -> nodes.Tuple:
         """visit a Tuple node by returning a fresh instance of it"""
         context = self._get_context(node)
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Tuple(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Tuple(
-                ctx=context,
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                parent=parent,
-            )
+        newnode = nodes.Tuple(
+            ctx=context,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
     def visit_unaryop(self, node: "ast.UnaryOp", parent: NodeNG) -> nodes.UnaryOp:
         """visit a UnaryOp node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.UnaryOp(
-                op=self._parser_module.unary_op_classes[node.op.__class__],
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.UnaryOp(
-                self._parser_module.unary_op_classes[node.op.__class__],
-                node.lineno,
-                node.col_offset,
-                parent,
-            )
+        newnode = nodes.UnaryOp(
+            op=self._parser_module.unary_op_classes[node.op.__class__],
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(self.visit(node.operand, newnode))
         return newnode
 
     def visit_while(self, node: "ast.While", parent: NodeNG) -> nodes.While:
         """visit a While node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.While(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.While(node.lineno, node.col_offset, parent)
+        newnode = nodes.While(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         newnode.postinit(
             self.visit(node.test, newnode),
             [self.visit(child, newnode) for child in node.body],
@@ -2408,16 +2218,14 @@ class TreeRebuilder:
         node: Union["ast.With", "ast.AsyncWith"],
         parent: NodeNG,
     ) -> T_With:
-        if sys.version_info >= (3, 8):
-            newnode = cls(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = cls(node.lineno, node.col_offset, parent)
+        newnode = cls(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
 
         def visit_child(child: "ast.withitem") -> Tuple[NodeNG, Optional[NodeNG]]:
             expr = self.visit(child.context_expr, newnode)
@@ -2437,31 +2245,27 @@ class TreeRebuilder:
 
     def visit_yield(self, node: "ast.Yield", parent: NodeNG) -> NodeNG:
         """visit a Yield node by returning a fresh instance of it"""
-        if sys.version_info >= (3, 8):
-            newnode = nodes.Yield(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.Yield(node.lineno, node.col_offset, parent)
+        newnode = nodes.Yield(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         if node.value is not None:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
     def visit_yieldfrom(self, node: "ast.YieldFrom", parent: NodeNG) -> NodeNG:
-        if sys.version_info >= (3, 8):
-            newnode = nodes.YieldFrom(
-                lineno=node.lineno,
-                col_offset=node.col_offset,
-                end_lineno=node.end_lineno,
-                end_col_offset=node.end_col_offset,
-                parent=parent,
-            )
-        else:
-            newnode = nodes.YieldFrom(node.lineno, node.col_offset, parent)
+        newnode = nodes.YieldFrom(
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            # end_lineno and end_col_offset added in 3.8
+            end_lineno=getattr(node, "end_lineno", None),
+            end_col_offset=getattr(node, "end_col_offset", None),
+            parent=parent,
+        )
         if node.value is not None:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode


### PR DESCRIPTION
## Description

Simplify maintenance and reduce code duplication in `astroid.rebuilder` by using `getattr` instead of `sys.version_info` to guard against missing `end_lineno` and `end_col_offset` attributes.

This change is a tradeoff between linter support and reduced code duplication. I didn't saw a noticeable performance difference during testing. In the end, I think the simplified maintenance is slightly preferable here.

Once support for Python 3.8 / 3.9 is removed, the `getattr` calls can / should be replaced with normal attribute.