### PR TITLE
qt brain: Make slot argument optional for disconnect()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ What's New in astroid 2.11.6?
 =============================
 Release date: TBA
 
+* The Qt brain now correctly treats calling ``.disconnect()`` (with no
+  arguments) on a slot as valid.
 
 What's New in astroid 2.11.5?
 =============================

--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -24,10 +24,12 @@ def _looks_like_signal(node, signal_name="pyqtSignal"):
 def transform_pyqt_signal(node: nodes.FunctionDef) -> None:
     module = parse(
         """
+    _UNSET = object()
+
     class pyqtSignal(object):
         def connect(self, slot, type=None, no_receiver_check=False):
             pass
-        def disconnect(self, slot=None):
+        def disconnect(self, slot=_UNSET):
             pass
         def emit(self, *args):
             pass

--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -27,7 +27,7 @@ def transform_pyqt_signal(node: nodes.FunctionDef) -> None:
     class pyqtSignal(object):
         def connect(self, slot, type=None, no_receiver_check=False):
             pass
-        def disconnect(self, slot):
+        def disconnect(self, slot=None):
             pass
         def emit(self, *args):
             pass

--- a/tests/unittest_brain_qt.py
+++ b/tests/unittest_brain_qt.py
@@ -52,3 +52,21 @@ class TestBrainQt:
             pytest.skip("PyQt6 C bindings may not be installed?")
         assert isinstance(attribute_node, FunctionDef)
         assert attribute_node.implicit_parameters() == 1
+
+    @staticmethod
+    def test_slot_disconnect_no_args() -> None:
+        """Test calling .disconnect() on a signal.
+
+        See https://github.com/PyCQA/astroid/pull/1531#issuecomment-1111963792
+        """
+        src = """
+        from PyQt6.QtCore import QTimer
+        timer = QTimer()
+        timer.timeout.disconnect  #@
+        """
+        node = extract_node(src)
+        attribute_node = node.inferred()[0]
+        if attribute_node is Uninferable:
+            pytest.skip("PyQt6 C bindings may not be installed?")
+        assert isinstance(attribute_node, FunctionDef)
+        assert attribute_node.args.defaults


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

~~If this is an acceptable fix, I'll write a changelog~~ - two more questions:

- Is there a good way I can write a test for this?
- Should this go to `main` or to a maintenance branch

## Description

Discussed here:
https://github.com/PyCQA/astroid/pull/1531#issuecomment-1111963792

PyQt supports calling .disconnect() without any arguments in order to
disconnect all slots:
https://www.riverbankcomputing.com/static/Docs/PyQt6/signals_slots.html#disconnect

Strictly speaking, slot=None is a wrong call, as actually passing None
does not work:
https://github.com/python-qt-tools/PyQt5-stubs/pull/103

However, pylint/astroid does not support overloads needed to properly
express this: https://github.com/PyCQA/pylint/issues/5264

So, while this is "wrong", it's less wrong than before - without this
change, pylint expects a mandatory argument, thus raising a
false-positive here:

```python
from PyQt5.QtCore import QTimer
t = QTimer()
t.timeout.connect(lambda: None)
t.timeout.disconnect()
```

despite running fine, pylint complains:

    test.py:4:0: E1120: No value for argument 'slot' in method call (no-value-for-parameter)

while with this change, things work fine.


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
