### PR TITLE
Infer returned value of .copy() method for collections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 
+* Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``
+  and ``frozenset``.
+
+  Closes #1403
 
 What's New in astroid 2.11.5?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,7 +16,7 @@ Release date: TBA
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 
-* Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``
+* Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``,
   and ``frozenset``.
 
   Closes #1403

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -5,7 +5,7 @@
 """Astroid hooks for various builtins."""
 
 from functools import partial
-from typing import Optional
+from typing import Iterator, Optional, Union
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder
@@ -892,12 +892,15 @@ def infer_dict_fromkeys(node, context=None):
     return _build_dict_with_elements([])
 
 
-def _looks_like_copy_method(node):
+def _looks_like_copy_method(node: nodes.Call) -> bool:
     func = node.func
     return isinstance(func, nodes.Attribute) and func.attrname == "copy"
 
 
-def _infer_copy_method(node, context=None):
+def _infer_copy_method(
+    node: nodes.Call,
+    context: Optional[InferenceContext]=None
+) -> Iterator[Union[nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet]]:
     inferred = list(node.func.expr.infer(context=context))
     if all(
         isinstance(inferred_node, (nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet))

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -894,12 +894,13 @@ def infer_dict_fromkeys(node, context=None):
 
 
 def _infer_copy_method(
-    node: nodes.Call,
-    context: Optional[InferenceContext]=None
+    node: nodes.Call, context: Optional[InferenceContext] = None
 ) -> Iterator[Union[nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet]]:
     inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))
     if all(
-        isinstance(inferred_node, (nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet))
+        isinstance(
+            inferred_node, (nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet)
+        )
         for inferred_node in inferred_orig
     ):
         return inferred_copy
@@ -940,5 +941,5 @@ AstroidManager().register_transform(
     nodes.Call,
     inference_tip(_infer_copy_method),
     lambda node: isinstance(node.func, nodes.Attribute)
-    and node.func.attrname == 'copy',
+    and node.func.attrname == "copy",
 )

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -897,16 +897,12 @@ def _looks_like_copy_method(node):
     return isinstance(func, nodes.Attribute) and func.attrname == "copy"
 
 
-def _has_copy_method(node):
-    return any(
-        isinstance(node, klass)
-        for klass in [nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet]
-    )
-
-
 def _infer_copy_method(node, context=None):
     inferred = list(node.func.expr.infer(context=context))
