### PR TITLE
Add CI job for PyPy 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -360,10 +360,10 @@ jobs:
         with:
           path: venv
           key: >-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            ${{ runner.os }}-${{ matrix.python-version }}-${{
             steps.generate-python-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
+            ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ env.CACHE_VERSION }}-
       - name: Create Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -396,7 +396,7 @@ jobs:
         with:
           path: venv
           key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            ${{ runner.os }}-${{ matrix.python-version }}-${{
             needs.prepare-tests-pypy.outputs.python-key }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,7 +336,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["pypy-3.6"]
+        python-version: ["pypy-3.6", "pypy-3.7"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -381,7 +381,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.6"]
+        python-version: ["pypy-3.6", "pypy-3.7"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.0

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -84,18 +84,18 @@ if os.name == "nt":
         except AttributeError:
             pass
 
-if platform.python_implementation() == "PyPy":
+if platform.python_implementation() == "PyPy" and sys.version_info < (3, 8):
     # PyPy stores the stdlib in two places: sys.prefix/lib_pypy and sys.prefix/lib-python/3
     # sysconfig.get_path on PyPy returns the first, but without an underscore so we patch this manually.
+    # Beginning with 3.8 the stdlib is only stored in: sys.prefix/pypy{py_version_short}
     STD_LIB_DIRS.add(str(Path(sysconfig.get_path("stdlib")).parent / "lib_pypy"))
-    STD_LIB_DIRS.add(
-        sysconfig.get_path("stdlib", vars={"implementation_lower": "python/3"})
-    )
+    STD_LIB_DIRS.add(str(Path(sysconfig.get_path("stdlib")).parent / "lib-python/3"))
+
     # TODO: This is a fix for a workaround in virtualenv. At some point we should revisit
     # whether this is still necessary. See https://github.com/PyCQA/astroid/pull/1324.
     STD_LIB_DIRS.add(str(Path(sysconfig.get_path("platstdlib")).parent / "lib_pypy"))
     STD_LIB_DIRS.add(
-        sysconfig.get_path("platstdlib", vars={"implementation_lower": "python/3"})
+        str(Path(sysconfig.get_path("platstdlib")).parent / "lib-python/3")
     )
 
 if os.name == "posix":


### PR DESCRIPTION
## Description
Similar to https://github.com/PyCQA/pylint/pull/5853
Python 3.6 will be removed soon, start testing PyPy 3.7 now.

To workaround https://github.com/actions/setup-python/issues/345, update pypy cache keys.