### PR TITLE
Move ``builtin_lookup`` out of main ``scoped_nodes`` file

### DIFF
--- a/astroid/nodes/scoped_nodes/__init__.py
+++ b/astroid/nodes/scoped_nodes/__init__.py
@@ -19,10 +19,10 @@ from astroid.nodes.scoped_nodes.scoped_nodes import (
     Module,
     SetComp,
     _is_metaclass,
-    builtin_lookup,
     function_to_method,
     get_wrapping_class,
 )
+from astroid.nodes.scoped_nodes.utils import builtin_lookup
 
 __all__ = (
     "AsyncFunctionDef",

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -45,7 +45,6 @@ This module contains the classes for "scoped" node, i.e. which are opening a
 new local scope in the language definition : Module, ClassDef, FunctionDef (and
 Lambda, GeneratorExp, DictComp and SetComp to some extent).
 """
-import builtins
 import io
 import itertools
 import os
@@ -80,6 +79,7 @@ from astroid.interpreter.dunder_lookup import lookup
 from astroid.interpreter.objectmodel import ClassModel, FunctionModel, ModuleModel
 from astroid.manager import AstroidManager
 from astroid.nodes import Arguments, Const, node_classes
+from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
 
 if sys.version_info >= (3, 6, 2):
@@ -213,21 +213,6 @@ def function_to_method(n, klass):
         if n.type != "staticmethod":
             return bases.UnboundMethod(n)
     return n
-
-
-def builtin_lookup(name):
-    """lookup a name into the builtin module
-    return the list of matching statements and the astroid for the builtin
-    module
-    """
-    builtin_astroid = AstroidManager().ast_from_module(builtins)
-    if name == "__dict__":
-        return builtin_astroid, ()
-    try:
-        stmts = builtin_astroid.locals[name]
-    except KeyError:
-        stmts = ()
-    return builtin_astroid, stmts
 
 
 # TODO move this Mixin to mixins.py; problem: 'FunctionDef' in _scope_lookup

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -6,7 +6,7 @@ This module contains utility functions for scoped nodes.
 """
 
 import builtins
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 from astroid.manager import AstroidManager
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from astroid import nodes
 
 
-BUILTINS_AST: Optional["nodes.Module"] = None
+_builtin_astroid: "nodes.Module | None" = None
 
 
 def builtin_lookup(name: str) -> Tuple["nodes.Module", List["nodes.NodeNG"]]:
@@ -23,13 +23,13 @@ def builtin_lookup(name: str) -> Tuple["nodes.Module", List["nodes.NodeNG"]]:
     Return the list of matching statements and the ast for the builtin module
     """
     # pylint: disable-next=global-statement
-    global BUILTINS_AST
-    if not BUILTINS_AST:
-        BUILTINS_AST = AstroidManager().ast_from_module(builtins)
+    global _builtin_astroid
+    if _builtin_astroid is None:
+        _builtin_astroid = AstroidManager().ast_from_module(builtins)
     if name == "__dict__":
-        return BUILTINS_AST, ()
+        return _builtin_astroid, ()
     try:
-        stmts = BUILTINS_AST.locals[name]
+        stmts = _builtin_astroid.locals[name]
     except KeyError:
         stmts = ()
-    return BUILTINS_AST, stmts
+    return _builtin_astroid, stmts

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -6,7 +6,7 @@ This module contains utility functions for scoped nodes.
 """
 
 import builtins
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Sequence, Tuple
 
 from astroid.manager import AstroidManager
 

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -1,0 +1,35 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+
+"""
+This module contains utility functions for scoped nodes.
+"""
+
+import builtins
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from astroid.manager import AstroidManager
+
+if TYPE_CHECKING:
+    from astroid import nodes
+
+
+BUILTINS_AST: Optional["nodes.Module"] = None
+
+
+def builtin_lookup(name: str) -> Tuple["nodes.Module", List["nodes.NodeNG"]]:
+    """Lookup a name in the builtin module.
+
+    Return the list of matching statements and the ast for the builtin module
+    """
+    # pylint: disable-next=global-statement
+    global BUILTINS_AST
+    if not BUILTINS_AST:
+        BUILTINS_AST = AstroidManager().ast_from_module(builtins)
+    if name == "__dict__":
+        return BUILTINS_AST, ()
+    try:
+        stmts = BUILTINS_AST.locals[name]
+    except KeyError:
+        stmts = ()
+    return BUILTINS_AST, stmts

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -6,7 +6,7 @@ This module contains utility functions for scoped nodes.
 """
 
 import builtins
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, Tuple
 
 from astroid.manager import AstroidManager
 

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 _builtin_astroid: "nodes.Module | None" = None
 
 
-def builtin_lookup(name: str) -> Tuple["nodes.Module", List["nodes.NodeNG"]]:
+def builtin_lookup(name: str) -> Tuple["nodes.Module", Sequence["nodes.NodeNG"]]:
     """Lookup a name in the builtin module.
 
     Return the list of matching statements and the ast for the builtin module
@@ -29,7 +29,7 @@ def builtin_lookup(name: str) -> Tuple["nodes.Module", List["nodes.NodeNG"]]:
     if name == "__dict__":
         return _builtin_astroid, ()
     try:
-        stmts = _builtin_astroid.locals[name]
+        stmts: Sequence["nodes.NodeNG"] = _builtin_astroid.locals[name]
     except KeyError:
         stmts = ()
     return _builtin_astroid, stmts


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

I was looking into some of the code in `scoped_nodes` for a potential refactor to remove some circular dependencies. 
Noticed that this function could be optimised by not building the `Module` node every time, but only doing this once.

Tested with `pylint` over `pylint`. Went from 80th to 145th in terms of time spent in function and child-calls.

_This prepares for the move of all mixins from `scoped_nodes` for which a multiple years old TODO is still included._

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue