### PR TITLE
Replace platform import

### DIFF
--- a/astroid/const.py
+++ b/astroid/const.py
@@ -13,6 +13,7 @@ BUILTINS = "builtins"  # TODO Remove in 2.8
 WIN32 = sys.platform == "win32"
 
 IS_PYPY = platform.python_implementation() == "PyPy"
+IS_JYTHON = platform.python_implementation() == "Jython"
 
 
 class Context(enum.Enum):

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -12,7 +12,7 @@ BUILTINS = "builtins"  # TODO Remove in 2.8
 
 WIN32 = sys.platform == "win32"
 
-IMPLEMENTATION_PYPY = platform.python_implementation() == "PyPy"
+IS_PYPY = platform.python_implementation() == "PyPy"
 
 
 class Context(enum.Enum):

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -1,5 +1,4 @@
 import enum
-import platform
 import sys
 
 PY36 = sys.version_info[:2] == (3, 6)
@@ -12,8 +11,8 @@ BUILTINS = "builtins"  # TODO Remove in 2.8
 
 WIN32 = sys.platform == "win32"
 
-IS_PYPY = platform.python_implementation() == "PyPy"
-IS_JYTHON = platform.python_implementation() == "Jython"
+IS_PYPY = sys.implementation.name == "pypy"
+IS_JYTHON = sys.implementation.name == "jython"
 
 
 class Context(enum.Enum):

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -53,6 +53,7 @@ import types
 from pathlib import Path
 from typing import Dict, Set
 
+from astroid.const import IS_PYPY
 from astroid.interpreter._import import spec, util
 
 if sys.platform.startswith("win"):
@@ -84,7 +85,7 @@ if os.name == "nt":
         except AttributeError:
             pass
 
-if platform.python_implementation() == "PyPy" and sys.version_info < (3, 8):
+if IS_PYPY and sys.version_info < (3, 8):
     # PyPy stores the stdlib in two places: sys.prefix/lib_pypy and sys.prefix/lib-python/3
     # sysconfig.get_path on PyPy returns the first, but without an underscore so we patch this manually.
     # Beginning with 3.8 the stdlib is only stored in: sys.prefix/pypy{py_version_short}

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -46,14 +46,13 @@ import importlib.machinery
 import importlib.util
 import itertools
 import os
-import platform
 import sys
 import sysconfig
 import types
 from pathlib import Path
 from typing import Dict, Set
 
-from astroid.const import IS_PYPY
+from astroid.const import IS_JYTHON, IS_PYPY
 from astroid.interpreter._import import spec, util
 
 if sys.platform.startswith("win"):
@@ -125,7 +124,6 @@ if os.name == "posix":
         STD_LIB_DIRS.add(_posix_path("lib64"))
 
 EXT_LIB_DIRS = {sysconfig.get_path("purelib"), sysconfig.get_path("platlib")}
-IS_JYTHON = platform.python_implementation() == "Jython"
 BUILTIN_MODULES = dict.fromkeys(sys.builtin_module_names, True)
 
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -57,7 +57,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, TypeVar, Union, ove
 from astroid import bases
 from astroid import decorators as decorators_mod
 from astroid import mixins, util
-from astroid.const import IMPLEMENTATION_PYPY, PY38, PY38_PLUS, PY39_PLUS
+from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2399,7 +2399,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     @cached_property
     def fromlineno(self) -> Optional[int]:
         """The first line that this node appears on in the source code."""
-        if not PY38_PLUS or PY38 and IMPLEMENTATION_PYPY:
+        if not PY38_PLUS or PY38 and IS_PYPY:
             # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
             lineno = self.lineno

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -54,7 +54,7 @@ from typing import (
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
-from astroid.const import IMPLEMENTATION_PYPY, PY36, PY38, PY38_PLUS, PY39_PLUS, Context
+from astroid.const import IS_PYPY, PY36, PY38, PY38_PLUS, PY39_PLUS, Context
 from astroid.manager import AstroidManager
 from astroid.nodes import NodeNG
 from astroid.nodes.utils import Position
@@ -224,7 +224,7 @@ class TreeRebuilder:
 
         lineno = node.lineno or 1  # lineno of modules is 0
         end_range: Optional[int] = node.doc_node.lineno
-        if IMPLEMENTATION_PYPY and not PY39_PLUS:
+        if IS_PYPY and not PY39_PLUS:
             end_range = None
         # pylint: disable-next=unsubscriptable-object
         data = "\n".join(self._data[lineno - 1 : end_range])
@@ -312,7 +312,7 @@ class TreeRebuilder:
             doc_node=self.visit(doc_ast_node, newnode),
         )
         self._fix_doc_node_position(newnode)
