### PR TITLE
Avoid adding the name of a parent namedtuple to child's locals

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ What's New in astroid 2.11.2?
 =============================
 Release date: TBA
 
+* Avoided adding the name of a parent namedtuple to its child's locals.
+
+  Refs PyCQA/pylint#5982
 
 
 What's New in astroid 2.11.1?

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -133,7 +133,11 @@ def infer_func_form(
     # we know it is a namedtuple anyway.
     name = name or "Uninferable"
     # we want to return a Class node instance with proper attributes set
-    class_node = nodes.ClassDef(name, parent=node.parent)
+    class_node = nodes.ClassDef(name)
+    # A typical ClassDef automatically adds its name to the parent scope,
+    # but doing so causes problems, so defer setting parent until after init
+    # see: https://github.com/PyCQA/pylint/issues/5982
+    class_node.parent = node.parent
     class_node.postinit(
         # set base class=tuple
         bases=[base_type],

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -159,6 +159,8 @@ class NamedTupleTest(unittest.TestCase):
         self.assertEqual(
             [anc.name for anc in klass.ancestors()], ["X", "tuple", "object"]
         )
+        # See: https://github.com/PyCQA/pylint/issues/5982
+        self.assertNotIn("X", klass.locals)
         for anc in klass.ancestors():
             self.assertFalse(anc.parent is None)
 


### PR DESCRIPTION
## Description

When subclassing a `namedtuple`, the behavior before d30592a5d27ca801aae36248ed169ae3dee5f4c9 was for astroid to avoid adding the name of the namedtuple to the child class's locals. Apparently doing so caused the crash in PyCQA/pylint#5982.

## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Refs PyCQA/pylint#5982
