### PR TITLE
Deprecate passing the ``doc`` argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release date: TBA
   ``nodes.FunctionDef`` has been deprecated in favour of the ``doc_node`` attribute.
   Note: ``doc_node`` is an (optional) ``nodes.Const`` whereas ``doc`` was an (optional) ``str``.
 
+* Passing the ``doc`` argument to the ``__init__`` of ``nodes.Module``, ``nodes.ClassDef``,
+  and ``nodes.FunctionDef`` has been deprecated in favour of the ``postinit`` ``doc_node`` attribute.
+  Note: ``doc_node`` is an (optional) ``nodes.Const`` whereas ``doc`` was an (optional) ``str``.
+
 * Replace custom ``cachedproperty`` with ``functools.cached_property`` and deprecate it
   for Python 3.8+.
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -435,6 +435,7 @@ class Module(LocalsDictNodeNG):
     end_col_offset: None
     parent: None
 
+    @decorators_mod.deprecate_arguments(doc="Use the postinit arg 'doc_node' instead")
     def __init__(
         self,
         name: str,
@@ -1533,6 +1534,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
     )
     _type = None
 
+    @decorators_mod.deprecate_arguments(doc="Use the postinit arg 'doc_node' instead")
     def __init__(
         self,
         name=None,
@@ -2199,6 +2201,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     _other_other_fields = ("locals", "_newstyle")
     _newstyle = None
 
+    @decorators_mod.deprecate_arguments(doc="Use the postinit arg 'doc_node' instead")
     def __init__(
         self,
         name=None,

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2720,7 +2720,7 @@ def test_deprecation_of_doc_attribute() -> None:
         assert node_func.doc == "Docstring"
         assert len(records) == 1
 
-    # If 'doc' is passed Module, ClassDef, FunctionDef,
+    # If 'doc' is passed to Module, ClassDef, FunctionDef,
     # a DeprecationWarning should be raised
     doc_node = nodes.Const("Docstring")
     with pytest.warns(DeprecationWarning) as records:

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2720,6 +2720,15 @@ def test_deprecation_of_doc_attribute() -> None:
         assert node_func.doc == "Docstring"
         assert len(records) == 1
 
+    # If 'doc' is passed Module, ClassDef, FunctionDef,
+    # a DeprecationWarning should be raised
+    doc_node = nodes.Const("Docstring")
+    with pytest.warns(DeprecationWarning) as records:
+        node_module = nodes.Module(name="MyModule", doc="Docstring")
+        node_class = nodes.ClassDef(name="MyClass", doc="Docstring")
+        node_func = nodes.FunctionDef(name="MyFunction", doc="Docstring")
+        assert len(records) == 3
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Based on @cdce8p's work in https://github.com/PyCQA/astroid/issues/1414.

I have not done anything to the tests other than testing if the decorator works. I'll leave changing the tests to a later PR.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Related Issue
