### PR TITLE
Define ``_infer`` instead of ``infer`` on subclasses of ``NodeNG``

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -16,6 +16,7 @@ from typing import (
     Callable,
     ClassVar,
     Generator,
+    Iterator,
     Optional,
     Type,
     TypeVar,
@@ -4876,7 +4877,9 @@ class EvaluatedObject(NodeNG):
             parent=self.original.parent,
         )
 
-    def infer(self, context=None, **kwargs):
+    def _infer(
+        self, context: Optional[InferenceContext] = None
+    ) -> Iterator[Union[NodeNG, Type[util.Uninferable]]]:
         yield self.value
 
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -12,8 +12,10 @@ leads to an inferred FrozenSet:
 """
 
 import sys
+from typing import Iterator, Optional, TypeVar
 
 from astroid import bases, decorators, util
+from astroid.context import InferenceContext
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -29,6 +31,8 @@ if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from astroid.decorators import cachedproperty as cached_property
+
+_T = TypeVar("_T")
 
 
 class FrozenSet(node_classes.BaseContainer):
@@ -324,5 +328,5 @@ class Property(scoped_nodes.FunctionDef):
     def infer_call_result(self, caller=None, context=None):
         raise InferenceError("Properties are not callable")
 
-    def infer(self, context=None, **kwargs):
-        return iter((self,))
+    def _infer(self: _T, context: Optional[InferenceContext] = None) -> Iterator[_T]:
+        yield self


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

`NodeNG.infer` actually handles some of the caching and `context` handling of `infer`. Although perhaps a bit overkill, I think it makes sense to adhere to the pattern of only defining `_infer` (normally done in `inference.py`)  for all of its subclasses.

After this PR only `NodeNG` and `Proxy` have `infer` defined.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue
