### PR TITLE
Capture and log messages emitted by C modules when importing them

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,11 @@ Release date: TBA
 
   Closes #1512
 
+* Capture and log messages emitted by C extensions when importing them.
+  This prevents contaminating programmatic output, e.g. pylint's JSON reporter.
+
+  Closes PyCQA/pylint#3518
+
 * Remove dependency on ``pkg_resources`` from ``setuptools``.
 
   Closes #1103

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,6 @@ coveralls~=3.3
 coverage~=6.3.3
 pre-commit~=2.19
 pytest-cov~=3.0
-contributors-txt>=0.7.3
 tbump~=6.9.0
 types-typed-ast; implementation_name=="cpython" and python_version<"3.8"
 types-pkg_resources==0.1.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,6 +5,7 @@ coveralls~=3.3
 coverage~=6.3.3
 pre-commit~=2.19
 pytest-cov~=3.0
+contributors-txt>=0.7.3
 tbump~=6.9.0
 types-typed-ast; implementation_name=="cpython" and python_version<"3.8"
 types-pkg_resources==0.1.3

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -57,7 +57,7 @@ class ModuleFileTest(unittest.TestCase):
 
 
 class LoadModuleFromNameTest(unittest.TestCase):
-    """load a python module from it's name"""
+    """load a python module from its name"""
 
     def test_known_values_load_module_from_name_1(self) -> None:
         self.assertEqual(modutils.load_module_from_name("sys"), sys)


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

~Pipe stdout to stderr~ Capture and log messages emitted while importing C modules. This prevents contaminating programmatic output, e.g. pylint's JSON reporter.

An alternative would be to silence stdout altogether, but there may be users who appreciate the notice that code is being executed. This way no information is lost, while still allowing clean programmatic output.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes PyCQA/pylint#3518

/cc @piotr-machura, what do you think of this approach?