### PR TITLE
Prevent special case for `virtualenv`'s patching of `distutils` from catching other submodules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,11 @@ Release date: TBA
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 
+* Fix a bug where in attempting to handle the patching of ``distutils`` by ``virtualenv``,
+  library submodules called ``distutils`` (e.g. ``numpy.distutils``) were included also.
+
+  Refs PyCQA/pylint#6497
+
 
 What's New in astroid 2.11.4?
 =============================

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -153,7 +153,7 @@ class ImportlibFinder(Finder):
                 if os.path.isdir(os.path.join(p, *processed))
             ]
         elif spec.name == "distutils" and not any(
-            spec.location.startswith(ext_lib_dir.lower())
+            spec.location.lower().startswith(ext_lib_dir.lower())
             for ext_lib_dir in EXT_LIB_DIRS
         ):
             # virtualenv below 20.0 patches distutils in an unexpected way

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -153,7 +153,8 @@ class ImportlibFinder(Finder):
                 if os.path.isdir(os.path.join(p, *processed))
             ]
         elif spec.name == "distutils" and not any(
-            spec.location.startswith(ext_lib_dir) for ext_lib_dir in EXT_LIB_DIRS
+            spec.location.startswith(ext_lib_dir.lower())
+            for ext_lib_dir in EXT_LIB_DIRS
         ):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -14,6 +14,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Sequence, Tuple
 
+from astroid.modutils import EXT_LIB_DIRS
+
 from . import util
 
 
@@ -150,7 +152,9 @@ class ImportlibFinder(Finder):
                 for p in sys.path
                 if os.path.isdir(os.path.join(p, *processed))
             ]
-        elif spec.name == "distutils":
+        elif spec.name == "distutils" and not any(
+            spec.location.startswith(ext_lib_dir) for ext_lib_dir in EXT_LIB_DIRS
+        ):
             # virtualenv below 20.0 patches distutils in an unexpected way
             # so we just find the location of distutils that will be
             # imported to avoid spurious import-error messages

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -81,6 +81,19 @@ multiply([1, 2], [3, 4])
         inferred = callfunc.inferred()
         self.assertEqual(len(inferred), 1)
 
+    @unittest.skipUnless(HAS_NUMPY, "Needs numpy")
+    def test_numpy_distutils(self):
+        """Special handling of virtualenv's patching of distutils shouldn't interfere
+        with numpy.distutils"""
+        node = extract_node(
+            """
+from numpy.distutils.misc_util import is_sequence
+is_sequence("ABC") #@
+"""
+        )
+        inferred = node.inferred()
+        self.assertIsInstance(inferred[0], nodes.Const)
+
     def test_nameconstant(self) -> None:
         # used to fail for Python 3.4
         builder = AstroidBuilder()

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -87,7 +87,7 @@ multiply([1, 2], [3, 4])
         with numpy.distutils.
 
         PY312_PLUS -- This test will likely become unnecessary when Python 3.12 is
-        numypy's minimum version. (numpy.distutils will be removed then.)
+        numpy's minimum version. (numpy.distutils will be removed then.)
         """
         node = extract_node(
             """

--- a/tests/unittest_regrtest.py
+++ b/tests/unittest_regrtest.py
@@ -84,7 +84,11 @@ multiply([1, 2], [3, 4])
     @unittest.skipUnless(HAS_NUMPY, "Needs numpy")
     def test_numpy_distutils(self):
         """Special handling of virtualenv's patching of distutils shouldn't interfere
-        with numpy.distutils"""
+        with numpy.distutils.
+
+        PY312_PLUS -- This test will likely become unnecessary when Python 3.12 is
+        numypy's minimum version. (numpy.distutils will be removed then.)
+        """
         node = extract_node(
             """
 from numpy.distutils.misc_util import is_sequence


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Apparently, #1386 traded a false positive created by `virtualenv` for a false positive in `numpy.distutils`. This PR tightens the condition to pass both cases.

The regression test for `virtualenv` has to be manually triggered on PyCQA. So I [tested this](https://github.com/jacobtylerwalls/astroid/runs/6292399587?check_suite_focus=true) on my fork where I could fiddle with the workflow trigger. Or I could push this branch to PyCQA; that might allow us to trigger the workflow on a branch, but not certain.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Refs PyCQA/pylint#6497
