### PR TITLE
Fix incorrect xfailed test

### DIFF
--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -4056,10 +4056,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, nodes.Const)
         self.assertEqual(inferred.value, 25)
 
-    @pytest.mark.xfail(reason="Cannot reuse inner value due to inference context reuse")
-    def test_inner_value_redefined_by_subclass_with_mro(self):
-        # This might work, but it currently doesn't due to not being able
-        # to reuse inference contexts.
+    def test_inner_value_redefined_by_subclass_with_mro(self) -> None:
         ast_node = extract_node(
             """
         class X(object):
@@ -4079,8 +4076,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         )
         inferred = next(ast_node.infer())
-        self.assertIsInstance(inferred, nodes.Const)
-        self.assertEqual(inferred.value, 25)
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 26
 
     def test_getitem_of_class_raised_type_error(self) -> None:
         # Test that we wrap an AttributeInferenceError


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

I might be missing something, but:
```console
❯ cat test.py
class X(object):
    M = lambda self, arg: arg + 1
    x = 24

    def __init__(self):
        y = self
        self.m = y.M(1) + y.z

class C(object):
    z = 24

class Y(X, C):
    M = lambda self, arg: arg + 1

    def blurb(self):
        print(self.m)

Y().blurb()%                                                                                                                                         
❯ python test.py
26
```

I don't think this test is correct and the tested value should be 26.
The underlying issue which originally prompted the xfail has probably been solved.

While I was at it I also changed the test to use `pytest` asserts instead of unittest.


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

