### PR TITLE
Make `FunctionDef.implicit_parameters` return 1 for methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,11 @@ Release date: TBA
 
 * Fix ``col_offset`` attribute for nodes involving ``with`` on ``PyPy``.
 
+* Made ``FunctionDef.implicit_parameters`` return 1 for instance methods by making
+  ``FunctionDef.is_bound`` return ``True``, as it does for class methods.
+
+  Closes PyCQA/pylint#6464
+
 
 What's New in astroid 2.11.3?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,7 +23,7 @@ Release date: TBA
 
 * Fix ``col_offset`` attribute for nodes involving ``with`` on ``PyPy``.
 
-* Made ``FunctionDef.implicit_parameters`` return 1 for instance methods by making
+* Made ``FunctionDef.implicit_parameters`` return 1 for methods by making
   ``FunctionDef.is_bound`` return ``True``, as it does for class methods.
 
   Closes PyCQA/pylint#6464

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1645,7 +1645,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
             False otherwise.
         :rtype: bool
         """
-        return self.type in ("method", "classmethod")
+        return self.type in {"method", "classmethod"}
 
     def is_abstract(self, pass_is_abstract=True, any_raise_is_abstract=False):
         """Check if the method is abstract.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1581,6 +1581,9 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         """
         return self.args.tolineno
 
+    def implicit_parameters(self):
+        return 1 if self.is_bound() else 0
+
     def block_range(self, lineno):
         """Get a range from the given line number to where this node ends.
 
@@ -1642,7 +1645,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
             False otherwise.
         :rtype: bool
         """
-        return self.type == "classmethod"
+        return self.type in ("method", "classmethod")
 
     def is_abstract(self, pass_is_abstract=True, any_raise_is_abstract=False):
         """Check if the method is abstract.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1581,7 +1581,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         """
         return self.args.tolineno
 
-    def implicit_parameters(self):
+    def implicit_parameters(self) -> Literal[0, 1]:
         return 1 if self.is_bound() else 0
 
     def block_range(self, lineno):

--- a/tests/unittest_brain_qt.py
+++ b/tests/unittest_brain_qt.py
@@ -39,7 +39,7 @@ class TestBrainQt:
         assert isinstance(attribute_node.instance_attrs["connect"][0], FunctionDef)
 
     @staticmethod
-    def test_implicit_parameters():
+    def test_implicit_parameters() -> None:
         """Regression test for https://github.com/PyCQA/pylint/issues/6464"""
         src = """
         from PyQt6.QtCore import QTimer

--- a/tests/unittest_brain_qt.py
+++ b/tests/unittest_brain_qt.py
@@ -16,7 +16,7 @@ HAS_PYQT6 = find_spec("PyQt6")
 
 @pytest.mark.skipif(HAS_PYQT6 is None, reason="This test requires the PyQt6 library.")
 class TestBrainQt:
-    AstroidManager.brain["extension_package_whitelist"] = {"PyQt6.QtPrintSupport"}
+    AstroidManager.brain["extension_package_whitelist"] = {"PyQt6"}
 
     @staticmethod
     def test_value_of_lambda_instance_attrs_is_list():

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -617,6 +617,24 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
         self.assertIsInstance(one, nodes.Const)
         self.assertEqual(one.value, 1)
 
+    def test_func_is_bound(self) -> None:
+        data = """
+        class MyClass:
+            def bound():  #@
+                pass
+        """
+        func = builder.extract_node(data)
+        self.assertIs(func.is_bound(), True)
+        self.assertEqual(func.implicit_parameters(), 1)
+
+        data2 = """
+        def not_bound():  #@
+            pass
+        """
+        func2 = builder.extract_node(data2)
+        self.assertIs(func2.is_bound(), False)
+        self.assertEqual(func2.implicit_parameters(), 0)
+
     def test_type_builtin_descriptor_subclasses(self) -> None:
         astroid = builder.parse(
             """


### PR DESCRIPTION
## Description

When a node is inferred as `FunctionDef` instead of `BoundMethod`, `implicit_parameters()` always returns 0, which can cause problems in `pylint` with `no-value-for-parameter` and such. We can at least fall back to the knowledge that it is bound and return 1.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes PyCQA/pylint#6464 (because we will not be writing Qt tests there)

- [x] Todo: see if this closes any other pylint issues for `no-value-for-parameter`
