### PR TITLE
Improve recognition of ``_io`` module during bootstrapping on ``PyPy``

### DIFF
--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -20,7 +20,7 @@ from astroid import helpers, nodes, objects, test_utils, util
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Instance, UnboundMethod
 from astroid.builder import AstroidBuilder, extract_node, parse
-from astroid.const import IS_PYPY, PY38_PLUS, PY39_PLUS
+from astroid.const import PY38_PLUS, PY39_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -816,9 +816,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(len(inferred), 1)
         self.assertIsInstance(inferred[0], nodes.FunctionDef)
         self.assertEqual(inferred[0].name, "open")
-
-    if IS_PYPY:
-        test_builtin_open = unittest.expectedFailure(test_builtin_open)
 
     def test_callfunc_context_func(self) -> None:
         code = """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This was added in https://github.com/PyCQA/astroid/commit/9d090ce96e3f3177708d792613fd66f343309bc0.
However, with this change the test still passes. We have likely mitigated the circular dependency somewhere else. This line did make it so that we did not infer `builtins` defined in `_io` and `io`.
Test show that we now infer this correctly 😄 

I believe this is also the last remaining issue for https://github.com/PyCQA/pylint/pull/6406.
It will also make it possible to run some additional tests on `PyPy` in `pylint.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

