### PR TITLE
Rename TypeVars

### DIFF
--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -21,8 +21,8 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec
 
-R = TypeVar("R")
-P = ParamSpec("P")
+_R = TypeVar("_R")
+_P = ParamSpec("_P")
 
 
 @wrapt.decorator
@@ -153,7 +153,7 @@ if util.check_warnings_filter():
 
     def deprecate_default_argument_values(
         astroid_version: str = "3.0", **arguments: str
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
         """Decorator which emits a DeprecationWarning if any arguments specified
         are None or not passed at all.
 
@@ -167,11 +167,11 @@ if util.check_warnings_filter():
         # Decorator for DeprecationWarning: https://stackoverflow.com/a/49802489
         # Typing of stacked decorators: https://stackoverflow.com/a/68290080
 
-        def deco(func: Callable[P, R]) -> Callable[P, R]:
+        def deco(func: Callable[_P, _R]) -> Callable[_P, _R]:
             """Decorator function."""
 
             @functools.wraps(func)
-            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 """Emit DeprecationWarnings if conditions are met."""
 
                 keys = list(inspect.signature(func).parameters.keys())
@@ -212,7 +212,7 @@ if util.check_warnings_filter():
 
     def deprecate_arguments(
         astroid_version: str = "3.0", **arguments: str
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
         """Decorator which emits a DeprecationWarning if any arguments specified
         are passed.
 
@@ -223,9 +223,9 @@ if util.check_warnings_filter():
         the default one are enabled.
         """
 
-        def deco(func: Callable[P, R]) -> Callable[P, R]:
+        def deco(func: Callable[_P, _R]) -> Callable[_P, _R]:
             @functools.wraps(func)
-            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
 
                 keys = list(inspect.signature(func).parameters.keys())
                 for arg, note in arguments.items():
@@ -252,10 +252,10 @@ else:
 
     def deprecate_default_argument_values(
         astroid_version: str = "3.0", **arguments: str
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
         """Passthrough decorator to improve performance if DeprecationWarnings are disabled."""
 
-        def deco(func: Callable[P, R]) -> Callable[P, R]:
+        def deco(func: Callable[_P, _R]) -> Callable[_P, _R]:
             """Decorator function."""
             return func
 
@@ -263,10 +263,10 @@ else:
 
     def deprecate_arguments(
         astroid_version: str = "3.0", **arguments: str
-    ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
         """Passthrough decorator to improve performance if DeprecationWarnings are disabled."""
 
-        def deco(func: Callable[P, R]) -> Callable[P, R]:
+        def deco(func: Callable[_P, _R]) -> Callable[_P, _R]:
             """Decorator function."""
             return func
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -56,12 +56,12 @@ def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
 
 
-T_Nodes = TypeVar("T_Nodes", bound=NodeNG)
+_NodesT = TypeVar("_NodesT", bound=NodeNG)
 
 AssignedStmtsPossibleNode = Union["List", "Tuple", "AssignName", "AssignAttr", None]
 AssignedStmtsCall = Callable[
     [
-        T_Nodes,
+        _NodesT,
         AssignedStmtsPossibleNode,
         Optional[InferenceContext],
         Optional[typing.List[int]],

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -49,9 +49,9 @@ else:
     from astroid.decorators import cachedproperty as cached_property
 
 # Types for 'NodeNG.nodes_of_class()'
-T_Nodes = TypeVar("T_Nodes", bound="NodeNG")
-T_Nodes2 = TypeVar("T_Nodes2", bound="NodeNG")
-T_Nodes3 = TypeVar("T_Nodes3", bound="NodeNG")
+_NodesT = TypeVar("_NodesT", bound="NodeNG")
+_NodesT2 = TypeVar("_NodesT2", bound="NodeNG")
+_NodesT3 = TypeVar("_NodesT3", bound="NodeNG")
 SkipKlassT = Union[None, Type["NodeNG"], Tuple[Type["NodeNG"], ...]]
 
 
@@ -513,45 +513,45 @@ class NodeNG:
     @overload
     def nodes_of_class(
         self,
-        klass: Type[T_Nodes],
+        klass: Type[_NodesT],
         skip_klass: SkipKlassT = None,
-    ) -> Iterator[T_Nodes]:
+    ) -> Iterator[_NodesT]:
         ...
 
     @overload
     def nodes_of_class(
         self,
-        klass: Tuple[Type[T_Nodes], Type[T_Nodes2]],
+        klass: Tuple[Type[_NodesT], Type[_NodesT2]],
         skip_klass: SkipKlassT = None,
-    ) -> Union[Iterator[T_Nodes], Iterator[T_Nodes2]]:
+    ) -> Union[Iterator[_NodesT], Iterator[_NodesT2]]:
         ...
 
     @overload
     def nodes_of_class(
         self,
-        klass: Tuple[Type[T_Nodes], Type[T_Nodes2], Type[T_Nodes3]],
+        klass: Tuple[Type[_NodesT], Type[_NodesT2], Type[_NodesT3]],
         skip_klass: SkipKlassT = None,
-    ) -> Union[Iterator[T_Nodes], Iterator[T_Nodes2], Iterator[T_Nodes3]]:
+    ) -> Union[Iterator[_NodesT], Iterator[_NodesT2], Iterator[_NodesT3]]:
         ...
 
     @overload
     def nodes_of_class(
         self,
-        klass: Tuple[Type[T_Nodes], ...],
+        klass: Tuple[Type[_NodesT], ...],
         skip_klass: SkipKlassT = None,
-    ) -> Iterator[T_Nodes]:
+    ) -> Iterator[_NodesT]:
         ...
 
     def nodes_of_class(  # type: ignore[misc] # mypy doesn't correctly recognize the overloads
         self,
         klass: Union[
-            Type[T_Nodes],
-            Tuple[Type[T_Nodes], Type[T_Nodes2]],
-            Tuple[Type[T_Nodes], Type[T_Nodes2], Type[T_Nodes3]],
-            Tuple[Type[T_Nodes], ...],
+            Type[_NodesT],
+            Tuple[Type[_NodesT], Type[_NodesT2]],
+            Tuple[Type[_NodesT], Type[_NodesT2], Type[_NodesT3]],
+            Tuple[Type[_NodesT], ...],
         ],
         skip_klass: SkipKlassT = None,
-    ) -> Union[Iterator[T_Nodes], Iterator[T_Nodes2], Iterator[T_Nodes3]]:
+    ) -> Union[Iterator[_NodesT], Iterator[_NodesT2], Iterator[_NodesT3]]:
         """Get the nodes (including this one or below) of the given types.
 
         :param klass: The types of node to search for.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -66,7 +66,7 @@ BUILTIN_DESCRIPTORS = frozenset(
     {"classmethod", "staticmethod", "builtins.classmethod", "builtins.staticmethod"}
 )
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
 def _c3_merge(sequences, cls, context):
@@ -647,7 +647,7 @@ class Module(LocalsDictNodeNG):
     def get_children(self):
         yield from self.body
 
-    def frame(self: T, *, future: Literal[None, True] = None) -> T:
+    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -1254,7 +1254,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         yield self.args
         yield self.body
 
-    def frame(self: T, *, future: Literal[None, True] = None) -> T:
+    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -1800,7 +1800,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
                 return self, [frame]
         return super().scope_lookup(node, name, offset)
 
-    def frame(self: T, *, future: Literal[None, True] = None) -> T:
+    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -3102,7 +3102,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         )
         return list(itertools.chain.from_iterable(children_assign_nodes))
 
