### PR TITLE
Fix crash while obtaining `object_type()` of an `Unknown` node

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,7 +28,7 @@ What's New in astroid 2.11.5?
 =============================
 Release date: TBA
 
-* Fix crash while obtaining `object_type()` of an `Unknown` node.
+* Fix crash while obtaining ``object_type()`` of an ``Unknown`` node.
 
   Refs PyCQA/pylint#6539
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -28,7 +28,9 @@ What's New in astroid 2.11.5?
 =============================
 Release date: TBA
 
+* Fix crash while obtaining `object_type()` of an `Unknown` node.
 
+  Refs PyCQA/pylint#6539
 
 
 What's New in astroid 2.11.4?

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -55,6 +55,8 @@ def _object_type(node, context=None):
             yield _function_type(inferred, builtins)
         elif isinstance(inferred, scoped_nodes.Module):
             yield _build_proxy_class("module", builtins)
+        elif isinstance(inferred, nodes.Unknown):
+            raise InferenceError
         else:
             yield inferred._proxied
 

--- a/tests/unittest_helpers.py
+++ b/tests/unittest_helpers.py
@@ -5,7 +5,10 @@
 import builtins
 import unittest
 
+import pytest
+
 from astroid import builder, helpers, manager, nodes, raw_building, util
+from astroid.const import IS_PYPY
 from astroid.exceptions import _NonDeducibleTypeHierarchy
 from astroid.nodes.scoped_nodes import ClassDef
 
@@ -143,6 +146,11 @@ class TestHelpers(unittest.TestCase):
         """
         )
         self.assertEqual(helpers.object_type(node), util.Uninferable)
+
+    @pytest.mark.skipif(IS_PYPY, reason="__code__ will not be Unknown on PyPy")
+    def test_inference_errors_2(self) -> None:
+        node = builder.extract_node("type(float.__new__.__code__)")
+        self.assertIs(helpers.object_type(node), util.Uninferable)
 
     def test_object_type_too_many_types(self) -> None:
         node = builder.extract_node(


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Refs PyCQA/pylint#6539. We might be able to just close the issue, as the test will look identical in `pylint`.
