### PR TITLE
Promoted ``getattr()`` from FunctionDef to Lambda

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,13 +6,14 @@ What's New in astroid 2.12.0?
 =============================
 Release date: TBA
 
-* Promoted ``getattr()`` from ``astroid.scoped_nodes.FunctionDef`` to its parent
-  ``astroid.scoped_nodes.Lambda``.
 
 
 What's New in astroid 2.11.1?
 =============================
 Release date: TBA
+
+* Promoted ``getattr()`` from ``astroid.scoped_nodes.FunctionDef`` to its parent
+  ``astroid.scoped_nodes.Lambda``.
 
 
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in astroid 2.12.0?
 =============================
 Release date: TBA
 
+* Promoted ``getattr()`` from ``astroid.scoped_nodes.FunctionDef`` to its parent
+  ``astroid.scoped_nodes.Lambda``.
 
 
 What's New in astroid 2.11.1?

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -39,7 +39,7 @@ from astroid.exceptions import (
 from astroid.interpreter.dunder_lookup import lookup
 from astroid.interpreter.objectmodel import ClassModel, FunctionModel, ModuleModel
 from astroid.manager import AstroidManager
-from astroid.nodes import Arguments, Const, node_classes
+from astroid.nodes import Arguments, Const, NodeNG, node_classes
 from astroid.nodes.scoped_nodes.mixin import ComprehensionScope, LocalsDictNodeNG
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
@@ -1135,7 +1135,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         :type: list(NodeNG)
         """
 
-        self.instance_attrs: Dict[str, List[nodes.NodeNG]] = {}
+        self.instance_attrs: Dict[str, List[NodeNG]] = {}
 
         super().__init__(
             lineno=lineno,
@@ -1269,7 +1269,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
 
     def getattr(
         self, name: str, context: Optional[InferenceContext] = None
-    ) -> List[nodes.NodeNG]:
+    ) -> List[NodeNG]:
         if not name:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1075,10 +1075,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
     name = "<lambda>"
     is_lambda = True
     special_attributes = FunctionModel()
-    """The names of special attributes that this function has.
-
-    :type: objectmodel.FunctionModel
-    """
+    """The names of special attributes that this function has."""
 
     def implicit_parameters(self):
         return 0
@@ -1138,7 +1135,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         :type: list(NodeNG)
         """
 
-        self.instance_attrs = {}
+        self.instance_attrs: Dict[str, List[nodes.NodeNG]] = {}
 
         super().__init__(
             lineno=lineno,
@@ -1270,7 +1267,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         """
         return self
 
-    def getattr(self, name, context=None):
+    def getattr(self, name: str, context: Optional[InferenceContext]=None) -> List[nodes.NodeNG]:
         if not name:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1267,7 +1267,9 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         """
         return self
 
-    def getattr(self, name: str, context: Optional[InferenceContext]=None) -> List[nodes.NodeNG]:
+    def getattr(
+        self, name: str, context: Optional[InferenceContext] = None
+    ) -> List[nodes.NodeNG]:
         if not name:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4389,6 +4389,7 @@ class HasattrTest(unittest.TestCase):
         )
         inferred = next(node.infer())
         self.assertIsInstance(inferred, nodes.Const)
+        self.assertIs(inferred.value, False)
 
 
 class BoolOpTest(unittest.TestCase):

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4388,7 +4388,7 @@ class HasattrTest(unittest.TestCase):
         """
         )
         inferred = next(node.infer())
-        self.assertEqual(inferred, util.Uninferable)
+        self.assertIsInstance(inferred, nodes.Const)
 
 
 class BoolOpTest(unittest.TestCase):

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -486,7 +486,9 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
 
     def test_lambda_getattr(self) -> None:
         astroid = builder.parse("lmbd = lambda: None")
-        self.assertIsInstance(astroid["lmbd"].parent.value.getattr("__code__")[0], nodes.Unknown)
+        self.assertIsInstance(
+            astroid["lmbd"].parent.value.getattr("__code__")[0], nodes.Unknown
+        )
 
     def test_is_method(self) -> None:
         data = """

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -484,6 +484,10 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         astroid = builder.parse("lmbd = lambda: None", __name__)
         self.assertEqual(f"{__name__}.<lambda>", astroid["lmbd"].parent.value.qname())
 
+    def test_lambda_getattr(self) -> None:
+        astroid = builder.parse("lmbd = lambda: None")
+        self.assertIsInstance(astroid["lmbd"].parent.value.getattr("__code__")[0], nodes.Unknown)
+
     def test_is_method(self) -> None:
         data = """
             class A:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

Lambdas can have special attributes, such as `__code__`, or even arbitrary attributes. Attempting to use `getattr` on the `scoped_nodes.Lambda` instance, though, raised `AttributeError`.

Now, it won't: the PR promotes `getattr()` from `FunctionDef` to its parent, `Lambda`.

Discovered by pylint's primer tests during an attempt to remove an `except: AttributeError` from pylint's `TypeChecker`, discussed [here](https://github.com/PyCQA/pylint/pull/5544#discussion_r825305650).