-    def frame(self: T, *, future: Literal[None, True] = None) -> T:
+    def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
         """The node's frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -57,9 +57,9 @@ T_Doc = TypeVar(
     "ast.ClassDef",
     Union["ast.FunctionDef", "ast.AsyncFunctionDef"],
 )
-T_Function = TypeVar("T_Function", nodes.FunctionDef, nodes.AsyncFunctionDef)
-T_For = TypeVar("T_For", nodes.For, nodes.AsyncFor)
-T_With = TypeVar("T_With", nodes.With, nodes.AsyncWith)
+_FunctionT = TypeVar("_FunctionT", nodes.FunctionDef, nodes.AsyncFunctionDef)
+_ForT = TypeVar("_ForT", nodes.For, nodes.AsyncFor)
+_WithT = TypeVar("_WithT", nodes.With, nodes.AsyncWith)
 NodesWithDocsType = Union[nodes.Module, nodes.ClassDef, nodes.FunctionDef]
 
 
@@ -1179,8 +1179,8 @@ class TreeRebuilder:
         ...
 
     def _visit_for(
-        self, cls: Type[T_For], node: Union["ast.For", "ast.AsyncFor"], parent: NodeNG
-    ) -> T_For:
+        self, cls: Type[_ForT], node: Union["ast.For", "ast.AsyncFor"], parent: NodeNG
+    ) -> _ForT:
         """visit a For node by returning a fresh instance of it"""
         col_offset = node.col_offset
         if IS_PYPY and not PY39_PLUS and isinstance(node, ast.AsyncFor) and self._data:
@@ -1245,10 +1245,10 @@ class TreeRebuilder:
 
     def _visit_functiondef(
         self,
-        cls: Type[T_Function],
+        cls: Type[_FunctionT],
         node: Union["ast.FunctionDef", "ast.AsyncFunctionDef"],
         parent: NodeNG,
-    ) -> T_Function:
+    ) -> _FunctionT:
         """visit an FunctionDef node to become astroid"""
         self._global_names.append({})
         node, doc_ast_node = self._get_doc(node)
@@ -1905,10 +1905,10 @@ class TreeRebuilder:
 
     def _visit_with(
         self,
-        cls: Type[T_With],
+        cls: Type[_WithT],
         node: Union["ast.With", "ast.AsyncWith"],
         parent: NodeNG,
-    ) -> T_With:
+    ) -> _WithT:
         col_offset = node.col_offset
         if IS_PYPY and not PY39_PLUS and isinstance(node, ast.AsyncWith) and self._data:
             # pylint: disable-next=unsubscriptable-object


### PR DESCRIPTION
## Description
Rename TypeVars to match new naming style.
Pylint PR: https://github.com/PyCQA/pylint/pull/6446