### PR TITLE
Add annotations for `ModuleType`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@ Release date: TBA
 
   Closes #1512
 
+* Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
+  name and improve typing. Use ``type`` instead.
+
 
 What's New in astroid 2.11.4?
 =============================

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -345,7 +345,7 @@ def file_info_from_modpath(modpath, path=None, context_file=None):
         return spec.ModuleSpec(
             name="os.path",
             location=os.path.__file__,
-            module_type=spec.ModuleType.PY_SOURCE,
+            type=spec.ModuleType.PY_SOURCE,
         )
     return _spec_from_modpath(modpath, path, context)
 


### PR DESCRIPTION
## Description
Replace `collections.namedtuple` with `typing.NamedTuple`. An issue here is that `ModuleType` previously implemented a custom `__new__` method which modified one parameter name `type` vs `module_type`. This PR modifies the constructor parameter name (`module_type`). That way all existing `ModuleSpec` instances can still access the `type` attribute.

I've added a changelog entry since technically it's a breaking change. However, I don't think anyone should be impacted by it. `ModuleType` is (almost ?) exclusively used for internal code.