### PR TITLE
Require Python 3.7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -233,7 +233,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
@@ -282,7 +282,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.6", "pypy-3.7", "pypy-3.8"]
+        python-version: ["pypy-3.7", "pypy-3.8"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: pyupgrade
         exclude: tests/testdata
-        args: [--py36-plus]
+        args: [--py37-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in astroid 2.12.0?
 =============================
 Release date: TBA
 
+* ``astroid`` now requires Python 3.7.2 to run.
+
 * Fix ``re`` brain on Python ``3.11``. The flags now come from ``re._compile``.
 
 * Build ``nodes.Module`` for frozen modules which have location information in their

--- a/astroid/brain/brain_crypt.py
+++ b/astroid/brain/brain_crypt.py
@@ -4,25 +4,22 @@
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.const import PY37_PLUS
 from astroid.manager import AstroidManager
 
-if PY37_PLUS:
-    # Since Python 3.7 Hashing Methods are added
-    # dynamically to globals()
 
-    def _re_transform():
-        return parse(
-            """
-        from collections import namedtuple
-        _Method = namedtuple('_Method', 'name ident salt_chars total_size')
-
-        METHOD_SHA512 = _Method('SHA512', '6', 16, 106)
-        METHOD_SHA256 = _Method('SHA256', '5', 16, 63)
-        METHOD_BLOWFISH = _Method('BLOWFISH', 2, 'b', 22)
-        METHOD_MD5 = _Method('MD5', '1', 8, 34)
-        METHOD_CRYPT = _Method('CRYPT', None, 2, 13)
+def _re_transform():
+    return parse(
         """
-        )
+    from collections import namedtuple
+    _Method = namedtuple('_Method', 'name ident salt_chars total_size')
 
-    register_module_extender(AstroidManager(), "crypt", _re_transform)
+    METHOD_SHA512 = _Method('SHA512', '6', 16, 106)
+    METHOD_SHA256 = _Method('SHA256', '5', 16, 63)
+    METHOD_BLOWFISH = _Method('BLOWFISH', 2, 'b', 22)
+    METHOD_MD5 = _Method('MD5', '1', 8, 34)
+    METHOD_CRYPT = _Method('CRYPT', None, 2, 13)
+    """
+    )
+
+
+register_module_extender(AstroidManager(), "crypt", _re_transform)

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -17,7 +17,7 @@ from typing import FrozenSet, Generator, List, Optional, Tuple, Union
 
 from astroid import context, inference_tip
 from astroid.builder import parse
-from astroid.const import PY37_PLUS, PY39_PLUS
+from astroid.const import PY39_PLUS
 from astroid.exceptions import (
     AstroidSyntaxError,
     InferenceError,
@@ -449,19 +449,18 @@ def _infer_instance_from_annotation(
         yield klass.instantiate_class()
 
 
-if PY37_PLUS:
-    AstroidManager().register_transform(
-        ClassDef, dataclass_transform, is_decorated_with_dataclass
-    )
+AstroidManager().register_transform(
+    ClassDef, dataclass_transform, is_decorated_with_dataclass
+)
 
-    AstroidManager().register_transform(
-        Call,
-        inference_tip(infer_dataclass_field_call, raise_on_overwrite=True),
-        _looks_like_dataclass_field_call,
-    )
+AstroidManager().register_transform(
+    Call,
+    inference_tip(infer_dataclass_field_call, raise_on_overwrite=True),
+    _looks_like_dataclass_field_call,
+)
 
-    AstroidManager().register_transform(
-        Unknown,
-        inference_tip(infer_dataclass_attribute, raise_on_overwrite=True),
-        _looks_like_dataclass_attribute,
-    )
+AstroidManager().register_transform(
+    Unknown,
+    inference_tip(infer_dataclass_attribute, raise_on_overwrite=True),
+    _looks_like_dataclass_attribute,
+)

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -7,7 +7,7 @@ from typing import Optional
 from astroid import context, inference_tip, nodes
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import _extract_single_node, parse
-from astroid.const import PY37_PLUS, PY39_PLUS, PY311_PLUS
+from astroid.const import PY39_PLUS, PY311_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -90,7 +90,6 @@ def infer_pattern_match(
     return iter([class_def])
 
 
-if PY37_PLUS:
-    AstroidManager().register_transform(
-        nodes.Call, inference_tip(infer_pattern_match), _looks_like_pattern_or_match
-    )
+AstroidManager().register_transform(
+    nodes.Call, inference_tip(infer_pattern_match), _looks_like_pattern_or_match
+)

--- a/astroid/brain/brain_subprocess.py
+++ b/astroid/brain/brain_subprocess.py
@@ -6,7 +6,7 @@ import textwrap
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
-from astroid.const import PY37_PLUS, PY39_PLUS
+from astroid.const import PY39_PLUS
 from astroid.manager import AstroidManager
 
 
@@ -17,9 +17,7 @@ def _subprocess_transform():
         self, args, bufsize=0, executable=None, stdin=None, stdout=None, stderr=None,
         preexec_fn=None, close_fds=False, shell=False, cwd=None, env=None,
         universal_newlines=False, startupinfo=None, creationflags=0, restore_signals=True,
-        start_new_session=False, pass_fds=(), *, encoding=None, errors=None"""
-    if PY37_PLUS:
-        args += ", text=None"
+        start_new_session=False, pass_fds=(), *, encoding=None, errors=None, text=None"""
     init = f"""
         def __init__({args}):
             pass"""
@@ -30,57 +28,31 @@ def _subprocess_transform():
     """
     py3_args = "args = []"
 
-    if PY37_PLUS:
-        check_output_signature = """
-        check_output(
-            args, *,
-            stdin=None,
-            stderr=None,
-            shell=False,
-            cwd=None,
-            encoding=None,
-            errors=None,
-            universal_newlines=False,
-            timeout=None,
-            env=None,
-            text=None,
-            restore_signals=True,
-            preexec_fn=None,
-            pass_fds=(),
-            input=None,
-            bufsize=0,
-            executable=None,
-            close_fds=False,
-            startupinfo=None,
-            creationflags=0,
-            start_new_session=False
-        ):
-        """.strip()
-    else:
-        check_output_signature = """
-        check_output(
-            args, *,
-            stdin=None,
-            stderr=None,
-            shell=False,
-            cwd=None,
-            encoding=None,
-            errors=None,
-            universal_newlines=False,
-            timeout=None,
-            env=None,
-            restore_signals=True,
-            preexec_fn=None,
-            pass_fds=(),
-            input=None,
-            bufsize=0,
-            executable=None,
-            close_fds=False,
-            startupinfo=None,
-            creationflags=0,
-            start_new_session=False
-        ):
-        """.strip()
+    check_output_signature = """
+    check_output(
+        args, *,
+        stdin=None,
+        stderr=None,
+        shell=False,
+        cwd=None,
+        encoding=None,
+        errors=None,
+        universal_newlines=False,
+        timeout=None,
+        env=None,
+        text=None,
+        restore_signals=True,
+        preexec_fn=None,
+        pass_fds=(),
+        input=None,
+        bufsize=0,
+        executable=None,
+        close_fds=False,
+        startupinfo=None,
+        creationflags=0,
+        start_new_session=False
+    ):
+    """.strip()
 
     code = textwrap.dedent(
         f"""

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -6,7 +6,6 @@ import enum
 import sys
 
 PY38 = sys.version_info[:2] == (3, 8)
-PY37_PLUS = sys.version_info >= (3, 7)
 PY38_PLUS = sys.version_info >= (3, 8)
 PY39_PLUS = sys.version_info >= (3, 9)
 PY310_PLUS = sys.version_info >= (3, 10)

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -5,7 +5,6 @@
 import enum
 import sys
 
-PY36 = sys.version_info[:2] == (3, 6)
 PY38 = sys.version_info[:2] == (3, 8)
 PY37_PLUS = sys.version_info >= (3, 7)
 PY38_PLUS = sys.version_info >= (3, 8)

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -13,7 +13,7 @@ import os
 import sys
 import typing
 import warnings
-from typing import Dict, List, Optional, Set, TypeVar, Union, overload
+from typing import Dict, List, NoReturn, Optional, Set, TypeVar, Union, overload
 
 from astroid import bases
 from astroid import decorators as decorators_mod
@@ -43,12 +43,6 @@ from astroid.nodes import Arguments, Const, NodeNG, node_classes
 from astroid.nodes.scoped_nodes.mixin import ComprehensionScope, LocalsDictNodeNG
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
-
-if sys.version_info >= (3, 6, 2):
-    from typing import NoReturn
-else:
-    from typing_extensions import NoReturn
-
 
 if sys.version_info >= (3, 8):
     from functools import cached_property

--- a/pylintrc
+++ b/pylintrc
@@ -43,7 +43,7 @@ unsafe-load-any-extension=no
 extension-pkg-whitelist=
 
 # Minimum supported python version
-py-version = 3.7.2
+py-version = 3.6.2
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -43,7 +43,7 @@ unsafe-load-any-extension=no
 extension-pkg-whitelist=
 
 # Minimum supported python version
-py-version = 3.6.2
+py-version = 3.7.2
 
 
 [REPORTS]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -43,7 +42,7 @@ install_requires =
     setuptools>=20.0
     typed-ast>=1.4.0,<2.0;implementation_name=="cpython" and python_version<"3.8"
     typing-extensions>=3.10;python_version<"3.10"
-python_requires = >=3.6.2
+python_requires = >=3.7.2
 
 [options.packages.find]
 include =

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -15,7 +15,6 @@ import pytest
 import astroid
 from astroid import MANAGER, bases, builder, nodes, objects, test_utils, util
 from astroid.bases import Instance
-from astroid.const import PY37_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -3110,7 +3109,6 @@ def test_http_client_brain() -> None:
     assert isinstance(inferred, astroid.Instance)
 
 
-@pytest.mark.skipif(not PY37_PLUS, reason="Needs 3.7+")
 def test_http_status_brain() -> None:
     node = astroid.extract_node(
         """
@@ -3147,7 +3145,6 @@ def test_oserror_model() -> None:
     assert strerror.value == ""
 
 
-@pytest.mark.skipif(not PY37_PLUS, reason="Dynamic module attributes since Python 3.7")
 def test_crypt_brain() -> None:
     module = MANAGER.ast_from_module_name("crypt")
     dynamic_attrs = [

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1658,7 +1658,6 @@ class TypingBrain(unittest.TestCase):
         attr = next(attr_def.infer())
         self.assertEqual(attr.value, "bar")
 
-    @test_utils.require_version(minver="3.7")
     def test_tuple_type(self):
         node = builder.extract_node(
             """
@@ -1671,7 +1670,6 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
         assert inferred.qname() == "typing.Tuple"
 
-    @test_utils.require_version(minver="3.7")
     def test_callable_type(self):
         node = builder.extract_node(
             """
@@ -1684,7 +1682,6 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
         assert inferred.qname() == "typing.Callable"
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_generic_subscriptable(self):
         """Test typing.Generic is subscriptable with __class_getitem__ (added in PY37)"""
         node = builder.extract_node(
@@ -1711,7 +1708,6 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(inferred, nodes.ClassDef)
         assert isinstance(inferred.getattr("__class_getitem__")[0], nodes.FunctionDef)
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_generic_slots(self):
         """Test slots for Generic subclass."""
         node = builder.extract_node(
@@ -1778,7 +1774,6 @@ class TypingBrain(unittest.TestCase):
         # Test TypedDict instance is callable
         assert next(code[1].infer()).callable() is True
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_alias_type(self):
         """
         Test that the type aliased thanks to typing._alias function are
@@ -1812,7 +1807,6 @@ class TypingBrain(unittest.TestCase):
             ],
         )
 
-    @test_utils.require_version(minver="3.7.2")
     def test_typing_alias_type_2(self):
         """
         Test that the type aliased thanks to typing._alias function are
@@ -1839,7 +1833,6 @@ class TypingBrain(unittest.TestCase):
             ],
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_object_not_subscriptable(self):
         """Hashable is not subscriptable"""
         wrong_node = builder.extract_node(
@@ -1868,7 +1861,6 @@ class TypingBrain(unittest.TestCase):
         with self.assertRaises(AttributeInferenceError):
             inferred.getattr("__class_getitem__")
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_object_subscriptable(self):
         """Test that MutableSet is subscriptable"""
         right_node = builder.extract_node(
@@ -1895,7 +1887,6 @@ class TypingBrain(unittest.TestCase):
             inferred.getattr("__class_getitem__")[0], nodes.FunctionDef
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_object_subscriptable_2(self):
         """Multiple inheritance with subscriptable typing alias"""
         node = builder.extract_node(
@@ -1919,7 +1910,6 @@ class TypingBrain(unittest.TestCase):
             ],
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_typing_object_notsubscriptable_3(self):
         """Until python39 ByteString class of the typing module is not subscritable (whereas it is in the collections module)"""
         right_node = builder.extract_node(
@@ -2005,11 +1995,10 @@ class ReBrainTest(unittest.TestCase):
             self.assertIn(name, re_ast)
             self.assertEqual(next(re_ast[name].infer()).value, getattr(re, name))
 
-    @test_utils.require_version(minver="3.7", maxver="3.9")
+    @test_utils.require_version(maxver="3.9")
     def test_re_pattern_unsubscriptable(self):
         """
         re.Pattern and re.Match are unsubscriptable until PY39.
-        re.Pattern and re.Match were added in PY37.
         """
         right_node1 = builder.extract_node(
             """

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -6,13 +6,8 @@ import pytest
 
 import astroid
 from astroid import bases, nodes
-from astroid.const import PY37_PLUS
 from astroid.exceptions import InferenceError
 from astroid.util import Uninferable
-
-if not PY37_PLUS:
-    pytest.skip("Dataclasses were added in 3.7", allow_module_level=True)
-
 
 parametrize_module = pytest.mark.parametrize(
     ("module",), (["dataclasses"], ["pydantic.dataclasses"], ["marshmallow_dataclass"])

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1724,7 +1724,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         assert isinstance(cls, nodes.ClassDef)
         self.assertEqualMro(cls, ["C", "A", "B", "object"])
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_1(self):
         cls = builder.extract_node(
             """
@@ -1740,7 +1739,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".C", ".A", "typing.Generic", ".B", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_2(self):
         cls = builder.extract_node(
             """
@@ -1756,7 +1754,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".C", ".A", ".B", "typing.Generic", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_3(self):
         cls = builder.extract_node(
             """
@@ -1773,7 +1770,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".D", ".B", ".A", ".C", "typing.Generic", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_4(self):
         cls = builder.extract_node(
             """
@@ -1789,7 +1785,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".C", ".A", ".B", "typing.Generic", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_5(self):
         cls = builder.extract_node(
             """
@@ -1806,7 +1801,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".C", ".A", ".B", "typing.Generic", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_6(self):
         cls = builder.extract_node(
             """
@@ -1823,7 +1817,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".C", ".A", ".Generic", ".B", "typing.Generic", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_7(self):
         cls = builder.extract_node(
             """
@@ -1841,7 +1834,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             cls, [".E", ".C", ".A", ".B", "typing.Generic", ".D", "builtins.object"]
         )
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_error_1(self):
         cls = builder.extract_node(
             """
@@ -1855,7 +1847,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         with self.assertRaises(DuplicateBasesError):
             cls.mro()
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_generic_error_2(self):
         cls = builder.extract_node(
             """
@@ -1869,7 +1860,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         with self.assertRaises(DuplicateBasesError):
             cls.mro()
 
-    @test_utils.require_version(minver="3.7")
     def test_mro_typing_extensions(self):
         """Regression test for mro() inference on typing_extesnions.
 
@@ -2544,7 +2534,6 @@ def test_posonlyargs_default_value() -> None:
     assert first_param.value == 1
 
 
-@test_utils.require_version(minver="3.7")
 def test_ancestor_with_generic() -> None:
     # https://github.com/PyCQA/astroid/issues/942
     tree = builder.parse(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310}
 skip_missing_interpreters = true
 
 [testenv:pylint]


### PR DESCRIPTION
## Description
Require Python 3.7.2 to run `astroid`. Partner to https://github.com/PyCQA/pylint/pull/5921.

One benefit of dropping 3.6 is to reduce risk from proposed performance-enhancing changes in #1536, where according to the complicated history of https://github.com/python/cpython/pull/5481 and its (initial?) reversion on 3.6, it is possible that the behavior might vary there.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
