### PR TITLE
Fix a crash in the `gi` brain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#6221
 
+* Fixed a crash in the ``gi`` brain.
+
+  Closes PyCQA/pylint#6371
+
 
 What's New in astroid 2.11.2?
 =============================

--- a/astroid/brain/brain_gi.py
+++ b/astroid/brain/brain_gi.py
@@ -74,7 +74,9 @@ def _gi_build_stub(parent):
 
         try:
             obj = getattr(parent, name)
-        except AttributeError:
+        except Exception:  # pylint: disable=broad-except
+            # gi.module.IntrospectionModule.__getattr__() can raise all kinds of things
+            # like ValueError, TypeError, NotImplementedError, RepositoryError, etc
             continue
 
         if inspect.isclass(obj):


### PR DESCRIPTION
## Description

Fix a crash in the `gi` brain which calls `gi.module.IntrospectionModule.__getattr__()`. It can raise [various](https://gitlab.gnome.org/GNOME/pygobject/-/blob/master/gi/module.py) exceptions, so catching `AttributeError` is too narrow.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes PyCQA/pylint#6371.

@senier, would you be able to let us know if this resolves your issue? I haven't reproduced the crash locally because I'd like to avoid installing the C headers for `cairo` if possible.