-        if IMPLEMENTATION_PYPY and PY38:
+        if IS_PYPY and PY38:
             self._reset_end_lineno(newnode)
         return newnode
 

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -43,7 +43,7 @@ import unittest.mock
 import pytest
 
 from astroid import Instance, builder, nodes, test_utils, util
-from astroid.const import IMPLEMENTATION_PYPY, PY38, PY38_PLUS, PY39_PLUS
+from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidSyntaxError,
@@ -79,7 +79,7 @@ class FromToLineNoTest(unittest.TestCase):
         self.assertEqual(name.tolineno, 4)
         strarg = callfunc.args[0]
         self.assertIsInstance(strarg, nodes.Const)
-        if IMPLEMENTATION_PYPY:
+        if IS_PYPY:
             self.assertEqual(strarg.fromlineno, 4)
             if not PY39_PLUS:
                 self.assertEqual(strarg.tolineno, 4)
@@ -187,7 +187,7 @@ class FromToLineNoTest(unittest.TestCase):
 
         c = ast_module.body[2]
         assert isinstance(c, nodes.ClassDef)
-        if not PY38_PLUS or PY38 and IMPLEMENTATION_PYPY:
+        if not PY38_PLUS or PY38 and IS_PYPY:
             # Not perfect, but best we can do for Python 3.7 and PyPy 3.8
             # Can't detect closing bracket on new line.
             assert c.fromlineno == 12

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -44,7 +44,6 @@
 
 """Tests for the astroid inference capabilities"""
 
-import platform
 import textwrap
 import unittest
 from abc import ABCMeta
@@ -61,7 +60,7 @@ from astroid import helpers, nodes, objects, test_utils, util
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Instance, UnboundMethod
 from astroid.builder import AstroidBuilder, extract_node, parse
-from astroid.const import PY38_PLUS, PY39_PLUS
+from astroid.const import IS_PYPY, PY38_PLUS, PY39_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -858,7 +857,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred[0], nodes.FunctionDef)
         self.assertEqual(inferred[0].name, "open")
 
-    if platform.python_implementation() == "PyPy":
+    if IS_PYPY:
         test_builtin_open = unittest.expectedFailure(test_builtin_open)
 
     def test_callfunc_context_func(self) -> None:

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -24,7 +24,6 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
 import os
-import platform
 import site
 import sys
 import time
@@ -36,13 +35,14 @@ import pkg_resources
 
 import astroid
 from astroid import manager, test_utils
+from astroid.const import IS_JYTHON
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 
 from . import resources
 
 
 def _get_file_from_object(obj) -> str:
