### PR TITLE
Add missing `shape` parameter to numpy methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,10 @@ Release date: TBA
 
   Closes #1410
 
+* Fix false positive for ``shape`` parameter of ``numpy.zeros_like`` method.
+
+  Closes PyCQA/pylint#5871
+
 
 What's New in astroid 2.10.1?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,14 +18,15 @@ Release date: TBA
 
   Closes #1410
 
-* Fix false positive for ``shape`` parameter of ``numpy.zeros_like`` method.
-
-  Closes PyCQA/pylint#5871
-
 * Set ``end_lineno`` and ``end_col_offset`` attributes to ``None`` for all nodes
   with PyPy 3.8. PyPy 3.8 assigns these attributes inconsistently which could lead
   to unexpected errors. Overwriting them with ``None`` will cause a fallback
   to the already supported way of PyPy 3.7.
+
+* Add missing ``shape`` parameter to numpy ``zeros_like``, ``ones_like``,
+  and ``full_like`` methods.
+
+  Closes PyCQA/pylint#5871
 
 
 What's New in astroid 2.10.1?

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -24,7 +24,7 @@ def numpy_core_numeric_transform():
         """
     # different functions defined in numeric.py
     import numpy
-    def zeros_like(a, dtype=None, order='K', subok=True, shape=0): return numpy.ndarray((0, 0))
+    def zeros_like(a, dtype=None, order='K', subok=True, shape=None): return numpy.ndarray((0, 0))
     def ones_like(a, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
     def full_like(a, fill_value, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
         """

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -25,8 +25,8 @@ def numpy_core_numeric_transform():
     # different functions defined in numeric.py
     import numpy
     def zeros_like(a, dtype=None, order='K', subok=True, shape=None): return numpy.ndarray((0, 0))
-    def ones_like(a, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
-    def full_like(a, fill_value, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
+    def ones_like(a, dtype=None, order='K', subok=True, shape=None): return numpy.ndarray((0, 0))
+    def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None): return numpy.ndarray((0, 0))
         """
     )
 

--- a/astroid/brain/brain_numpy_core_numeric.py
+++ b/astroid/brain/brain_numpy_core_numeric.py
@@ -24,7 +24,7 @@ def numpy_core_numeric_transform():
         """
     # different functions defined in numeric.py
     import numpy
-    def zeros_like(a, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
+    def zeros_like(a, dtype=None, order='K', subok=True, shape=0): return numpy.ndarray((0, 0))
     def ones_like(a, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
     def full_like(a, fill_value, dtype=None, order='K', subok=True): return numpy.ndarray((0, 0))
         """

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -1,7 +1,7 @@
 attrs
 types-attrs
 nose
-numpy
+numpy>=1.17.0
 python-dateutil
 types-python-dateutil
 six

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -83,7 +83,7 @@ def test_function_parameters(method: str, expected_args: List[str]) -> None:
     numpy.{method} #@
     """
     )
-    actual_args = list(instance.infer())[0].args.args
+    actual_args = instance.inferred()[0].args.args
     assert [arg.name for arg in actual_args] == expected_args
 
 

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -7,6 +7,7 @@
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+import pytest
 import unittest
 
 try:
@@ -60,6 +61,27 @@ class BrainNumpyCoreNumericTest(unittest.TestCase):
                         func_[0], inferred_values[-1].pytype()
                     ),
                 )
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="This test requires the numpy library.")
+@pytest.mark.parametrize(
+    "method, expected_args",
+    [
+        ("zeros_like", ["a", "dtype", "order", "subok", "shape"]),
+        ("full_like", ["a", "fill_value", "dtype", "order", "subok", "shape"]),
+        ("ones_like", ["a", "dtype", "order", "subok", "shape"]),
+        ("ones", ["shape", "dtype", "order"]),
+    ],
+)
+def test_parameters(method, expected_args) -> None:
+    instance = builder.extract_node(
+        f"""
+    import numpy
+    numpy.{method} #@
+    """
+    )
+    actual_args = list(instance.infer())[0].args.args
+    assert [arg.name for arg in actual_args] == expected_args
 
 
 if __name__ == "__main__":

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -4,11 +4,12 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
-
-import unittest
-
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+
+import unittest
+from typing import List
+
 import pytest
 
 try:
@@ -74,7 +75,7 @@ class BrainNumpyCoreNumericTest(unittest.TestCase):
         ("ones", ["shape", "dtype", "order"]),
     ],
 )
-def test_parameters(method, expected_args) -> None:
+def test_function_parameters(method: str, expected_args: List[str]) -> None:
     instance = builder.extract_node(
         f"""
     import numpy

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2021 Pierre Sassoulas <pierre.sassoulas@gmail.com>
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
+
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -5,10 +5,11 @@
 # Copyright (c) 2021 Daniël van Noord <13665637+DanielNoord@users.noreply.github.com>
 # Copyright (c) 2021 Marc Mueller <30130371+cdce8p@users.noreply.github.com>
 
+import unittest
+
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 import pytest
-import unittest
 
 try:
     import numpy  # pylint: disable=unused-import


### PR DESCRIPTION
Add the missing `shape` parameter to the brain for:
- [numpy.zeros_like](https://numpy.org/doc/stable/reference/generated/numpy.zeros_like.html#numpy-zeros-like)
- [numpy.full_like](https://numpy.org/doc/stable/reference/generated/numpy.full_like.html?highlight=full_like#numpy-full-like)
- [numpy.ones_like](https://numpy.org/doc/stable/reference/generated/numpy.ones_like.html#numpy-ones-like)


<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

Closes with relevant test PyCQA/pylint#5871
