### PR TITLE
Handle inference of ``ComprehensionScope`` better

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ What's New in astroid 2.12.0?
 =============================
 Release date: TBA
 
+* Infer comprehensions and generators as their respective nodes instead of
+  as ``Uninferable``.
+
+  Closes #135, #1404
 
 
 What's New in astroid 2.11.1?

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -55,6 +55,9 @@ def _object_type(node, context=None):
             yield _function_type(inferred, builtins)
         elif isinstance(inferred, scoped_nodes.Module):
             yield _build_proxy_class("module", builtins)
+        # TODO: Implement type() lookup for ComprehenscopScope, perhaps through _proxied
+        elif isinstance(inferred, nodes.ComprehensionScope):
+            raise InferenceError
         else:
             yield inferred._proxied
 

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -170,3 +170,6 @@ class ComprehensionScope(LocalsDictNodeNG):
     """Scoping for different types of comprehensions."""
 
     scope_lookup = LocalsDictNodeNG._scope_lookup
+
+    generators: List["nodes.Comprehension"]
+    """The generators that are looped through."""

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -4,6 +4,7 @@
 
 """This module contains mixin classes for scoped nodes."""
 
+import abc
 from typing import TYPE_CHECKING, Dict, List, TypeVar
 
 from astroid.filter_statements import _filter_stmts
@@ -173,3 +174,7 @@ class ComprehensionScope(LocalsDictNodeNG):
 
     generators: List["nodes.Comprehension"]
     """The generators that are looped through."""
+
+    @abc.abstractmethod
+    def pytype(self) -> str:
+        pass

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -5,7 +5,7 @@
 """This module contains mixin classes for scoped nodes."""
 
 import abc
-from typing import TYPE_CHECKING, Dict, List, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, TypeVar
 
 from astroid.filter_statements import _filter_stmts
 from astroid.nodes import node_classes, scoped_nodes
@@ -13,6 +13,8 @@ from astroid.nodes.scoped_nodes.utils import builtin_lookup
 
 if TYPE_CHECKING:
     from astroid import nodes
+    from astroid.context import InferenceContext
+
 
 _T = TypeVar("_T")
 
@@ -174,6 +176,15 @@ class ComprehensionScope(LocalsDictNodeNG):
 
     generators: List["nodes.Comprehension"]
     """The generators that are looped through."""
+
+    def qname(self):
+        """Get the 'qualified' name of the node."""
+        return self.pytype()
+
+    def infer(
+        self: _T, context: Optional["InferenceContext"] = None, **kwargs: Any
+    ) -> Iterator[_T]:
+        yield self
 
     @abc.abstractmethod
     def pytype(self) -> str:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -750,6 +750,9 @@ class GeneratorExp(ComprehensionScope):
 
         yield from self.generators
 
+    def pytype(self) -> str:
+        return "builtins.generator"
+
 
 class DictComp(ComprehensionScope):
     """Class representing an :class:`ast.DictComp` node.
@@ -849,6 +852,9 @@ class DictComp(ComprehensionScope):
 
         yield from self.generators
 
+    def pytype(self) -> str:
+        return "builtins.dict"
+
 
 class SetComp(ComprehensionScope):
     """Class representing an :class:`ast.SetComp` node.
@@ -936,6 +942,9 @@ class SetComp(ComprehensionScope):
 
         yield from self.generators
 
+    def pytype(self) -> str:
+        return "builtins.set"
+
 
 class ListComp(ComprehensionScope):
     """Class representing an :class:`ast.ListComp` node.
@@ -1006,6 +1015,9 @@ class ListComp(ComprehensionScope):
         yield self.elt
 
         yield from self.generators
+
+    def pytype(self) -> str:
+        return "builtins.list"
 
 
 def _infer_decorator_callchain(node):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -61,6 +61,9 @@ else:
     # pylint: disable-next=ungrouped-imports
     from astroid.decorators import cachedproperty as cached_property
 
+if TYPE_CHECKING:
+    from astroid import nodes
+
 
 ITER_METHODS = ("__iter__", "__getitem__")
 EXCEPTION_BASE_CLASSES = frozenset({"Exception", "BaseException"})
@@ -677,11 +680,6 @@ class GeneratorExp(ComprehensionScope):
 
     :type: NodeNG or None
     """
