### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -5,6 +5,9 @@ on: workflow_dispatch
 env:
   DEFAULT_PYTHON: 3.8
 
+permissions:
+  contents: read
+
 jobs:
   virtualenv-15-windows-test:
     # Regression test added in https://github.com/PyCQA/astroid/pull/1386

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 env:
   DEFAULT_PYTHON: 3.9
 
+permissions:
+  contents: read
+
 jobs:
   release-pypi:
     name: Upload release to PyPI


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
