### PR TITLE
Fix a crash when `_filter_stmts` encounters an `EmptyNode`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,7 +25,8 @@ Release date: TBA
 
 * Fixed a crash when ``_filter_stmts`` encounters an ``EmptyNode``.
 
-  Closes #6438
+  Closes PyCQA/pylint#6438
+
 
 What's New in astroid 2.11.3?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,9 @@ Release date: TBA
 
 * Fix ``col_offset`` attribute for nodes involving ``with`` on ``PyPy``.
 
+* Fixed a crash when ``_filter_stmts`` encounters an ``EmptyNode``.
+
+  Closes #6438
 
 What's New in astroid 2.11.3?
 =============================

--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -112,15 +112,15 @@ def _filter_stmts(base_node: nodes.NodeNG, stmts, frame, offset):
         # Fixes issue #375
         if mystmt is stmt and _is_from_decorator(base_node):
             continue
-        assert hasattr(node, "assign_type"), (
-            node,
-            node.scope(),
-            node.scope().locals,
-        )
-        assign_type = node.assign_type()
         if node.has_base(base_node):
             break
 
+        if isinstance(node, nodes.EmptyNode):
+            # EmptyNode does not have assign_type(), so just add it and move on
+            _stmts.append(node)
+            continue
+
+        assign_type = node.assign_type()
         _stmts, done = assign_type._get_filtered_stmts(base_node, node, _stmts, mystmt)
         if done:
             break

--- a/tests/unittest_filter_statements.py
+++ b/tests/unittest_filter_statements.py
@@ -1,0 +1,20 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
+
+import unittest
+
+from astroid.builder import extract_node
+from astroid.filter_statements import _filter_stmts
+from astroid.nodes import EmptyNode
+
+
+class FilterStatementsTest(unittest.TestCase):
+    def test_empty_node(self) -> None:
+        enum_mod = extract_node("import enum")
+        empty = EmptyNode(parent=enum_mod)
+        empty.is_statement = True
+        filtered_statements = _filter_stmts(
+            empty, [empty.statement(future=True)], empty.frame(future=True), 0
+        )
+        self.assertIs(filtered_statements[0], empty)

--- a/tests/unittest_filter_statements.py
+++ b/tests/unittest_filter_statements.py
@@ -2,19 +2,16 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-import unittest
-
 from astroid.builder import extract_node
 from astroid.filter_statements import _filter_stmts
 from astroid.nodes import EmptyNode
 
 
-class FilterStatementsTest(unittest.TestCase):
-    def test_empty_node(self) -> None:
-        enum_mod = extract_node("import enum")
-        empty = EmptyNode(parent=enum_mod)
-        empty.is_statement = True
-        filtered_statements = _filter_stmts(
-            empty, [empty.statement(future=True)], empty.frame(future=True), 0
-        )
-        self.assertIs(filtered_statements[0], empty)
+def test_empty_node() -> None:
+    enum_mod = extract_node("import enum")
+    empty = EmptyNode(parent=enum_mod)
+    empty.is_statement = True
+    filtered_statements = _filter_stmts(
+        empty, [empty.statement(future=True)], empty.frame(future=True), 0
+    )
+    assert filtered_statements[0] is empty


### PR DESCRIPTION
## Description
An assertion was added in 864d2f31b0d30a25d5986cb8682c5500454da6c8 "to be removed later". `EmptyNode` was failing the condition, see also related issue PyCQA/pylint#2535. This PR removes the assertion and short-circuits.


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes PyCQA/pylint#6438. Added a regression test without Qt.