-    generators = None
-    """The generators that are looped through.
-
-    :type: list(Comprehension) or None
-    """
 
     def __init__(
         self,
@@ -724,14 +722,13 @@ class GeneratorExp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(self, elt=None, generators=None):
+    def postinit(self, elt=None, generators: Optional["nodes.Comprehension"] = None):
         """Do some setup after initialisation.
 
         :param elt: The element that forms the output of the expression.
         :type elt: NodeNG or None
 
         :param generators: The generators that are looped through.
-        :type generators: list(Comprehension) or None
         """
         self.elt = elt
         if generators is None:
@@ -775,11 +772,6 @@ class DictComp(ComprehensionScope):
 
     :type: NodeNG or None
     """
-    generators = None
-    """The generators that are looped through.
-
-    :type: list(Comprehension) or None
-    """
 
     def __init__(
         self,
@@ -822,7 +814,9 @@ class DictComp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(self, key=None, value=None, generators=None):
+    def postinit(
+        self, key=None, value=None, generators: Optional["nodes.Comprehension"] = None
+    ):
         """Do some setup after initialisation.
 
         :param key: What produces the keys.
@@ -832,7 +826,6 @@ class DictComp(ComprehensionScope):
         :type value: NodeNG or None
 
         :param generators: The generators that are looped through.
-        :type generators: list(Comprehension) or None
         """
         self.key = key
         self.value = value
@@ -873,11 +866,6 @@ class SetComp(ComprehensionScope):
 
     :type: NodeNG or None
     """
-    generators = None
-    """The generators that are looped through.
-
-    :type: list(Comprehension) or None
-    """
 
     def __init__(
         self,
@@ -920,14 +908,13 @@ class SetComp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(self, elt=None, generators=None):
+    def postinit(self, elt=None, generators: Optional["nodes.Comprehension"] = None):
         """Do some setup after initialisation.
 
         :param elt: The element that forms the output of the expression.
         :type elt: NodeNG or None
 
         :param generators: The generators that are looped through.
-        :type generators: list(Comprehension) or None
         """
         self.elt = elt
         if generators is None:
@@ -968,12 +955,6 @@ class ListComp(ComprehensionScope):
     :type: NodeNG or None
     """
 
-    generators = None
-    """The generators that are looped through.
-
-    :type: list(Comprehension) or None
-    """
-
     def __init__(
         self,
         lineno=None,
@@ -997,7 +978,7 @@ class ListComp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(self, elt=None, generators=None):
+    def postinit(self, elt=None, generators: Optional["nodes.Comprehension"] = None):
         """Do some setup after initialisation.
 
         :param elt: The element that forms the output of the expression.
@@ -1007,7 +988,10 @@ class ListComp(ComprehensionScope):
         :type generators: list(Comprehension) or None
         """
         self.elt = elt
-        self.generators = generators
+        if generators is None:
+            self.generators = []
+        else:
+            self.generators = generators
 
     def bool_value(self, context=None):
         """Determine the boolean value of this node.

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -2645,11 +2645,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         klass = module["Class"]
         self.assertTrue(klass.bool_value())
         dict_comp = next(module["dict_comp"].infer())
-        self.assertEqual(dict_comp, util.Uninferable)
+        assert isinstance(dict_comp, nodes.DictComp)
         set_comp = next(module["set_comp"].infer())
-        self.assertEqual(set_comp, util.Uninferable)
+        assert isinstance(set_comp, nodes.SetComp)
         list_comp = next(module["list_comp"].infer())
-        self.assertEqual(list_comp, util.Uninferable)
+        assert isinstance(list_comp, nodes.ListComp)
         lambda_func = next(module["lambda_func"].infer())
         self.assertTrue(lambda_func)
         unbound_method = next(module["unbound_method"].infer())
@@ -4198,8 +4198,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_uninferable_type_subscript(self) -> None:
         node = extract_node("[type for type in [] if type['id']]")
-        with self.assertRaises(InferenceError):
-            _ = next(node.infer())
+        assert isinstance(node.inferred()[0], nodes.ListComp)
 
 
 class GetattrTest(unittest.TestCase):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This makes it so that `ComprehensionScopes` are actually inferred. This requires some changes in `pylint` as we rely on the fact that these don't get inferred currently.
I have made a related PR to `pylint` which shows what these changes would be. I think it will be useful to review this simultaneously, as they show how this impacts `astroid's` output.

One problem I couldn't overcome: this will break `pre-commit` for the project that merges this first. The change in behaviour changes various checks and we need to resolve an order in which these get merged.

Let me know what you guys think!
_We might want to add some additional tests._

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Related Issue