-    if all(_has_copy_method(x) for x in inferred):
+    if all(
+        isinstance(inferred_node, (nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet))
+        for inferred_node in inferred
+    ):
         return iter(inferred)
 
     raise UseInferenceDefault()

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -6,7 +6,7 @@
 
 import itertools
 from functools import partial
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder
@@ -895,7 +895,7 @@ def infer_dict_fromkeys(node, context=None):
 
 def _infer_copy_method(
     node: nodes.Call, context: Optional[InferenceContext] = None
-) -> Iterator[Union[nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet]]:
+) -> Iterator[nodes.nodeNG]:
     inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))
     if all(
         isinstance(

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -895,7 +895,7 @@ def infer_dict_fromkeys(node, context=None):
 
 def _infer_copy_method(
     node: nodes.Call, context: Optional[InferenceContext] = None
-) -> Iterator[nodes.nodeNG]:
+) -> Iterator[nodes.NodeNG]:
     assert isinstance(node.func, nodes.Attribute)
     inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))
     if all(

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -892,11 +892,6 @@ def infer_dict_fromkeys(node, context=None):
     return _build_dict_with_elements([])
 
 
-def _looks_like_copy_method(node: nodes.Call) -> bool:
-    func = node.func
-    return isinstance(func, nodes.Attribute) and func.attrname == "copy"
-
-
 def _infer_copy_method(
     node: nodes.Call,
     context: Optional[InferenceContext]=None
@@ -943,5 +938,6 @@ AstroidManager().register_transform(
 AstroidManager().register_transform(
     nodes.Call,
     inference_tip(_infer_copy_method),
-    _looks_like_copy_method,
+    lambda node: isinstance(node.func, nodes.Attribute)
+    and node.func.attrname == 'copy',
 )

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -894,7 +894,7 @@ def infer_dict_fromkeys(node, context=None):
 
 def _looks_like_copy_method(node):
     func = node.func
-    return isinstance(func, nodes.Attribute) and func.attrname == 'copy'
+    return isinstance(func, nodes.Attribute) and func.attrname == "copy"
 
 
 def _has_copy_method(node):

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -896,6 +896,7 @@ def infer_dict_fromkeys(node, context=None):
 def _infer_copy_method(
     node: nodes.Call, context: Optional[InferenceContext] = None
 ) -> Iterator[nodes.nodeNG]:
+    assert isinstance(node.func, nodes.Attribute)
     inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))
     if all(
         isinstance(

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -4,6 +4,7 @@
 
 """Astroid hooks for various builtins."""
 
+import itertools
 from functools import partial
 from typing import Iterator, Optional, Union
 
@@ -896,12 +897,12 @@ def _infer_copy_method(
     node: nodes.Call,
     context: Optional[InferenceContext]=None
 ) -> Iterator[Union[nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet]]:
-    inferred = list(node.func.expr.infer(context=context))
+    inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))
     if all(
         isinstance(inferred_node, (nodes.Dict, nodes.List, nodes.Set, objects.FrozenSet))
-        for inferred_node in inferred
+        for inferred_node in inferred_orig
     ):
-        return iter(inferred)
+        return inferred_copy
 
     raise UseInferenceDefault()
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -2080,7 +2080,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertInferFrozenSet(ast[3], [1, 2, 3])
 
         inferred_unknown = next(ast[4].infer())
-        self.assertEqual(util.Uninferable, inferred_unknown)
+        assert inferred_unknown == util.Uninferable
 
     def test_str_methods(self) -> None:
         code = """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -2053,27 +2053,34 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def test_copy_method_inference(self) -> None:
         code = """
-        a = {"b": 1, "c": 2}
-        b = a.copy()
-        b #@
+        a_dict = {"b": 1, "c": 2}
+        b_dict = a_dict.copy()
+        b_dict #@
 
-        a = [1, 2, 3]
-        b = a.copy()
-        b #@
+        a_list = [1, 2, 3]
+        b_list = a_list.copy()
+        b_list #@
 
-        a = set([1, 2, 3])
-        b = a.copy()
-        b #@
+        a_set = set([1, 2, 3])
+        b_set = a_set.copy()
+        b_set #@
 
-        a = frozenset([1, 2, 3])
-        b = a.copy()
-        b #@
+        a_frozenset = frozenset([1, 2, 3])
+        b_frozenset = a_frozenset.copy()
+        b_frozenset #@
+
+        a_unknown = unknown()
+        b_unknown = a_unknown.copy()
+        b_unknown #@
         """
         ast = extract_node(code, __name__)
         self.assertInferDict(ast[0], {"b": 1, "c": 2})
         self.assertInferList(ast[1], [1, 2, 3])
         self.assertInferSet(ast[2], [1, 2, 3])
         self.assertInferFrozenSet(ast[3], [1, 2, 3])
+
+        inferred_unknown = next(ast[4].infer())
+        self.assertEqual(util.Uninferable, inferred_unknown)
 
     def test_str_methods(self) -> None:
         code = """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -2051,6 +2051,30 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             self.assertIsInstance(inferred, Instance)
             self.assertEqual(inferred.qname(), "builtins.dict")
 
+    def test_copy_method_inference(self) -> None:
+        code = """
+        a = {"b": 1, "c": 2}
+        b = a.copy()
+        b #@
+
+        a = [1, 2, 3]
+        b = a.copy()
+        b #@
+
+        a = set([1, 2, 3])
+        b = a.copy()
+        b #@
+
+        a = frozenset([1, 2, 3])
+        b = a.copy()
+        b #@
+        """
+        ast = extract_node(code, __name__)
+        self.assertInferDict(ast[0], {"b": 1, "c": 2})
+        self.assertInferList(ast[1], [1, 2, 3])
+        self.assertInferSet(ast[2], [1, 2, 3])
+        self.assertInferFrozenSet(ast[3], [1, 2, 3])
+
     def test_str_methods(self) -> None:
         code = """
         ' '.decode() #@


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Description

Where Astroid can infer that the subject of a `.copy()` method call is a built-in type that supports the copy operator, we can infer that the returned value will have the same value as whatever was inferred.

This change only adds support for `list`, `dict`, `set` and `frozenset`; in theory we can apply it to anything inferred to be of type `collections.abc.MutableSequence`, but: a) that doesn't cover `set` and `frozenset` so we'd need special cases for them anyway and b) Astroid doesn't currently seem to support inferring which types implement `MutableSequence`.

`bytearray` is another type for which we could infer `.copy()` behavior, but Astroid doesn't seem to have any explicit support for it, so adding this looks like more work.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #1403 
