### PR TITLE
Remove dependency on `pkg_resources` from `setuptools`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release date: TBA
 
   Closes #1512
 
+* Remove dependency on ``pkg_resources`` from ``setuptools``.
+
+  Closes #1103
+
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -147,7 +147,7 @@ class ImportlibFinder(Finder):
             # Builtin.
             return None
 
-        if util._is_setuptools_namespace(spec.location):
+        if util._is_setuptools_namespace(Path(spec.location)):
             # extend_path is called, search sys.path for module/packages
             # of this name see pkgutil.extend_path documentation
             path = [

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -171,7 +171,7 @@ class ImportlibFinder(Finder):
 
 
 class ExplicitNamespacePackageFinder(ImportlibFinder):
-    """A finder for the explicit namespace packages, generated through pkg_resources."""
+    """A finder for the explicit namespace packages."""
 
     def find_module(self, modname, module_parts, processed, submodule_path):
         if processed:

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -144,7 +144,7 @@ class ImportlibFinder(Finder):
             # Builtin.
             return None
 
-        if _is_setuptools_namespace(spec.location):
+        if util._is_setuptools_namespace(spec.location):
             # extend_path is called, search sys.path for module/packages
             # of this name see pkgutil.extend_path documentation
             path = [
@@ -251,20 +251,6 @@ _SPEC_FINDERS = (
     PathSpecFinder,
     ExplicitNamespacePackageFinder,
 )
-
-
-def _is_setuptools_namespace(location):
-    try:
-        with open(os.path.join(location, "__init__.py"), "rb") as stream:
-            data = stream.read(4096)
-    except OSError:
-        return None
-    else:
-        extend_path = b"pkgutil" in data and b"extend_path" in data
-        declare_namespace = (
-            b"pkg_resources" in data and b"declare_namespace(__name__)" in data
-        )
-        return extend_path or declare_namespace
 
 
 @lru_cache()

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -2,8 +2,6 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-from __future__ import annotations
-
 import sys
 from functools import lru_cache
 from importlib.util import _find_spec_from_path

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 import pathlib
+import sys
 from functools import lru_cache
-from importlib.machinery import BuiltinImporter
 from importlib.util import _find_spec_from_path
 
 
@@ -26,6 +26,9 @@ def _is_setuptools_namespace(location: pathlib.Path) -> bool:
 
 @lru_cache(maxsize=4096)
 def is_namespace(modname: str) -> bool:
+    if modname in sys.builtin_module_names:
+        return False
+
     found_spec = None
 
     # find_spec() attempts to import parent packages when given dotted paths.
@@ -45,10 +48,6 @@ def is_namespace(modname: str) -> bool:
         last_parent = working_modname
 
     if found_spec is None:
-        return False
-
-    if found_spec.loader is BuiltinImporter:
-        # TODO(Py39): remove, since found_spec.origin will be "built-in"
         return False
 
     return found_spec.origin is None

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -31,14 +31,11 @@ def is_namespace(modname: str) -> bool:
     # That's unacceptable here, so we fallback to _find_spec_from_path(), which does
     # not, but requires instead that each single parent ('astroid', 'nodes', etc.)
     # be specced from left to right.
-    working_modname = ""
+    processed_components = []
     last_parent = None
     for component in modname.split("."):
-        if working_modname:
-            working_modname += "." + component
-        else:
-            # First component
-            working_modname = component
+        processed_components.append(component)
+        working_modname = ".".join(processed_components)
         try:
             found_spec = _find_spec_from_path(working_modname, last_parent)
         except ValueError:

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -4,15 +4,14 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 from functools import lru_cache
 from importlib.util import _find_spec_from_path
 
 
-def _is_setuptools_namespace(location: str | pathlib.Path) -> bool:
+def _is_setuptools_namespace(location: pathlib.Path) -> bool:
     try:
-        with open(os.path.join(location, "__init__.py"), "rb") as stream:
+        with open(location / "__init__.py", "rb") as stream:
             data = stream.read(4096)
     except OSError:
         return False

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -2,15 +2,34 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-from importlib.util import find_spec
+from importlib.util import _find_spec_from_path
 
 
-def is_namespace(modname):
-    try:
-        found_spec = find_spec(modname)
-    except ValueError:
-        # execution of .pth files may not have __spec__
-        return True
+def is_namespace(modname: str) -> bool:
+    found_spec = None
+
+    # find_spec() attempts to import parent packages when given dotted paths.
+    # That's unacceptable here, so we fallback to _find_spec_from_path(), which does
+    # not, but requires instead that each single parent ('astroid', 'nodes', etc.)
+    # be specced from left to right.
+    working_modname = ""
+    last_parent = None
+    for component in modname.split("."):
+        if working_modname:
+            working_modname += "." + component
+        else:
+            # First component
+            working_modname = component
+        try:
+            found_spec = _find_spec_from_path(working_modname, last_parent)
+        except (
+            AttributeError,  # TODO: remove AttributeError when 3.7+ is min
+            ValueError,
+        ):
+            # executed .pth files may not have __spec__
+            return True
+        last_parent = working_modname
+
     if found_spec is None:
         return
     # origin can be either a string on older Python versions

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -2,13 +2,15 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import os
 import pathlib
 from functools import lru_cache
 from importlib.util import _find_spec_from_path
 
 
-def _is_setuptools_namespace(location) -> bool:
+def _is_setuptools_namespace(location: str | pathlib.Path) -> bool:
     try:
         with open(os.path.join(location, "__init__.py"), "rb") as stream:
             data = stream.read(4096)
@@ -48,6 +50,9 @@ def is_namespace(modname: str) -> bool:
     if found_spec is None:
         return False
 
+    if found_spec.origin == "namespace":
+        return True
+
     if found_spec.submodule_search_locations is not None:
         for search_location in found_spec.submodule_search_locations:
             if any(
@@ -57,4 +62,4 @@ def is_namespace(modname: str) -> bool:
             ):
                 return True
 
-    return found_spec.origin == "namespace"
+    return False

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -4,6 +4,7 @@
 
 import os
 import pathlib
+from functools import lru_cache
 from importlib.util import _find_spec_from_path
 
 
@@ -21,6 +22,7 @@ def _is_setuptools_namespace(location) -> bool:
         return extend_path or declare_namespace
 
 
+@lru_cache(maxsize=4096)
 def is_namespace(modname: str) -> bool:
     found_spec = None
 

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -2,15 +2,18 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-try:
-    import pkg_resources
-except ImportError:
-    pkg_resources = None  # type: ignore[assignment]
+from importlib.util import find_spec
 
 
 def is_namespace(modname):
-    return (
-        pkg_resources is not None
-        and hasattr(pkg_resources, "_namespace_packages")
-        and modname in pkg_resources._namespace_packages
-    )
+    try:
+        found_spec = find_spec(modname)
+    except ValueError:
+        # execution of .pth files may not have __spec__
+        return True
+    if found_spec is None:
+        return
+    # origin can be either a string on older Python versions
+    # or None in case it is a namespace package:
+    # https://github.com/python/cpython/pull/5481
+    return found_spec.origin in {None, "namespace"}

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -4,24 +4,9 @@
 
 from __future__ import annotations
 
-import pathlib
 import sys
 from functools import lru_cache
 from importlib.util import _find_spec_from_path
-
-
-def _is_setuptools_namespace(location: pathlib.Path) -> bool:
-    try:
-        with open(location / "__init__.py", "rb") as stream:
-            data = stream.read(4096)
-    except OSError:
-        return False
-    else:
-        extend_path = b"pkgutil" in data and b"extend_path" in data
-        declare_namespace = (
-            b"pkg_resources" in data and b"declare_namespace(__name__)" in data
-        )
-        return extend_path or declare_namespace
 
 
 @lru_cache(maxsize=4096)

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import pathlib
 from functools import lru_cache
+from importlib.machinery import BuiltinImporter
 from importlib.util import _find_spec_from_path
 
 
@@ -44,6 +45,10 @@ def is_namespace(modname: str) -> bool:
         last_parent = working_modname
 
     if found_spec is None:
+        return False
+
+    if found_spec.loader is BuiltinImporter:
+        # TODO(Py39): remove, since found_spec.origin will be "built-in"
         return False
 
     if found_spec.origin is None:

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -49,7 +49,7 @@ def is_namespace(modname: str) -> bool:
     if found_spec.submodule_search_locations and any(
         _is_setuptools_namespace(directory)
         for directory in pathlib.Path(
-            found_spec.submodule_search_locations._path[0]
+            found_spec.submodule_search_locations[0]
         ).iterdir()
         if directory.is_dir()
     ):

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -7,12 +7,12 @@ import pathlib
 from importlib.util import _find_spec_from_path
 
 
-def _is_setuptools_namespace(location):
+def _is_setuptools_namespace(location) -> bool:
     try:
         with open(os.path.join(location, "__init__.py"), "rb") as stream:
             data = stream.read(4096)
     except OSError:
-        return None
+        return False
     else:
         extend_path = b"pkgutil" in data and b"extend_path" in data
         declare_namespace = (

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -51,16 +51,4 @@ def is_namespace(modname: str) -> bool:
         # TODO(Py39): remove, since found_spec.origin will be "built-in"
         return False
 
-    if found_spec.origin is None:
-        return True
-
-    if found_spec.submodule_search_locations is not None:
-        for search_location in found_spec.submodule_search_locations:
-            if any(
-                _is_setuptools_namespace(directory)
-                for directory in pathlib.Path(search_location).iterdir()
-                if directory.is_dir()
-            ):
-                return True
-
-    return False
+    return found_spec.origin is None

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -31,7 +31,7 @@ def is_namespace(modname: str) -> bool:
         last_parent = working_modname
 
     if found_spec is None:
-        return
+        return False
     # origin can be either a string on older Python versions
     # or None in case it is a namespace package:
     # https://github.com/python/cpython/pull/5481

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -46,13 +46,13 @@ def is_namespace(modname: str) -> bool:
     if found_spec is None:
         return False
 
-    if found_spec.submodule_search_locations and any(
-        _is_setuptools_namespace(directory)
-        for directory in pathlib.Path(
-            found_spec.submodule_search_locations[0]
-        ).iterdir()
-        if directory.is_dir()
-    ):
-        return True
+    if found_spec.submodule_search_locations is not None:
+        for search_location in found_spec.submodule_search_locations:
+            if any(
+                _is_setuptools_namespace(directory)
+                for directory in pathlib.Path(search_location).iterdir()
+                if directory.is_dir()
+            ):
+                return True
 
     return found_spec.origin == "namespace"

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -46,7 +46,7 @@ def is_namespace(modname: str) -> bool:
     if found_spec is None:
         return False
 
-    if found_spec.origin == "namespace":
+    if found_spec.origin is None:
         return True
 
     if found_spec.submodule_search_locations is not None:

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -22,17 +22,12 @@ def is_namespace(modname: str) -> bool:
             working_modname = component
         try:
             found_spec = _find_spec_from_path(working_modname, last_parent)
-        except (
-            AttributeError,  # TODO: remove AttributeError when 3.7+ is min
-            ValueError,
-        ):
+        except ValueError:
             # executed .pth files may not have __spec__
             return True
         last_parent = working_modname
 
     if found_spec is None:
         return False
-    # origin can be either a string on older Python versions
-    # or None in case it is a namespace package:
-    # https://github.com/python/cpython/pull/5481
-    return found_spec.origin in {None, "namespace"}
+
+    return found_spec.origin == "namespace"

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from astroid.const import BRAIN_MODULES_DIRECTORY
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
-from astroid.interpreter._import import spec
+from astroid.interpreter._import import spec, util
 from astroid.modutils import (
     NoSourceFile,
     _cache_normalize_path_,
@@ -382,6 +382,7 @@ class AstroidManager:
         for lru_cache in (
             LookupMixIn.lookup,
             _cache_normalize_path_,
+            util.is_namespace,
             ObjectModel.attributes,
         ):
             lru_cache.cache_clear()

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ packages = find:
 install_requires =
     lazy_object_proxy>=1.4.0
     wrapt>=1.11,<2
-    setuptools>=20.0
     typed-ast>=1.4.0,<2.0;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.10;python_version<"3.10"
 python_requires = >=3.6.2

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -10,8 +10,6 @@ import unittest
 from contextlib import contextmanager
 from typing import Iterator
 
-import pkg_resources
-
 import astroid
 from astroid import manager, test_utils
 from astroid.const import IS_JYTHON
@@ -128,7 +126,6 @@ class AstroidManagerTest(
     def test_namespace_package_pth_support(self) -> None:
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
         site.addpackage(resources.RESOURCE_PATH, pth, [])
-        pkg_resources._namespace_packages["foogle"] = []
 
         try:
             module = self.manager.ast_from_module_name("foogle.fax")
@@ -138,18 +135,14 @@ class AstroidManagerTest(
             with self.assertRaises(AstroidImportError):
                 self.manager.ast_from_module_name("foogle.moogle")
         finally:
-            del pkg_resources._namespace_packages["foogle"]
             sys.modules.pop("foogle")
 
     def test_nested_namespace_import(self) -> None:
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
         site.addpackage(resources.RESOURCE_PATH, pth, [])
-        pkg_resources._namespace_packages["foogle"] = ["foogle.crank"]
-        pkg_resources._namespace_packages["foogle.crank"] = []
         try:
             self.manager.ast_from_module_name("foogle.crank")
         finally:
-            del pkg_resources._namespace_packages["foogle"]
             sys.modules.pop("foogle")
 
     def test_namespace_and_file_mismatch(self) -> None:
@@ -158,12 +151,10 @@ class AstroidManagerTest(
         self.assertEqual(ast.name, "unittest")
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
         site.addpackage(resources.RESOURCE_PATH, pth, [])
-        pkg_resources._namespace_packages["foogle"] = []
         try:
             with self.assertRaises(AstroidImportError):
                 self.manager.ast_from_module_name("unittest.foogle.fax")
         finally:
-            del pkg_resources._namespace_packages["foogle"]
             sys.modules.pop("foogle")
 
     def _test_ast_from_zip(self, archive: str) -> None:

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -109,6 +109,10 @@ class AstroidManagerTest(
         self._test_ast_from_old_namespace_package_protocol("pkg_resources")
 
     def test_identify_old_namespace_package_protocol(self) -> None:
+        # Like the above cases, this package follows the old namespace package protocol
+        # astroid currently assumes such packages are in sys.modules, so import it
+        import tests.testdata.python3.data.path_pkg_resources_1.package.foo  # noqa
+
         self.assertTrue(
             util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1")
         )

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -325,6 +325,7 @@ class ClearCacheTest(unittest.TestCase, resources.AstroidCacheSetupMixin):
         lrus = (
             astroid.nodes.node_classes.LookupMixIn.lookup,
             astroid.modutils._cache_normalize_path_,
+            util.is_namespace,
             astroid.interpreter.objectmodel.ObjectModel.attributes,
         )
 
@@ -334,6 +335,7 @@ class ClearCacheTest(unittest.TestCase, resources.AstroidCacheSetupMixin):
         # Generate some hits and misses
         ClassDef().lookup("garbage")
         is_standard_module("unittest", std_path=["garbage_path"])
+        util.is_namespace("unittest")
         astroid.interpreter.objectmodel.ObjectModel().attributes()
 
         # Did the hits or misses actually happen?

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -113,7 +113,8 @@ class AstroidManagerTest(
     def test_identify_old_namespace_package_protocol(self) -> None:
         # Like the above cases, this package follows the old namespace package protocol
         # astroid currently assumes such packages are in sys.modules, so import it
-        import tests.testdata.python3.data.path_pkg_resources_1.package.foo  # noqa
+        # pylint: disable-next=import-outside-toplevel
+        import tests.testdata.python3.data.path_pkg_resources_1.package.foo as _  # noqa
 
         self.assertTrue(
             util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1")

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -14,6 +14,7 @@ import astroid
 from astroid import manager, test_utils
 from astroid.const import IS_JYTHON
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
+from astroid.interpreter._import import util
 from astroid.nodes import Const
 
 from . import resources
@@ -106,6 +107,11 @@ class AstroidManagerTest(
 
     def test_ast_from_namespace_pkg_resources(self) -> None:
         self._test_ast_from_old_namespace_package_protocol("pkg_resources")
+
+    def test_identify_old_namespace_package_protocol(self) -> None:
+        self.assertTrue(
+            util.is_namespace("tests.testdata.python3.data.path_pkg_resources_1")
+        )
 
     def test_implicit_namespace_package(self) -> None:
         data_dir = os.path.dirname(resources.find("data/namespace_pep_420"))


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Remove dependence on `pkg_resources` from `setuptools`, which is discouraged, and which increases import time.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


## Related Issue

Closes #1103
Closes #1320 
 - [unscientific benchmark]: 50% reduction of import time on an M1 mac, 67% reduction on a cloud console