-    if platform.python_implementation() == "Jython":
+    if IS_JYTHON:
         return obj.__file__.split("$py.class")[0] + ".py"
     return obj.__file__
 

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -33,7 +33,6 @@
 """
 import copy
 import os
-import platform
 import sys
 import textwrap
 import unittest
@@ -52,7 +51,7 @@ from astroid import (
     transforms,
     util,
 )
-from astroid.const import PY38_PLUS, PY310_PLUS, Context
+from astroid.const import IS_PYPY, PY38_PLUS, PY310_PLUS, Context
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidBuildingError,
@@ -292,10 +291,7 @@ def func(param: Tuple):
 
     # This test is disabled on PyPy because we cannot get a release that has proper
     # support for f-strings (we need 7.2 at least)
-    @pytest.mark.skipif(
-        platform.python_implementation() == "PyPy",
-        reason="Needs f-string support.",
-    )
+    @pytest.mark.skipif(IS_PYPY, reason="Needs f-string support.")
     def test_f_strings(self):
         code = r'''
 a = f"{'a'}"

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -51,7 +51,7 @@ from astroid import (
     transforms,
     util,
 )
-from astroid.const import IS_PYPY, PY38_PLUS, PY310_PLUS, Context
+from astroid.const import PY38_PLUS, PY310_PLUS, Context
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidBuildingError,
@@ -289,9 +289,6 @@ def func(param: Tuple):
         ast = abuilder.string_build(code)
         self.assertEqual(ast.as_string().strip(), code.strip())
 
-    # This test is disabled on PyPy because we cannot get a release that has proper
-    # support for f-strings (we need 7.2 at least)
-    @pytest.mark.skipif(IS_PYPY, reason="Needs f-string support.")
     def test_f_strings(self):
         code = r'''
 a = f"{'a'}"

--- a/tests/unittest_nodes_lineno.py
+++ b/tests/unittest_nodes_lineno.py
@@ -4,11 +4,11 @@ import pytest
 
 import astroid
 from astroid import builder, nodes
-from astroid.const import IMPLEMENTATION_PYPY, PY38, PY38_PLUS, PY39_PLUS, PY310_PLUS
+from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, PY310_PLUS
 
 
 @pytest.mark.skipif(
-    PY38_PLUS and not (PY38 and IMPLEMENTATION_PYPY),
+    PY38_PLUS and not (PY38 and IS_PYPY),
     reason="end_lineno and end_col_offset were added in PY38",
 )
 class TestEndLinenoNotSet:
@@ -37,7 +37,7 @@ class TestEndLinenoNotSet:
 
 
 @pytest.mark.skipif(
-    not PY38_PLUS or PY38 and IMPLEMENTATION_PYPY,
+    not PY38_PLUS or PY38 and IS_PYPY,
     reason="end_lineno and end_col_offset were added in PY38",
 )
 class TestLinenoColOffset:

--- a/tests/unittest_raw_building.py
+++ b/tests/unittest_raw_building.py
@@ -13,13 +13,13 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 
-import platform
 import unittest
 
 import _io
 import pytest
 
 from astroid.builder import AstroidBuilder
+from astroid.const import IS_PYPY
 from astroid.raw_building import (
     attach_dummy_node,
     build_class,
@@ -85,7 +85,7 @@ class RawBuildingTC(unittest.TestCase):
         node = build_from_import("astroid", names)
         self.assertEqual(len(names), len(node.names))
 
-    @unittest.skipIf(platform.python_implementation() == "PyPy", "Only affects CPython")
+    @unittest.skipIf(IS_PYPY, "Only affects CPython")
     def test_io_is__io(self):
         # _io module calls itself io. This leads
         # to cyclic dependencies when astroid tries to resolve

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -58,7 +58,7 @@ from astroid import (
     util,
 )
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod
-from astroid.const import IMPLEMENTATION_PYPY, PY38, PY38_PLUS, PY310_PLUS, WIN32
+from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY310_PLUS, WIN32
 from astroid.exceptions import (
     AttributeInferenceError,
     DuplicateBasesError,
@@ -1291,7 +1291,7 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse(data)
         self.assertEqual(astroid["g1"].fromlineno, 4)
         self.assertEqual(astroid["g1"].tolineno, 5)
-        if not PY38_PLUS or PY38 and IMPLEMENTATION_PYPY:
+        if not PY38_PLUS or PY38 and IS_PYPY:
             self.assertEqual(astroid["g2"].fromlineno, 9)
         else:
             self.assertEqual(astroid["g2"].fromlineno, 10)


### PR DESCRIPTION
## Description
Replace `platform.python_implementation` with `sys.implementation.name`.
https://docs.python.org/3/library/sys.html#sys.implementation
https://www.python.org/dev/peps/pep-0421/#required-attributes

Rename `IMPLEMENTATION_PYPY` to `IS_PYPY`. That name is also used by pylint.
_Which also needs to be updated to not import `platform`._

Remove `skipif` from f-string test for PyPy. f-strings are fully supported now.

Follow up to https://github.com/PyCQA/astroid/pull/1454#discussion_r822362553