### PR TITLE
Fix a crash involving two starred expressions inside a call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,11 @@ Release date: TBA
 
 * Fix ``col_offset`` attribute for nodes involving ``with`` on ``PyPy``.
 
+* Fixed a crash involving two starred expressions: one inside a comprehension,
+  both inside a call.
+
+  Refs PyCQA/pylint#6372
+
 
 What's New in astroid 2.11.3?
 =============================

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -690,6 +690,9 @@ def starred_assigned_stmts(
     if isinstance(stmt, nodes.Assign):
         value = stmt.value
         lhs = stmt.targets[0]
+        if not hasattr(lhs, "elts"):
+            yield util.Uninferable
+            return
 
         if sum(1 for _ in lhs.nodes_of_class(nodes.Starred)) > 1:
             raise InferenceError(

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -690,7 +690,7 @@ def starred_assigned_stmts(
     if isinstance(stmt, nodes.Assign):
         value = stmt.value
         lhs = stmt.targets[0]
-        if not hasattr(lhs, "elts"):
+        if not isinstance(lhs, nodes.BaseContainer):
             yield util.Uninferable
             return
 

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -124,6 +124,11 @@ class ProtocolTests(unittest.TestCase):
         self._helper_starred_expected(
             "a, (*b, c), d = (1, (2, 3, 4), 5) #@", Uninferable
         )
+        # Regression test for https://github.com/PyCQA/pylint/issues/6372
+        self._helper_starred_expected(
+            "string_twos = ''.join(str(*y) for _, *y in [[1, 2], [1, 2]]) #@",
+            Uninferable,
+        )
 
     def test_assign_stmts_starred_fails(self) -> None:
         # Too many starred


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Before, there was an assumption that given an assign statement with a starred node on the right-hand side, there will be a container on the left-hand side. When the starred node is inside a call, that assumption is violated.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Refs PyCQA/pylint#6372