### PR TITLE
Astroid manager

### DIFF
--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -319,7 +319,6 @@ class Instance(BaseInstance):
         return result
 
     def getitem(self, index, context=None):
-        # TODO: Rewrap index to Const for this case
         new_context = bind_context_to_node(context, self)
         if not context:
             context = new_context

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -25,6 +25,7 @@ from astroid.modutils import (
     modpath_from_file,
 )
 from astroid.transforms import TransformVisitor
+from astroid.typing import AstroidManagerBrain
 
 if TYPE_CHECKING:
     from astroid import nodes
@@ -46,20 +47,28 @@ class AstroidManager:
     """
 
     name = "astroid loader"
-    brain = {}
+    brain: AstroidManagerBrain = {
+        "astroid_cache": {},
+        "_mod_file_cache": {},
+        "_failed_import_hooks": [],
+        "always_load_extensions": False,
+        "optimize_ast": False,
+        "extension_package_whitelist": set(),
+        "_transform": TransformVisitor(),
+    }
     max_inferable_values: ClassVar[int] = 100
 
     def __init__(self):
-        self.__dict__ = AstroidManager.brain
-        if not self.__dict__:
-            # NOTE: cache entries are added by the [re]builder
-            self.astroid_cache = {}
-            self._mod_file_cache = {}
-            self._failed_import_hooks = []
-            self.always_load_extensions = False
-            self.optimize_ast = False
-            self.extension_package_whitelist = set()
-            self._transform = TransformVisitor()
+        # NOTE: cache entries are added by the [re]builder
+        self.astroid_cache = AstroidManager.brain["astroid_cache"]
+        self._mod_file_cache = AstroidManager.brain["_mod_file_cache"]
+        self._failed_import_hooks = AstroidManager.brain["_failed_import_hooks"]
+        self.always_load_extensions = AstroidManager.brain["always_load_extensions"]
+        self.optimize_ast = AstroidManager.brain["optimize_ast"]
+        self.extension_package_whitelist = AstroidManager.brain[
+            "extension_package_whitelist"
+        ]
+        self._transform = AstroidManager.brain["_transform"]
 
     @property
     def register_transform(self):

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -3,10 +3,10 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 import sys
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Set
 
 if TYPE_CHECKING:
-    from astroid import nodes
+    from astroid import nodes, transforms
     from astroid.context import InferenceContext
 
 if sys.version_info >= (3, 8):
@@ -25,3 +25,15 @@ class InferenceErrorInfo(TypedDict):
 
 
 InferFn = Callable[..., Any]
+
+
+class AstroidManagerBrain(TypedDict):
+    """Dictionary to store relevant information for a AstroidManager class."""
+
+    astroid_cache: Dict
+    _mod_file_cache: Dict
+    _failed_import_hooks: List
+    always_load_extensions: bool
+    optimize_ast: bool
+    extension_package_whitelist: Set
+    _transform: "transforms.TransformVisitor"


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

I could split out the comment commit, but I had that stored so wanted to get it in somewhere. Comment is outdated, see commit message.

Refactor is because of `mypy` and `pylint` complaining about the attributes. Not sure if this is the most elegant way to do this, but both `astroid` and `pylint` tests passed locally with this.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

