### PR TITLE
Fix crash on direct inference via nodes.FunctionDef._infer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@ What's New in astroid 2.12.0?
 =============================
 Release date: TBA
 
+* Fixed crash on direct inference via ``nodes.FunctionDef._infer``.
+
+  Closes #817
 
 
 What's New in astroid 2.11.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,9 +6,6 @@ What's New in astroid 2.12.0?
 =============================
 Release date: TBA
 
-* Fixed crash on direct inference via ``nodes.FunctionDef._infer``.
-
-  Closes #817
 
 
 What's New in astroid 2.11.1?
@@ -18,6 +15,9 @@ Release date: TBA
 * Promoted ``getattr()`` from ``astroid.scoped_nodes.FunctionDef`` to its parent
   ``astroid.scoped_nodes.Lambda``.
 
+* Fixed crash on direct inference via ``nodes.FunctionDef._infer``.
+
+  Closes #817
 
 
 What's New in astroid 2.11.0?

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -1039,8 +1039,10 @@ nodes.IfExp._infer = infer_ifexp  # type: ignore[assignment]
 
 # pylint: disable=dangerous-default-value
 @wrapt.decorator
-def _cached_generator(func, instance, args, kwargs, _cache={}):  # noqa: B006
-    node = args[0]
+def _cached_generator(
+    func, instance: _FunctionDefT, args, kwargs, _cache={}  # noqa: B006
+):
+    node = instance
     try:
         return iter(_cache[func, id(node)])
     except KeyError:

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -165,7 +165,7 @@ class NodeNG:
 
         if not context:
             # nodes_inferred?
-            yield from self._infer(context, **kwargs)
+            yield from self._infer(context=context, **kwargs)
             return
 
         key = (self, context.lookupname, context.callcontext, context.boundnode)
@@ -173,7 +173,7 @@ class NodeNG:
             yield from context.inferred[key]
             return
 
-        generator = self._infer(context, **kwargs)
+        generator = self._infer(context=context, **kwargs)
         results = []
 
         # Limit inference amount to help with performance issues with

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6640,5 +6640,11 @@ def test_recursion_on_inference_tip() -> None:
     assert module
 
 
+def test_function_def_cached_generator() -> None:
+    """Regression test for https://github.com/PyCQA/astroid/issues/817."""
+    funcdef: nodes.FunctionDef = extract_node("def func(): pass")
+    next(funcdef._infer())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Fix as suggested in the issue.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #817