### PR TITLE
Update typing for Python 3.7 (1)

### DIFF
--- a/astroid/_ast.py
+++ b/astroid/_ast.py
@@ -2,17 +2,19 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import ast
 import sys
 import types
 from functools import partial
-from typing import Dict, List, NamedTuple, Optional, Type
+from typing import NamedTuple
 
 from astroid.const import PY38_PLUS, Context
 
 if sys.version_info >= (3, 8):
     # On Python 3.8, typed_ast was merged back into `ast`
-    _ast_py3: Optional[types.ModuleType] = ast
+    _ast_py3: types.ModuleType | None = ast
 else:
     try:
         import typed_ast.ast3 as _ast_py3
@@ -21,17 +23,17 @@ else:
 
 
 class FunctionType(NamedTuple):
-    argtypes: List[ast.expr]
+    argtypes: list[ast.expr]
     returns: ast.expr
 
 
 class ParserModule(NamedTuple):
     module: types.ModuleType
-    unary_op_classes: Dict[Type[ast.unaryop], str]
-    cmp_op_classes: Dict[Type[ast.cmpop], str]
-    bool_op_classes: Dict[Type[ast.boolop], str]
-    bin_op_classes: Dict[Type[ast.operator], str]
-    context_classes: Dict[Type[ast.expr_context], Context]
+    unary_op_classes: dict[type[ast.unaryop], str]
+    cmp_op_classes: dict[type[ast.cmpop], str]
+    bool_op_classes: dict[type[ast.boolop], str]
+    bin_op_classes: dict[type[ast.operator], str]
+    context_classes: dict[type[ast.expr_context], Context]
 
     def parse(self, string: str, type_comments: bool = True) -> ast.Module:
         if self.module is _ast_py3:
@@ -46,7 +48,7 @@ class ParserModule(NamedTuple):
         return parse_func(string)
 
 
-def parse_function_type_comment(type_comment: str) -> Optional[FunctionType]:
+def parse_function_type_comment(type_comment: str) -> FunctionType | None:
     """Given a correct type comment, obtain a FunctionType object"""
     if _ast_py3 is None:
         return None
@@ -78,13 +80,13 @@ def get_parser_module(type_comments: bool = True) -> ParserModule:
 
 def _unary_operators_from_module(
     module: types.ModuleType,
-) -> Dict[Type[ast.unaryop], str]:
+) -> dict[type[ast.unaryop], str]:
     return {module.UAdd: "+", module.USub: "-", module.Not: "not", module.Invert: "~"}
 
 
 def _binary_operators_from_module(
     module: types.ModuleType,
-) -> Dict[Type[ast.operator], str]:
+) -> dict[type[ast.operator], str]:
     binary_operators = {
         module.Add: "+",
         module.BitAnd: "&",
@@ -105,13 +107,13 @@ def _binary_operators_from_module(
 
 def _bool_operators_from_module(
     module: types.ModuleType,
-) -> Dict[Type[ast.boolop], str]:
+) -> dict[type[ast.boolop], str]:
     return {module.And: "and", module.Or: "or"}
 
 
 def _compare_operators_from_module(
     module: types.ModuleType,
-) -> Dict[Type[ast.cmpop], str]:
+) -> dict[type[ast.cmpop], str]:
     return {
         module.Eq: "==",
         module.Gt: ">",
@@ -128,7 +130,7 @@ def _compare_operators_from_module(
 
 def _contexts_from_module(
     module: types.ModuleType,
-) -> Dict[Type[ast.expr_context], Context]:
+) -> dict[type[ast.expr_context], Context]:
     return {
         module.Load: Context.Load,
         module.Store: Context.Store,

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-from typing import Optional, Set
+from __future__ import annotations
 
 from astroid import nodes
 from astroid.bases import Instance
@@ -36,7 +36,7 @@ class CallSite:
         self.argument_context_map = argument_context_map
         args = callcontext.args
         keywords = callcontext.keywords
-        self.duplicated_keywords: Set[str] = set()
+        self.duplicated_keywords: set[str] = set()
         self._unpacked_args = self._unpack_args(args, context=context)
         self._unpacked_kwargs = self._unpack_keywords(keywords, context=context)
 
@@ -50,7 +50,7 @@ class CallSite:
         }
 
     @classmethod
-    def from_call(cls, call_node, context: Optional[InferenceContext] = None):
+    def from_call(cls, call_node, context: InferenceContext | None = None):
         """Get a CallSite object from the given Call node.
 
         context will be used to force a single inference path.

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -3,10 +3,11 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for various builtins."""
+from __future__ import annotations
 
 import itertools
 from functools import partial
-from typing import Iterator, Optional
+from typing import Iterator
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder
@@ -534,7 +535,7 @@ def infer_callable(node, context=None):
 
 
 def infer_property(
-    node: nodes.Call, context: Optional[InferenceContext] = None
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> objects.Property:
     """Understand `property` class
 
@@ -894,7 +895,7 @@ def infer_dict_fromkeys(node, context=None):
 
 
 def _infer_copy_method(
-    node: nodes.Call, context: Optional[InferenceContext] = None
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> Iterator[nodes.NodeNG]:
     assert isinstance(node.func, nodes.Attribute)
     inferred_orig, inferred_copy = itertools.tee(node.func.expr.infer(context=context))

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for various builtins."""
+
 from __future__ import annotations
 
 import itertools

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -12,8 +12,10 @@ dataclasses. References:
 - https://lovasoa.github.io/marshmallow_dataclass/
 
 """
+from __future__ import annotations
+
 import sys
-from typing import FrozenSet, Generator, List, Optional, Tuple, Union
+from typing import Generator, Tuple, Union
 
 from astroid import context, inference_tip
 from astroid.builder import parse
@@ -179,7 +181,7 @@ def _check_generate_dataclass_init(node: ClassDef) -> bool:
     )
 
 
-def _generate_dataclass_init(assigns: List[AnnAssign]) -> str:
+def _generate_dataclass_init(assigns: list[AnnAssign]) -> str:
     """Return an init method for a dataclass given the targets."""
     target_names = []
     params = []
@@ -234,7 +236,7 @@ def _generate_dataclass_init(assigns: List[AnnAssign]) -> str:
 
 
 def infer_dataclass_attribute(
-    node: Unknown, ctx: Optional[context.InferenceContext] = None
+    node: Unknown, ctx: context.InferenceContext | None = None
 ) -> Generator:
     """Inference tip for an Unknown node that was dynamically generated to
     represent a dataclass attribute.
@@ -257,7 +259,7 @@ def infer_dataclass_attribute(
 
 
 def infer_dataclass_field_call(
-    node: Call, ctx: Optional[context.InferenceContext] = None
+    node: Call, ctx: context.InferenceContext | None = None
 ) -> Generator:
     """Inference tip for dataclass field calls."""
     if not isinstance(node.parent, (AnnAssign, Assign)):
@@ -276,7 +278,7 @@ def infer_dataclass_field_call(
 
 
 def _looks_like_dataclass_decorator(
-    node: NodeNG, decorator_names: FrozenSet[str] = DATACLASSES_DECORATORS
+    node: NodeNG, decorator_names: frozenset[str] = DATACLASSES_DECORATORS
 ) -> bool:
     """Return True if node looks like a dataclass decorator.
 
@@ -423,7 +425,7 @@ _INFERABLE_TYPING_TYPES = frozenset(
 
 
 def _infer_instance_from_annotation(
-    node: NodeNG, ctx: Optional[context.InferenceContext] = None
+    node: NodeNG, ctx: context.InferenceContext | None = None
 ) -> Generator:
     """Infer an instance corresponding to the type annotation represented by node.
 

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -12,6 +12,7 @@ dataclasses. References:
 - https://lovasoa.github.io/marshmallow_dataclass/
 
 """
+
 from __future__ import annotations
 
 import sys

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for understanding functools library module."""
+
 from __future__ import annotations
 
 from functools import partial

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -3,9 +3,11 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for understanding functools library module."""
+from __future__ import annotations
+
 from functools import partial
 from itertools import chain
-from typing import Iterator, Optional
+from typing import Iterator
 
 from astroid import BoundMethod, arguments, extract_node, helpers, nodes, objects
 from astroid.context import InferenceContext
@@ -63,7 +65,7 @@ def _transform_lru_cache(node, context=None) -> None:
 
 
 def _functools_partial_inference(
-    node: nodes.Call, context: Optional[InferenceContext] = None
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> Iterator[objects.PartialFunction]:
     call = arguments.CallSite.from_call(node, context=context)
     number_of_positional = len(call.positional_arguments)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -3,11 +3,12 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for the Python standard library."""
+from __future__ import annotations
 
 import functools
 import keyword
 from textwrap import dedent
-from typing import Iterator, List, Optional, Tuple
+from typing import Iterator
 
 import astroid
 from astroid import arguments, inference_tip, nodes, util
@@ -71,9 +72,9 @@ def _find_func_form_arguments(node, context):
 def infer_func_form(
     node: nodes.Call,
     base_type: nodes.NodeNG,
-    context: Optional[InferenceContext] = None,
+    context: InferenceContext | None = None,
     enum: bool = False,
-) -> Tuple[nodes.ClassDef, str, List[str]]:
+) -> tuple[nodes.ClassDef, str, list[str]]:
     """Specific inference function for namedtuple or Python 3 enum."""
     # node is a Call node, class name as first argument and generated class
     # attributes as second argument
@@ -177,7 +178,7 @@ _looks_like_typing_namedtuple = functools.partial(_looks_like, name="NamedTuple"
 
 
 def infer_named_tuple(
-    node: nodes.Call, context: Optional[InferenceContext] = None
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> Iterator[nodes.ClassDef]:
     """Specific inference function for namedtuple Call node"""
     tuple_base_name = nodes.Name(name="tuple", parent=node.root())
@@ -503,7 +504,7 @@ def infer_typing_namedtuple_function(node, context=None):
 
 
 def infer_typing_namedtuple(
-    node: nodes.Call, context: Optional[InferenceContext] = None
+    node: nodes.Call, context: InferenceContext | None = None
 ) -> Iterator[nodes.ClassDef]:
     """Infer a typing.NamedTuple(...) call."""
     # This is essentially a namedtuple with different arguments

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for the Python standard library."""
+
 from __future__ import annotations
 
 import functools

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -3,7 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Different utilities for the numpy brains"""
-from typing import Tuple
+from __future__ import annotations
 
 from astroid.builder import extract_node
 from astroid.nodes.node_classes import Attribute, Import, Name, NodeNG
@@ -20,7 +20,7 @@ def numpy_supports_type_hints() -> bool:
     return np_ver and np_ver > NUMPY_VERSION_TYPE_HINTS_SUPPORT
 
 
-def _get_numpy_version() -> Tuple[str, str, str]:
+def _get_numpy_version() -> tuple[str, str, str]:
     """
     Return the numpy version number if numpy can be imported. Otherwise returns
     ('0', '0', '0')

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Different utilities for the numpy brains"""
+
 from __future__ import annotations
 
 from astroid.builder import extract_node

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -2,7 +2,7 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-from typing import Optional
+from __future__ import annotations
 
 from astroid import context, inference_tip, nodes
 from astroid.brain.helpers import register_module_extender
@@ -74,9 +74,7 @@ def _looks_like_pattern_or_match(node: nodes.Call) -> bool:
     )
 
 
-def infer_pattern_match(
-    node: nodes.Call, ctx: Optional[context.InferenceContext] = None
-):
+def infer_pattern_match(node: nodes.Call, ctx: context.InferenceContext | None = None):
     """Infer re.Pattern and re.Match as classes. For PY39+ add `__class_getitem__`."""
     class_def = nodes.ClassDef(
         name=node.parent.targets[0].name,

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for typing.py support."""
+
 from __future__ import annotations
 
 import typing

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -3,6 +3,8 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for typing.py support."""
+from __future__ import annotations
+
 import typing
 from functools import partial
 
@@ -140,7 +142,7 @@ def _looks_like_typing_subscript(node):
 
 
 def infer_typing_attr(
-    node: Subscript, ctx: typing.Optional[context.InferenceContext] = None
+    node: Subscript, ctx: context.InferenceContext | None = None
 ) -> typing.Iterator[ClassDef]:
     """Infer a typing.X[...] subscript"""
     try:
@@ -179,14 +181,14 @@ def infer_typing_attr(
 
 
 def _looks_like_typedDict(  # pylint: disable=invalid-name
-    node: typing.Union[FunctionDef, ClassDef],
+    node: FunctionDef | ClassDef,
 ) -> bool:
     """Check if node is TypedDict FunctionDef."""
     return node.qname() in {"typing.TypedDict", "typing_extensions.TypedDict"}
 
 
 def infer_old_typedDict(  # pylint: disable=invalid-name
-    node: ClassDef, ctx: typing.Optional[context.InferenceContext] = None
+    node: ClassDef, ctx: context.InferenceContext | None = None
 ) -> typing.Iterator[ClassDef]:
     func_to_add = _extract_single_node("dict")
     node.locals["__call__"] = [func_to_add]
@@ -194,7 +196,7 @@ def infer_old_typedDict(  # pylint: disable=invalid-name
 
 
 def infer_typedDict(  # pylint: disable=invalid-name
-    node: FunctionDef, ctx: typing.Optional[context.InferenceContext] = None
+    node: FunctionDef, ctx: context.InferenceContext | None = None
 ) -> typing.Iterator[ClassDef]:
     """Replace TypedDict FunctionDef with ClassDef."""
     class_def = ClassDef(
@@ -254,7 +256,7 @@ def _forbid_class_getitem_access(node: ClassDef) -> None:
 
 
 def infer_typing_alias(
-    node: Call, ctx: typing.Optional[context.InferenceContext] = None
+    node: Call, ctx: context.InferenceContext | None = None
 ) -> typing.Iterator[ClassDef]:
     """
     Infers the call to _alias function
@@ -342,7 +344,7 @@ def _looks_like_special_alias(node: Call) -> bool:
 
 
 def infer_special_alias(
-    node: Call, ctx: typing.Optional[context.InferenceContext] = None
+    node: Call, ctx: context.InferenceContext | None = None
 ) -> typing.Iterator[ClassDef]:
     """Infer call to tuple alias as new subscriptable class typing.Tuple."""
     if not (
@@ -377,7 +379,7 @@ def _looks_like_typing_cast(node: Call) -> bool:
 
 
 def infer_typing_cast(
-    node: Call, ctx: typing.Optional[context.InferenceContext] = None
+    node: Call, ctx: context.InferenceContext | None = None
 ) -> typing.Iterator[NodeNG]:
     """Infer call to cast() returning same type as casted-from var"""
     if not isinstance(node.func, (Name, Attribute)):

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -7,11 +7,12 @@
 The builder is not thread safe and can't be used to parse different sources
 at the same time.
 """
+from __future__ import annotations
+
 import os
 import textwrap
 import types
 from tokenize import detect_encoding
-from typing import List, Optional, Tuple, Union
 
 from astroid import bases, modutils, nodes, raw_building, rebuilder, util
 from astroid._ast import get_parser_module
@@ -68,7 +69,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
         self._apply_transforms = apply_transforms
 
     def module_build(
-        self, module: types.ModuleType, modname: Optional[str] = None
+        self, module: types.ModuleType, modname: str | None = None
     ) -> nodes.Module:
         """Build an astroid from a living module instance."""
         node = None
@@ -162,7 +163,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
 
     def _data_build(
         self, data: str, modname, path
-    ) -> Tuple[nodes.Module, rebuilder.TreeRebuilder]:
+    ) -> tuple[nodes.Module, rebuilder.TreeRebuilder]:
         """Build tree node from data and add some informations"""
         try:
             node, parser_module = _parse_string(data, type_comments=True)
@@ -260,7 +261,7 @@ class AstroidBuilder(raw_building.InspectBuilder):
             pass
 
 
-def build_namespace_package_module(name: str, path: List[str]) -> nodes.Module:
+def build_namespace_package_module(name: str, path: list[str]) -> nodes.Module:
     return nodes.Module(name, path=path, package=True)
 
 
@@ -355,7 +356,7 @@ def _find_statement_by_line(node, line):
     return None
 
 
-def extract_node(code: str, module_name: str = "") -> Union[NodeNG, List[NodeNG]]:
+def extract_node(code: str, module_name: str = "") -> NodeNG | list[NodeNG]:
     """Parses some Python code as a module and extracts a designated AST node.
 
     Statements:

--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -7,6 +7,7 @@
 The builder is not thread safe and can't be used to parse different sources
 at the same time.
 """
+
 from __future__ import annotations
 
 import os

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Various context related utilities, including inference and call contexts."""
+
 from __future__ import annotations
 
 import contextlib

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -3,9 +3,11 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Various context related utilities, including inference and call contexts."""
+from __future__ import annotations
+
 import contextlib
 import pprint
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     from astroid.nodes.node_classes import Keyword, NodeNG
@@ -157,9 +159,9 @@ class CallContext:
 
     def __init__(
         self,
-        args: List["NodeNG"],
-        keywords: Optional[List["Keyword"]] = None,
-        callee: Optional["NodeNG"] = None,
+        args: list[NodeNG],
+        keywords: list[Keyword] | None = None,
+        callee: NodeNG | None = None,
     ):
         self.args = args  # Call positional arguments
         if keywords:
@@ -170,7 +172,7 @@ class CallContext:
         self.callee = callee  # Function being called
 
 
-def copy_context(context: Optional[InferenceContext]) -> InferenceContext:
+def copy_context(context: InferenceContext | None) -> InferenceContext:
     """Clone a context if given, or return a fresh contexxt"""
     if context is not None:
         return context.clone()

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -4,6 +4,7 @@
 
 """this module contains exceptions used in the astroid library
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/astroid/exceptions.py
+++ b/astroid/exceptions.py
@@ -4,6 +4,8 @@
 
 """this module contains exceptions used in the astroid library
 """
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from astroid import util
@@ -258,7 +260,7 @@ class ParentMissingError(AstroidError):
         target: The node for which the parent lookup failed.
     """
 
-    def __init__(self, target: "nodes.NodeNG") -> None:
+    def __init__(self, target: nodes.NodeNG) -> None:
         self.target = target
         super().__init__(message=f"Parent not found on {target!r}.")
 
@@ -272,7 +274,7 @@ class StatementMissing(ParentMissingError):
         target: The node for which the parent lookup failed.
     """
 
-    def __init__(self, target: "nodes.NodeNG") -> None:
+    def __init__(self, target: nodes.NodeNG) -> None:
         # pylint: disable-next=bad-super-call
         # https://github.com/PyCQA/pylint/issues/2903
         # https://github.com/PyCQA/astroid/pull/1217#discussion_r744149027

--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -5,15 +5,14 @@
 """_filter_stmts and helper functions. This method gets used in LocalsDictnodes.NodeNG._scope_lookup.
 It is not considered public.
 """
-
-from typing import List, Optional, Tuple
+from __future__ import annotations
 
 from astroid import nodes
 
 
 def _get_filtered_node_statements(
-    base_node: nodes.NodeNG, stmt_nodes: List[nodes.NodeNG]
-) -> List[Tuple[nodes.NodeNG, nodes.Statement]]:
+    base_node: nodes.NodeNG, stmt_nodes: list[nodes.NodeNG]
+) -> list[tuple[nodes.NodeNG, nodes.Statement]]:
     statements = [(node, node.statement(future=True)) for node in stmt_nodes]
     # Next we check if we have ExceptHandlers that are parent
     # of the underlying variable, in which case the last one survives
@@ -31,7 +30,7 @@ def _is_from_decorator(node):
     return any(isinstance(parent, nodes.Decorators) for parent in node.node_ancestors())
 
 
-def _get_if_statement_ancestor(node: nodes.NodeNG) -> Optional[nodes.If]:
+def _get_if_statement_ancestor(node: nodes.NodeNG) -> nodes.If | None:
     """Return the first parent node that is an If node (or None)"""
     for parent in node.node_ancestors():
         if isinstance(parent, nodes.If):
@@ -85,7 +84,7 @@ def _filter_stmts(base_node: nodes.NodeNG, stmts, frame, offset):
         ):
             myframe = myframe.parent.frame()
 
-    mystmt: Optional[nodes.Statement] = None
+    mystmt: nodes.Statement | None = None
     if base_node.parent:
         mystmt = base_node.statement(future=True)
 

--- a/astroid/filter_statements.py
+++ b/astroid/filter_statements.py
@@ -5,6 +5,7 @@
 """_filter_stmts and helper functions. This method gets used in LocalsDictnodes.NodeNG._scope_lookup.
 It is not considered public.
 """
+
 from __future__ import annotations
 
 from astroid import nodes

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -4,6 +4,7 @@
 
 """this module contains a set of functions to handle inference on astroid trees
 """
+
 from __future__ import annotations
 
 import ast

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -4,24 +4,13 @@
 
 """this module contains a set of functions to handle inference on astroid trees
 """
+from __future__ import annotations
 
 import ast
 import functools
 import itertools
 import operator
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterable,
-    Iterator,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Iterator, TypeVar
 
 from astroid import bases, decorators, helpers, nodes, protocols, util
 from astroid.context import (
@@ -791,7 +780,7 @@ def infer_binop(self, context=None):
 nodes.BinOp._infer_binop = _infer_binop
 nodes.BinOp._infer = infer_binop
 
-COMPARE_OPS: Dict[str, Callable[[Any, Any], bool]] = {
+COMPARE_OPS: dict[str, Callable[[Any, Any], bool]] = {
     "==": operator.eq,
     "!=": operator.ne,
     "<": operator.lt,
@@ -816,7 +805,7 @@ def _to_literal(node: nodes.NodeNG) -> Any:
 
 def _do_compare(
     left_iter: Iterable[nodes.NodeNG], op: str, right_iter: Iterable[nodes.NodeNG]
-) -> "bool | type[util.Uninferable]":
+) -> bool | type[util.Uninferable]:
     """
     If all possible combinations are either True or False, return that:
     >>> _do_compare([1, 2], '<=', [3, 4])
@@ -829,7 +818,7 @@ def _do_compare(
     >>> _do_compare([1, 3], '<=', [2, 4])
     util.Uninferable
     """
-    retval: Union[None, bool] = None
+    retval: bool | None = None
     if op in UNINFERABLE_OPS:
         return util.Uninferable
     op_func = COMPARE_OPS[op]
@@ -859,10 +848,10 @@ def _do_compare(
 
 
 def _infer_compare(
-    self: nodes.Compare, context: Optional[InferenceContext] = None
-) -> Iterator[Union[nodes.Const, Type[util.Uninferable]]]:
+    self: nodes.Compare, context: InferenceContext | None = None
+) -> Iterator[nodes.Const | type[util.Uninferable]]:
     """Chained comparison inference logic."""
-    retval: Union[bool, Type[util.Uninferable]] = True
+    retval: bool | type[util.Uninferable] = True
 
     ops = self.ops
     left_node = self.left
@@ -1036,8 +1025,8 @@ nodes.IfExp._infer = infer_ifexp  # type: ignore[assignment]
 
 
 def infer_functiondef(
-    self: _FunctionDefT, context: Optional[InferenceContext] = None
-) -> Generator[Union["Property", _FunctionDefT], None, InferenceErrorInfo]:
+    self: _FunctionDefT, context: InferenceContext | None = None
+) -> Generator[Property | _FunctionDefT, None, InferenceErrorInfo]:
     if not self.decorators or not bases._is_property(self):
         yield self
         return InferenceErrorInfo(node=self, context=context)

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Transform utilities (filters and decorator)"""
+
 from __future__ import annotations
 
 import typing

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Transform utilities (filters and decorator)"""
+from __future__ import annotations
 
 import typing
 
@@ -17,9 +18,7 @@ InferOptions = typing.Union[
     NodeNG, bases.Instance, bases.UnboundMethod, typing.Type[util.Uninferable]
 ]
 
-_cache: typing.Dict[
-    typing.Tuple[InferFn, NodeNG], typing.Optional[typing.List[InferOptions]]
-] = {}
+_cache: dict[tuple[InferFn, NodeNG], list[InferOptions] | None] = {}
 
 
 def clear_inference_tip_cache():

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -2,6 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import abc
 import enum
 import importlib
@@ -12,7 +14,7 @@ import sys
 import zipimport
 from functools import lru_cache
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Sequence, Tuple
+from typing import NamedTuple, Sequence
 
 from astroid.modutils import EXT_LIB_DIRS
 
@@ -43,9 +45,9 @@ class ModuleSpec(NamedTuple):
 
     name: str
     type: ModuleType
-    location: "str | None" = None
-    origin: "str | None" = None
-    submodule_search_locations: "Sequence[str] | None" = None
+    location: str | None = None
+    origin: str | None = None
+    submodule_search_locations: Sequence[str] | None = None
 
 
 class Finder:
@@ -58,10 +60,10 @@ class Finder:
     def find_module(
         self,
         modname: str,
-        module_parts: List[str],
-        processed: List[str],
-        submodule_path: Optional[List[str]],
-    ) -> Optional[ModuleSpec]:
+        module_parts: list[str],
+        processed: list[str],
+        submodule_path: list[str] | None,
+    ) -> ModuleSpec | None:
         """Find the given module
 
         Each finder is responsible for each protocol of finding, as long as
@@ -86,7 +88,7 @@ class Finder:
 class ImportlibFinder(Finder):
     """A finder based on the importlib module."""
 
-    _SUFFIXES: Sequence[Tuple[str, ModuleType]] = (
+    _SUFFIXES: Sequence[tuple[str, ModuleType]] = (
         [(s, ModuleType.C_EXTENSION) for s in importlib.machinery.EXTENSION_SUFFIXES]
         + [(s, ModuleType.PY_SOURCE) for s in importlib.machinery.SOURCE_SUFFIXES]
         + [(s, ModuleType.PY_COMPILED) for s in importlib.machinery.BYTECODE_SUFFIXES]
@@ -95,10 +97,10 @@ class ImportlibFinder(Finder):
     def find_module(
         self,
         modname: str,
-        module_parts: List[str],
-        processed: List[str],
-        submodule_path: Optional[List[str]],
-    ) -> Optional[ModuleSpec]:
+        module_parts: list[str],
+        processed: list[str],
+        submodule_path: list[str] | None,
+    ) -> ModuleSpec | None:
         if submodule_path is not None:
             submodule_path = list(submodule_path)
         else:

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -20,13 +20,14 @@ the model will be requested to return the corresponding value of that
 attribute. Thus the model can be viewed as a special part of the lookup
 mechanism.
 """
+from __future__ import annotations
 
 import itertools
 import os
 import pprint
 import types
 from functools import lru_cache
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import util
@@ -102,7 +103,7 @@ class ObjectModel:
         return name in self.attributes()
 
     @lru_cache()  # noqa
-    def attributes(self) -> List[str]:
+    def attributes(self) -> list[str]:
         """Get the attributes which are exported by this object model."""
         return [o[LEN_OF_IMPL_PREFIX:] for o in dir(self) if o.startswith(IMPL_PREFIX)]
 
@@ -809,7 +810,7 @@ class PropertyModel(ObjectModel):
 
         func = self._instance
 
-        def find_setter(func: "Property") -> Optional[astroid.FunctionDef]:
+        def find_setter(func: Property) -> astroid.FunctionDef | None:
             """
             Given a property, find the corresponding setter function and returns it.
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -20,6 +20,7 @@ the model will be requested to return the corresponding value of that
 attribute. Thus the model can be viewed as a special part of the lookup
 mechanism.
 """
+
 from __future__ import annotations
 
 import itertools

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -6,6 +6,7 @@
 possible by providing a class responsible to get astroid representation
 from various source and using a cache of built modules)
 """
+
 from __future__ import annotations
 
 import os

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -6,12 +6,13 @@
 possible by providing a class responsible to get astroid representation
 from various source and using a cache of built modules)
 """
+from __future__ import annotations
 
 import os
 import types
 import zipimport
 from importlib.util import find_spec, module_from_spec
-from typing import TYPE_CHECKING, ClassVar, List, Optional
+from typing import TYPE_CHECKING, ClassVar
 
 from astroid.const import BRAIN_MODULES_DIRECTORY
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
@@ -129,7 +130,7 @@ class AstroidManager:
 
         return AstroidBuilder(self).string_build("", modname)
 
-    def _build_namespace_module(self, modname: str, path: List[str]) -> "nodes.Module":
+    def _build_namespace_module(self, modname: str, path: list[str]) -> nodes.Module:
         # pylint: disable=import-outside-toplevel; circular import
         from astroid.builder import build_namespace_package_module
 
@@ -262,7 +263,7 @@ class AstroidManager:
             raise value.with_traceback(None)
         return value
 
-    def ast_from_module(self, module: types.ModuleType, modname: Optional[str] = None):
+    def ast_from_module(self, module: types.ModuleType, modname: str | None = None):
         """given an imported module, return the astroid object"""
         modname = modname or module.__name__
         if modname in self.astroid_cache:

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -4,9 +4,11 @@
 
 """This module contains some mixins for the different nodes.
 """
+from __future__ import annotations
+
 import itertools
 import sys
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from astroid import decorators
 from astroid.exceptions import AttributeInferenceError
@@ -43,7 +45,7 @@ class BlockRangeMixIn:
 class FilterStmtsMixin:
     """Mixin for statement filtering and assignment type"""
 
-    def _get_filtered_stmts(self, _, node, _stmts, mystmt: Optional["nodes.Statement"]):
+    def _get_filtered_stmts(self, _, node, _stmts, mystmt: nodes.Statement | None):
         """method used in _filter_stmts to get statements and trigger break"""
         if self.statement(future=True) is mystmt:
             # original node's statement is the assignment, only keep
@@ -60,7 +62,7 @@ class AssignTypeMixin:
         return self
 
     def _get_filtered_stmts(
-        self, lookup_node, node, _stmts, mystmt: Optional["nodes.Statement"]
+        self, lookup_node, node, _stmts, mystmt: nodes.Statement | None
     ):
         """method used in filter_stmts"""
         if self is mystmt:

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -4,6 +4,7 @@
 
 """This module contains some mixins for the different nodes.
 """
+
 from __future__ import annotations
 
 import itertools

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -13,6 +13,7 @@
 :type BUILTIN_MODULES: dict
 :var BUILTIN_MODULES: dictionary with builtin module names has key
 """
+
 from __future__ import annotations
 
 import importlib

--- a/astroid/modutils.py
+++ b/astroid/modutils.py
@@ -13,6 +13,7 @@
 :type BUILTIN_MODULES: dict
 :var BUILTIN_MODULES: dictionary with builtin module names has key
 """
+from __future__ import annotations
 
 import importlib
 import importlib.machinery
@@ -24,7 +25,6 @@ import sysconfig
 import types
 from functools import lru_cache
 from pathlib import Path
-from typing import Set
 
 from astroid.const import IS_JYTHON, IS_PYPY
 from astroid.interpreter._import import spec, util
@@ -611,7 +611,7 @@ def is_directory(specobj):
 
 
 def is_module_name_part_of_extension_package_whitelist(
-    module_name: str, package_whitelist: Set[str]
+    module_name: str, package_whitelist: set[str]
 ) -> bool:
     """
     Returns True if one part of the module name is in the package whitelist

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -3,7 +3,9 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """This module renders Astroid nodes as string"""
-from typing import TYPE_CHECKING, List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from astroid.nodes import Const
@@ -38,7 +40,7 @@ class AsStringVisitor:
         """Makes this visitor behave as a simple function"""
         return node.accept(self).replace(DOC_NEWLINE, "\n")
 
-    def _docs_dedent(self, doc_node: Optional["Const"]) -> str:
+    def _docs_dedent(self, doc_node: Const | None) -> str:
         """Stop newlines in docs being indented by self._stmt_list"""
         if not doc_node:
             return ""
@@ -540,11 +542,11 @@ class AsStringVisitor:
         """return Starred node as string"""
         return "*" + node.value.accept(self)
 
-    def visit_match(self, node: "Match") -> str:
+    def visit_match(self, node: Match) -> str:
         """Return an astroid.Match node as string."""
         return f"match {node.subject.accept(self)}:\n{self._stmt_list(node.cases)}"
 
-    def visit_matchcase(self, node: "MatchCase") -> str:
+    def visit_matchcase(self, node: MatchCase) -> str:
         """Return an astroid.MatchCase node as string."""
         guard_str = f" if {node.guard.accept(self)}" if node.guard else ""
         return (
@@ -552,24 +554,24 @@ class AsStringVisitor:
             f"{self._stmt_list(node.body)}"
         )
 
-    def visit_matchvalue(self, node: "MatchValue") -> str:
+    def visit_matchvalue(self, node: MatchValue) -> str:
         """Return an astroid.MatchValue node as string."""
         return node.value.accept(self)
 
     @staticmethod
-    def visit_matchsingleton(node: "MatchSingleton") -> str:
+    def visit_matchsingleton(node: MatchSingleton) -> str:
         """Return an astroid.MatchSingleton node as string."""
         return str(node.value)
 
-    def visit_matchsequence(self, node: "MatchSequence") -> str:
+    def visit_matchsequence(self, node: MatchSequence) -> str:
         """Return an astroid.MatchSequence node as string."""
         if node.patterns is None:
             return "[]"
         return f"[{', '.join(p.accept(self) for p in node.patterns)}]"
 
-    def visit_matchmapping(self, node: "MatchMapping") -> str:
+    def visit_matchmapping(self, node: MatchMapping) -> str:
         """Return an astroid.MatchMapping node as string."""
-        mapping_strings: List[str] = []
+        mapping_strings: list[str] = []
         if node.keys and node.patterns:
             mapping_strings.extend(
                 f"{key.accept(self)}: {p.accept(self)}"
@@ -579,11 +581,11 @@ class AsStringVisitor:
             mapping_strings.append(f"**{node.rest.accept(self)}")
         return f"{'{'}{', '.join(mapping_strings)}{'}'}"
 
-    def visit_matchclass(self, node: "MatchClass") -> str:
+    def visit_matchclass(self, node: MatchClass) -> str:
         """Return an astroid.MatchClass node as string."""
         if node.cls is None:
             raise Exception(f"{node} does not have a 'cls' node")
-        class_strings: List[str] = []
+        class_strings: list[str] = []
         if node.patterns:
             class_strings.extend(p.accept(self) for p in node.patterns)
         if node.kwd_attrs and node.kwd_patterns:
@@ -591,11 +593,11 @@ class AsStringVisitor:
                 class_strings.append(f"{attr}={pattern.accept(self)}")
         return f"{node.cls.accept(self)}({', '.join(class_strings)})"
 
-    def visit_matchstar(self, node: "MatchStar") -> str:
+    def visit_matchstar(self, node: MatchStar) -> str:
         """Return an astroid.MatchStar node as string."""
         return f"*{node.name.accept(self) if node.name else '_'}"
 
-    def visit_matchas(self, node: "MatchAs") -> str:
+    def visit_matchas(self, node: MatchAs) -> str:
         """Return an astroid.MatchAs node as string."""
         # pylint: disable=import-outside-toplevel
         # Prevent circular dependency
@@ -608,7 +610,7 @@ class AsStringVisitor:
             f"{f' as {node.name.accept(self)}' if node.name else ''}"
         )
 
-    def visit_matchor(self, node: "MatchOr") -> str:
+    def visit_matchor(self, node: MatchOr) -> str:
         """Return an astroid.MatchOr node as string."""
         if node.patterns is None:
             raise Exception(f"{node} does not have pattern nodes")
@@ -631,7 +633,7 @@ class AsStringVisitor:
     def visit_evaluatedobject(self, node):
         return node.original.accept(self)
 
-    def visit_unknown(self, node: "Unknown") -> str:
+    def visit_unknown(self, node: Unknown) -> str:
         return str(node)
 
 

--- a/astroid/nodes/as_string.py
+++ b/astroid/nodes/as_string.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """This module renders Astroid nodes as string"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Module for some node classes. More nodes in scoped_nodes.py"""
+
 from __future__ import annotations
 
 import abc

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Module for some node classes. More nodes in scoped_nodes.py"""
+from __future__ import annotations
 
 import abc
 import itertools
@@ -18,7 +19,6 @@ from typing import (
     Generator,
     Iterator,
     Optional,
-    Type,
     TypeVar,
     Union,
 )
@@ -98,7 +98,7 @@ def unpack_infer(stmt, context=None):
     return dict(node=stmt, context=context)
 
 
-def are_exclusive(stmt1, stmt2, exceptions: Optional[typing.List[str]] = None) -> bool:
+def are_exclusive(stmt1, stmt2, exceptions: list[str] | None = None) -> bool:
     """return true if the two given statements are mutually exclusive
 
     `exceptions` may be a list of exception names. If specified, discard If
@@ -281,12 +281,12 @@ class BaseContainer(
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -301,7 +301,7 @@ class BaseContainer(
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.elts: typing.List[NodeNG] = []
+        self.elts: list[NodeNG] = []
         """The elements in the node."""
 
         super().__init__(
@@ -312,7 +312,7 @@ class BaseContainer(
             parent=parent,
         )
 
-    def postinit(self, elts: typing.List[NodeNG]) -> None:
+    def postinit(self, elts: list[NodeNG]) -> None:
         """Do some setup after initialisation.
 
         :param elts: The list of elements the that node contains.
@@ -368,7 +368,7 @@ class LookupMixIn:
     """Mixin to look up a name in the right scope."""
 
     @lru_cache()  # noqa
-    def lookup(self, name: str) -> typing.Tuple[str, typing.List[NodeNG]]:
+    def lookup(self, name: str) -> tuple[str, list[NodeNG]]:
         """Lookup where the given variable is assigned.
 
         The lookup starts from self's scope. If self is not a frame itself
@@ -424,13 +424,13 @@ class AssignName(
     @decorators.deprecate_default_argument_values(name="str")
     def __init__(
         self,
-        name: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        name: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param name: The name that is assigned to.
@@ -447,7 +447,7 @@ class AssignName(
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.name: Optional[str] = name
+        self.name: str | None = name
         """The name that is assigned to."""
 
         super().__init__(
@@ -458,7 +458,7 @@ class AssignName(
             parent=parent,
         )
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["AssignName"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[AssignName]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -484,13 +484,13 @@ class DelName(
     @decorators.deprecate_default_argument_values(name="str")
     def __init__(
         self,
-        name: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        name: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param name: The name that is being deleted.
@@ -507,7 +507,7 @@ class DelName(
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.name: Optional[str] = name
+        self.name: str | None = name
         """The name that is being deleted."""
 
         super().__init__(
@@ -540,13 +540,13 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
     @decorators.deprecate_default_argument_values(name="str")
     def __init__(
         self,
-        name: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        name: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param name: The name that this node refers to.
@@ -563,7 +563,7 @@ class Name(mixins.NoChildrenMixin, LookupMixIn, NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.name: Optional[str] = name
+        self.name: str | None = name
         """The name that this node refers to."""
 
         super().__init__(
@@ -630,9 +630,9 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
 
     def __init__(
         self,
-        vararg: Optional[str] = None,
-        kwarg: Optional[str] = None,
-        parent: Optional[NodeNG] = None,
+        vararg: str | None = None,
+        kwarg: str | None = None,
+        parent: NodeNG | None = None,
     ) -> None:
         """
         :param vararg: The name of the variable length arguments.
@@ -643,13 +643,13 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         """
         super().__init__(parent=parent)
 
-        self.vararg: Optional[str] = vararg  # can be None
+        self.vararg: str | None = vararg  # can be None
         """The name of the variable length arguments."""
 
-        self.kwarg: Optional[str] = kwarg  # can be None
+        self.kwarg: str | None = kwarg  # can be None
         """The name of the variable length keyword arguments."""
 
-        self.args: Optional[typing.List[AssignName]]
+        self.args: list[AssignName] | None
         """The names of the required arguments.
 
         Can be None if the associated function does not have a retrievable
@@ -657,70 +657,70 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         This happens with builtin functions implemented in C.
         """
 
-        self.defaults: typing.List[NodeNG]
+        self.defaults: list[NodeNG]
         """The default values for arguments that can be passed positionally."""
 
-        self.kwonlyargs: typing.List[AssignName]
+        self.kwonlyargs: list[AssignName]
         """The keyword arguments that cannot be passed positionally."""
 
-        self.posonlyargs: typing.List[AssignName] = []
+        self.posonlyargs: list[AssignName] = []
         """The arguments that can only be passed positionally."""
 
-        self.kw_defaults: typing.List[Optional[NodeNG]]
+        self.kw_defaults: list[NodeNG | None]
         """The default values for keyword arguments that cannot be passed positionally."""
 
-        self.annotations: typing.List[Optional[NodeNG]]
+        self.annotations: list[NodeNG | None]
         """The type annotations of arguments that can be passed positionally."""
 
-        self.posonlyargs_annotations: typing.List[Optional[NodeNG]] = []
+        self.posonlyargs_annotations: list[NodeNG | None] = []
         """The type annotations of arguments that can only be passed positionally."""
 
-        self.kwonlyargs_annotations: typing.List[Optional[NodeNG]] = []
+        self.kwonlyargs_annotations: list[NodeNG | None] = []
         """The type annotations of arguments that cannot be passed positionally."""
 
-        self.type_comment_args: typing.List[Optional[NodeNG]] = []
+        self.type_comment_args: list[NodeNG | None] = []
         """The type annotation, passed by a type comment, of each argument.
 
         If an argument does not have a type comment,
         the value for that argument will be None.
         """
 
-        self.type_comment_kwonlyargs: typing.List[Optional[NodeNG]] = []
+        self.type_comment_kwonlyargs: list[NodeNG | None] = []
         """The type annotation, passed by a type comment, of each keyword only argument.
 
         If an argument does not have a type comment,
         the value for that argument will be None.
         """
 
-        self.type_comment_posonlyargs: typing.List[Optional[NodeNG]] = []
+        self.type_comment_posonlyargs: list[NodeNG | None] = []
         """The type annotation, passed by a type comment, of each positional argument.
 
         If an argument does not have a type comment,
         the value for that argument will be None.
         """
 
-        self.varargannotation: Optional[NodeNG] = None  # can be None
+        self.varargannotation: NodeNG | None = None  # can be None
         """The type annotation for the variable length arguments."""
 
-        self.kwargannotation: Optional[NodeNG] = None  # can be None
+        self.kwargannotation: NodeNG | None = None  # can be None
         """The type annotation for the variable length keyword arguments."""
 
     # pylint: disable=too-many-arguments
     def postinit(
         self,
-        args: typing.List[AssignName],
-        defaults: typing.List[NodeNG],
-        kwonlyargs: typing.List[AssignName],
-        kw_defaults: typing.List[Optional[NodeNG]],
-        annotations: typing.List[Optional[NodeNG]],
-        posonlyargs: Optional[typing.List[AssignName]] = None,
-        kwonlyargs_annotations: Optional[typing.List[Optional[NodeNG]]] = None,
-        posonlyargs_annotations: Optional[typing.List[Optional[NodeNG]]] = None,
-        varargannotation: Optional[NodeNG] = None,
-        kwargannotation: Optional[NodeNG] = None,
-        type_comment_args: Optional[typing.List[Optional[NodeNG]]] = None,
-        type_comment_kwonlyargs: Optional[typing.List[Optional[NodeNG]]] = None,
-        type_comment_posonlyargs: Optional[typing.List[Optional[NodeNG]]] = None,
+        args: list[AssignName],
+        defaults: list[NodeNG],
+        kwonlyargs: list[AssignName],
+        kw_defaults: list[NodeNG | None],
+        annotations: list[NodeNG | None],
+        posonlyargs: list[AssignName] | None = None,
+        kwonlyargs_annotations: list[NodeNG | None] | None = None,
+        posonlyargs_annotations: list[NodeNG | None] | None = None,
+        varargannotation: NodeNG | None = None,
+        kwargannotation: NodeNG | None = None,
+        type_comment_args: list[NodeNG | None] | None = None,
+        type_comment_kwonlyargs: list[NodeNG | None] | None = None,
+        type_comment_posonlyargs: list[NodeNG | None] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -784,7 +784,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         if type_comment_posonlyargs is not None:
             self.type_comment_posonlyargs = type_comment_posonlyargs
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["Arguments"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[Arguments]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -998,13 +998,13 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
     @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
-        attrname: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        attrname: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param attrname: The name of the attribute being assigned to.
@@ -1021,10 +1021,10 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.expr: Optional[NodeNG] = None
+        self.expr: NodeNG | None = None
         """What has the attribute that is being assigned to."""
 
-        self.attrname: Optional[str] = attrname
+        self.attrname: str | None = attrname
         """The name of the attribute being assigned to."""
 
         super().__init__(
@@ -1035,14 +1035,14 @@ class AssignAttr(mixins.ParentAssignTypeMixin, NodeNG):
             parent=parent,
         )
 
-    def postinit(self, expr: Optional[NodeNG] = None) -> None:
+    def postinit(self, expr: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param expr: What has the attribute that is being assigned to.
         """
         self.expr = expr
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["AssignAttr"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[AssignAttr]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1066,12 +1066,12 @@ class Assert(Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1086,10 +1086,10 @@ class Assert(Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.test: Optional[NodeNG] = None
+        self.test: NodeNG | None = None
         """The test that passes or fails the assertion."""
 
-        self.fail: Optional[NodeNG] = None  # can be None
+        self.fail: NodeNG | None = None  # can be None
         """The message shown when the assertion fails."""
 
         super().__init__(
@@ -1100,9 +1100,7 @@ class Assert(Statement):
             parent=parent,
         )
 
-    def postinit(
-        self, test: Optional[NodeNG] = None, fail: Optional[NodeNG] = None
-    ) -> None:
+    def postinit(self, test: NodeNG | None = None, fail: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param test: The test that passes or fails the assertion.
@@ -1136,12 +1134,12 @@ class Assign(mixins.AssignTypeMixin, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1156,13 +1154,13 @@ class Assign(mixins.AssignTypeMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.targets: typing.List[NodeNG] = []
+        self.targets: list[NodeNG] = []
         """What is being assigned to."""
 
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """The value being assigned to the variables."""
 
-        self.type_annotation: Optional[NodeNG] = None  # can be None
+        self.type_annotation: NodeNG | None = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
         super().__init__(
@@ -1175,9 +1173,9 @@ class Assign(mixins.AssignTypeMixin, Statement):
 
     def postinit(
         self,
-        targets: Optional[typing.List[NodeNG]] = None,
-        value: Optional[NodeNG] = None,
-        type_annotation: Optional[NodeNG] = None,
+        targets: list[NodeNG] | None = None,
+        value: NodeNG | None = None,
+        type_annotation: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1190,7 +1188,7 @@ class Assign(mixins.AssignTypeMixin, Statement):
         self.value = value
         self.type_annotation = type_annotation
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["Assign"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[Assign]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1224,12 +1222,12 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1244,16 +1242,16 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.target: Optional[NodeNG] = None
+        self.target: NodeNG | None = None
         """What is being assigned to."""
 
-        self.annotation: Optional[NodeNG] = None
+        self.annotation: NodeNG | None = None
         """The type annotation of what is being assigned to."""
 
-        self.value: Optional[NodeNG] = None  # can be None
+        self.value: NodeNG | None = None  # can be None
         """The value being assigned to the variables."""
 
-        self.simple: Optional[int] = None
+        self.simple: int | None = None
         """Whether :attr:`target` is a pure name or a complex statement."""
 
         super().__init__(
@@ -1269,7 +1267,7 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         target: NodeNG,
         annotation: NodeNG,
         simple: int,
-        value: Optional[NodeNG] = None,
+        value: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1287,7 +1285,7 @@ class AnnAssign(mixins.AssignTypeMixin, Statement):
         self.value = value
         self.simple = simple
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["AnnAssign"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[AnnAssign]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1317,13 +1315,13 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        op: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param op: The operator that is being combined with the assignment.
@@ -1341,16 +1339,16 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.target: Optional[NodeNG] = None
+        self.target: NodeNG | None = None
         """What is being assigned to."""
 
-        self.op: Optional[str] = op
+        self.op: str | None = op
         """The operator that is being combined with the assignment.
 
         This includes the equals sign.
         """
 
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """The value being assigned to the variable."""
 
         super().__init__(
@@ -1362,7 +1360,7 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         )
 
     def postinit(
-        self, target: Optional[NodeNG] = None, value: Optional[NodeNG] = None
+        self, target: NodeNG | None = None, value: NodeNG | None = None
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1373,7 +1371,7 @@ class AugAssign(mixins.AssignTypeMixin, Statement):
         self.target = target
         self.value = value
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["AugAssign"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[AugAssign]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1428,13 +1426,13 @@ class BinOp(NodeNG):
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        op: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param op: The operator.
@@ -1451,13 +1449,13 @@ class BinOp(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.left: Optional[NodeNG] = None
+        self.left: NodeNG | None = None
         """What is being applied to the operator on the left side."""
 
-        self.op: Optional[str] = op
+        self.op: str | None = op
         """The operator."""
 
-        self.right: Optional[NodeNG] = None
+        self.right: NodeNG | None = None
         """What is being applied to the operator on the right side."""
 
         super().__init__(
@@ -1468,9 +1466,7 @@ class BinOp(NodeNG):
             parent=parent,
         )
 
-    def postinit(
-        self, left: Optional[NodeNG] = None, right: Optional[NodeNG] = None
-    ) -> None:
+    def postinit(self, left: NodeNG | None = None, right: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param left: What is being applied to the operator on the left side.
@@ -1532,13 +1528,13 @@ class BoolOp(NodeNG):
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        op: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param op: The operator.
@@ -1555,10 +1551,10 @@ class BoolOp(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.op: Optional[str] = op
+        self.op: str | None = op
         """The operator."""
 
-        self.values: typing.List[NodeNG] = []
+        self.values: list[NodeNG] = []
         """The values being applied to the operator."""
 
         super().__init__(
@@ -1569,7 +1565,7 @@ class BoolOp(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, values: Optional[typing.List[NodeNG]] = None) -> None:
+    def postinit(self, values: list[NodeNG] | None = None) -> None:
         """Do some setup after initialisation.
 
         :param values: The values being applied to the operator.
@@ -1609,12 +1605,12 @@ class Call(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1629,13 +1625,13 @@ class Call(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.func: Optional[NodeNG] = None
+        self.func: NodeNG | None = None
         """What is being called."""
 
-        self.args: typing.List[NodeNG] = []
+        self.args: list[NodeNG] = []
         """The positional arguments being given to the call."""
 
-        self.keywords: typing.List["Keyword"] = []
+        self.keywords: list[Keyword] = []
         """The keyword arguments being given to the call."""
 
         super().__init__(
@@ -1648,9 +1644,9 @@ class Call(NodeNG):
 
     def postinit(
         self,
-        func: Optional[NodeNG] = None,
-        args: Optional[typing.List[NodeNG]] = None,
-        keywords: Optional[typing.List["Keyword"]] = None,
+        func: NodeNG | None = None,
+        args: list[NodeNG] | None = None,
+        keywords: list[Keyword] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1667,12 +1663,12 @@ class Call(NodeNG):
             self.keywords = keywords
 
     @property
-    def starargs(self) -> typing.List["Starred"]:
+    def starargs(self) -> list[Starred]:
         """The positional arguments that unpack something."""
         return [arg for arg in self.args if isinstance(arg, Starred)]
 
     @property
-    def kwargs(self) -> typing.List["Keyword"]:
+    def kwargs(self) -> list[Keyword]:
         """The keyword arguments that unpack something."""
         return [keyword for keyword in self.keywords if keyword.arg is None]
 
@@ -1701,12 +1697,12 @@ class Compare(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -1721,10 +1717,10 @@ class Compare(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.left: Optional[NodeNG] = None
+        self.left: NodeNG | None = None
         """The value at the left being applied to a comparison operator."""
 
-        self.ops: typing.List[typing.Tuple[str, NodeNG]] = []
+        self.ops: list[tuple[str, NodeNG]] = []
         """The remainder of the operators and their relevant right hand value."""
 
         super().__init__(
@@ -1737,8 +1733,8 @@ class Compare(NodeNG):
 
     def postinit(
         self,
-        left: Optional[NodeNG] = None,
-        ops: Optional[typing.List[typing.Tuple[str, NodeNG]]] = None,
+        left: NodeNG | None = None,
+        ops: list[tuple[str, NodeNG]] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1801,20 +1797,20 @@ class Comprehension(NodeNG):
     end_lineno: None
     end_col_offset: None
 
-    def __init__(self, parent: Optional[NodeNG] = None) -> None:
+    def __init__(self, parent: NodeNG | None = None) -> None:
         """
         :param parent: The parent node in the syntax tree.
         """
-        self.target: Optional[NodeNG] = None
+        self.target: NodeNG | None = None
         """What is assigned to by the comprehension."""
 
-        self.iter: Optional[NodeNG] = None
+        self.iter: NodeNG | None = None
         """What is iterated over by the comprehension."""
 
-        self.ifs: typing.List[NodeNG] = []
+        self.ifs: list[NodeNG] = []
         """The contents of any if statements that filter the comprehension."""
 
-        self.is_async: Optional[bool] = None
+        self.is_async: bool | None = None
         """Whether this is an asynchronous comprehension or not."""
 
         super().__init__(parent=parent)
@@ -1822,10 +1818,10 @@ class Comprehension(NodeNG):
     # pylint: disable=redefined-builtin; same name as builtin ast module.
     def postinit(
         self,
-        target: Optional[NodeNG] = None,
-        iter: Optional[NodeNG] = None,
-        ifs: Optional[typing.List[NodeNG]] = None,
-        is_async: Optional[bool] = None,
+        target: NodeNG | None = None,
+        iter: NodeNG | None = None,
+        ifs: list[NodeNG] | None = None,
+        is_async: bool | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1844,7 +1840,7 @@ class Comprehension(NodeNG):
             self.ifs = ifs
         self.is_async = is_async
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["Comprehension"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[Comprehension]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -1857,9 +1853,7 @@ class Comprehension(NodeNG):
         """
         return self
 
-    def _get_filtered_stmts(
-        self, lookup_node, node, stmts, mystmt: Optional[Statement]
-    ):
+    def _get_filtered_stmts(self, lookup_node, node, stmts, mystmt: Statement | None):
         """method used in filter_stmts"""
         if self is mystmt:
             if isinstance(lookup_node, (Const, Name)):
@@ -1900,13 +1894,13 @@ class Const(mixins.NoChildrenMixin, NodeNG, Instance):
     def __init__(
         self,
         value: Any,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
-        kind: Optional[str] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
+        kind: str | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param value: The value that the constant represents.
@@ -1928,7 +1922,7 @@ class Const(mixins.NoChildrenMixin, NodeNG, Instance):
         self.value: Any = value
         """The value that the constant represents."""
 
-        self.kind: Optional[str] = kind  # can be None
+        self.kind: str | None = kind  # can be None
         """"The string prefix. "u" for u-prefixed strings and ``None`` otherwise. Python 3.8+ only."""
 
         super().__init__(
@@ -2057,12 +2051,12 @@ class Decorators(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2077,7 +2071,7 @@ class Decorators(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.nodes: typing.List[NodeNG]
+        self.nodes: list[NodeNG]
         """The decorators that this node contains.
 
         :type: list(Name or Call) or None
@@ -2091,7 +2085,7 @@ class Decorators(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, nodes: typing.List[NodeNG]) -> None:
+    def postinit(self, nodes: list[NodeNG]) -> None:
         """Do some setup after initialisation.
 
         :param nodes: The decorators that this node contains.
@@ -2099,7 +2093,7 @@ class Decorators(NodeNG):
         """
         self.nodes = nodes
 
-    def scope(self) -> "LocalsDictNodeNG":
+    def scope(self) -> LocalsDictNodeNG:
         """The first parent node defining a new scope.
         These can be Module, FunctionDef, ClassDef, Lambda, or GeneratorExp nodes.
 
@@ -2133,13 +2127,13 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
     @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
-        attrname: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        attrname: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param attrname: The name of the attribute that is being deleted.
@@ -2156,13 +2150,13 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.expr: Optional[NodeNG] = None
+        self.expr: NodeNG | None = None
         """The name that this node represents.
 
         :type: Name or None
         """
 
-        self.attrname: Optional[str] = attrname
+        self.attrname: str | None = attrname
         """The name of the attribute that is being deleted."""
 
         super().__init__(
@@ -2173,7 +2167,7 @@ class DelAttr(mixins.ParentAssignTypeMixin, NodeNG):
             parent=parent,
         )
 
-    def postinit(self, expr: Optional[NodeNG] = None) -> None:
+    def postinit(self, expr: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param expr: The name that this node represents.
@@ -2200,12 +2194,12 @@ class Delete(mixins.AssignTypeMixin, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2220,7 +2214,7 @@ class Delete(mixins.AssignTypeMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.targets: typing.List[NodeNG] = []
+        self.targets: list[NodeNG] = []
         """What is being deleted."""
 
         super().__init__(
@@ -2231,7 +2225,7 @@ class Delete(mixins.AssignTypeMixin, Statement):
             parent=parent,
         )
 
-    def postinit(self, targets: Optional[typing.List[NodeNG]] = None) -> None:
+    def postinit(self, targets: list[NodeNG] | None = None) -> None:
         """Do some setup after initialisation.
 
         :param targets: What is being deleted.
@@ -2258,12 +2252,12 @@ class Dict(NodeNG, Instance):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2278,7 +2272,7 @@ class Dict(NodeNG, Instance):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.items: typing.List[typing.Tuple[NodeNG, NodeNG]] = []
+        self.items: list[tuple[NodeNG, NodeNG]] = []
         """The key-value pairs contained in the dictionary."""
 
         super().__init__(
@@ -2289,7 +2283,7 @@ class Dict(NodeNG, Instance):
             parent=parent,
         )
 
-    def postinit(self, items: typing.List[typing.Tuple[NodeNG, NodeNG]]) -> None:
+    def postinit(self, items: list[tuple[NodeNG, NodeNG]]) -> None:
         """Do some setup after initialisation.
 
         :param items: The key-value pairs contained in the dictionary.
@@ -2411,12 +2405,12 @@ class Expr(Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2431,7 +2425,7 @@ class Expr(Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """What the expression does."""
 
         super().__init__(
@@ -2442,7 +2436,7 @@ class Expr(Statement):
             parent=parent,
         )
 
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
+    def postinit(self, value: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: What the expression does.
@@ -2496,12 +2490,12 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2516,16 +2510,16 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.type: Optional[NodeNG] = None  # can be None
+        self.type: NodeNG | None = None  # can be None
         """The types that the block handles.
 
         :type: Tuple or NodeNG or None
         """
 
-        self.name: Optional[AssignName] = None  # can be None
+        self.name: AssignName | None = None  # can be None
         """The name that the caught exception is assigned to."""
 
-        self.body: typing.List[NodeNG] = []
+        self.body: list[NodeNG] = []
         """The contents of the block."""
 
         super().__init__(
@@ -2536,7 +2530,7 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
             parent=parent,
         )
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["ExceptHandler"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[ExceptHandler]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -2553,9 +2547,9 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(
         self,
-        type: Optional[NodeNG] = None,
-        name: Optional[AssignName] = None,
-        body: Optional[typing.List[NodeNG]] = None,
+        type: NodeNG | None = None,
+        name: AssignName | None = None,
+        body: list[NodeNG] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -2583,7 +2577,7 @@ class ExceptHandler(mixins.MultiLineBlockMixin, mixins.AssignTypeMixin, Statemen
             return self.type.tolineno
         return self.lineno
 
-    def catch(self, exceptions: Optional[typing.List[str]]) -> bool:
+    def catch(self, exceptions: list[str] | None) -> bool:
         """Check if this node handles any of the given
 
         :param exceptions: The names of the exceptions to check for.
@@ -2629,12 +2623,12 @@ class For(
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2649,19 +2643,19 @@ class For(
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.target: Optional[NodeNG] = None
+        self.target: NodeNG | None = None
         """What the loop assigns to."""
 
-        self.iter: Optional[NodeNG] = None
+        self.iter: NodeNG | None = None
         """What the loop iterates over."""
 
-        self.body: typing.List[NodeNG] = []
+        self.body: list[NodeNG] = []
         """The contents of the body of the loop."""
 
-        self.orelse: typing.List[NodeNG] = []
+        self.orelse: list[NodeNG] = []
         """The contents of the ``else`` block of the loop."""
 
-        self.type_annotation: Optional[NodeNG] = None  # can be None
+        self.type_annotation: NodeNG | None = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
         super().__init__(
@@ -2675,11 +2669,11 @@ class For(
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(
         self,
-        target: Optional[NodeNG] = None,
-        iter: Optional[NodeNG] = None,
-        body: Optional[typing.List[NodeNG]] = None,
-        orelse: Optional[typing.List[NodeNG]] = None,
-        type_annotation: Optional[NodeNG] = None,
+        target: NodeNG | None = None,
+        iter: NodeNG | None = None,
+        body: list[NodeNG] | None = None,
+        orelse: list[NodeNG] | None = None,
+        type_annotation: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -2699,7 +2693,7 @@ class For(
             self.orelse = orelse
         self.type_annotation = type_annotation
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["For"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[For]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -2761,12 +2755,12 @@ class Await(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -2781,7 +2775,7 @@ class Await(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """What to wait for."""
 
         super().__init__(
@@ -2792,7 +2786,7 @@ class Await(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
+    def postinit(self, value: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: What to wait for.
@@ -2816,15 +2810,15 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
 
     def __init__(
         self,
-        fromname: Optional[str],
-        names: typing.List[typing.Tuple[str, Optional[str]]],
-        level: Optional[int] = 0,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        fromname: str | None,
+        names: list[tuple[str, str | None]],
+        level: int | None = 0,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param fromname: The module that is being imported from.
@@ -2845,13 +2839,13 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.modname: Optional[str] = fromname  # can be None
+        self.modname: str | None = fromname  # can be None
         """The module that is being imported from.
 
         This is ``None`` for relative imports.
         """
 
-        self.names: typing.List[typing.Tuple[str, Optional[str]]] = names
+        self.names: list[tuple[str, str | None]] = names
         """What is being imported from the module.
 
         Each entry is a :class:`tuple` of the name being imported,
@@ -2859,7 +2853,7 @@ class ImportFrom(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         """
 
         # TODO When is 'level' None?
-        self.level: Optional[int] = level  # can be None
+        self.level: int | None = level  # can be None
         """The level of relative import.
 
         Essentially this is the number of dots in the import.
@@ -2884,13 +2878,13 @@ class Attribute(NodeNG):
     @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
-        attrname: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        attrname: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param attrname: The name of the attribute.
@@ -2907,13 +2901,13 @@ class Attribute(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.expr: Optional[NodeNG] = None
+        self.expr: NodeNG | None = None
         """The name that this node represents.
 
         :type: Name or None
         """
 
-        self.attrname: Optional[str] = attrname
+        self.attrname: str | None = attrname
         """The name of the attribute."""
 
         super().__init__(
@@ -2924,7 +2918,7 @@ class Attribute(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, expr: Optional[NodeNG] = None) -> None:
+    def postinit(self, expr: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param expr: The name that this node represents.
@@ -2949,13 +2943,13 @@ class Global(mixins.NoChildrenMixin, Statement):
 
     def __init__(
         self,
-        names: typing.List[str],
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        names: list[str],
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param names: The names being declared as global.
@@ -2972,7 +2966,7 @@ class Global(mixins.NoChildrenMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.names: typing.List[str] = names
+        self.names: list[str] = names
         """The names being declared as global."""
 
         super().__init__(
@@ -3001,12 +2995,12 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3021,13 +3015,13 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.test: Optional[NodeNG] = None
+        self.test: NodeNG | None = None
         """The condition that the statement tests."""
 
-        self.body: typing.List[NodeNG] = []
+        self.body: list[NodeNG] = []
         """The contents of the block."""
 
-        self.orelse: typing.List[NodeNG] = []
+        self.orelse: list[NodeNG] = []
         """The contents of the ``else`` block."""
 
         self.is_orelse: bool = False
@@ -3043,9 +3037,9 @@ class If(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def postinit(
         self,
-        test: Optional[NodeNG] = None,
-        body: Optional[typing.List[NodeNG]] = None,
-        orelse: Optional[typing.List[NodeNG]] = None,
+        test: NodeNG | None = None,
+        body: list[NodeNG] | None = None,
+        orelse: list[NodeNG] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -3165,12 +3159,12 @@ class IfExp(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3185,13 +3179,13 @@ class IfExp(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.test: Optional[NodeNG] = None
+        self.test: NodeNG | None = None
         """The condition that the statement tests."""
 
-        self.body: Optional[NodeNG] = None
+        self.body: NodeNG | None = None
         """The contents of the block."""
 
-        self.orelse: Optional[NodeNG] = None
+        self.orelse: NodeNG | None = None
         """The contents of the ``else`` block."""
 
         super().__init__(
@@ -3204,9 +3198,9 @@ class IfExp(NodeNG):
 
     def postinit(
         self,
-        test: Optional[NodeNG] = None,
-        body: Optional[NodeNG] = None,
-        orelse: Optional[NodeNG] = None,
+        test: NodeNG | None = None,
+        body: NodeNG | None = None,
+        orelse: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -3244,13 +3238,13 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
     @decorators.deprecate_default_argument_values(names="list[tuple[str, str | None]]")
     def __init__(
         self,
-        names: Optional[typing.List[typing.Tuple[str, Optional[str]]]] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        names: list[tuple[str, str | None]] | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param names: The names being imported.
@@ -3267,7 +3261,7 @@ class Import(mixins.NoChildrenMixin, mixins.ImportFromMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.names: typing.List[typing.Tuple[str, Optional[str]]] = names or []
+        self.names: list[tuple[str, str | None]] = names or []
         """The names being imported.
 
         Each entry is a :class:`tuple` of the name being imported,
@@ -3309,13 +3303,13 @@ class Keyword(NodeNG):
 
     def __init__(
         self,
-        arg: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        arg: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param arg: The argument being assigned to.
@@ -3332,10 +3326,10 @@ class Keyword(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.arg: Optional[str] = arg  # can be None
+        self.arg: str | None = arg  # can be None
         """The argument being assigned to."""
 
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """The value being assigned to the keyword argument."""
 
         super().__init__(
@@ -3346,7 +3340,7 @@ class Keyword(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
+    def postinit(self, value: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: The value being assigned to the keyword argument.
@@ -3370,13 +3364,13 @@ class List(BaseContainer):
 
     def __init__(
         self,
-        ctx: Optional[Context] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        ctx: Context | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param ctx: Whether the list is assigned to or loaded from.
@@ -3393,7 +3387,7 @@ class List(BaseContainer):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.ctx: Optional[Context] = ctx
+        self.ctx: Context | None = ctx
         """Whether the list is assigned to or loaded from."""
 
         super().__init__(
@@ -3404,7 +3398,7 @@ class List(BaseContainer):
             parent=parent,
         )
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["List"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[List]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -3444,13 +3438,13 @@ class Nonlocal(mixins.NoChildrenMixin, Statement):
 
     def __init__(
         self,
-        names: typing.List[str],
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        names: list[str],
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param names: The names being declared as not local.
@@ -3467,7 +3461,7 @@ class Nonlocal(mixins.NoChildrenMixin, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.names: typing.List[str] = names
+        self.names: list[str] = names
         """The names being declared as not local."""
 
         super().__init__(
@@ -3505,12 +3499,12 @@ class Raise(Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3525,10 +3519,10 @@ class Raise(Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.exc: Optional[NodeNG] = None  # can be None
+        self.exc: NodeNG | None = None  # can be None
         """What is being raised."""
 
-        self.cause: Optional[NodeNG] = None  # can be None
+        self.cause: NodeNG | None = None  # can be None
         """The exception being used to raise this one."""
 
         super().__init__(
@@ -3541,8 +3535,8 @@ class Raise(Statement):
 
     def postinit(
         self,
-        exc: Optional[NodeNG] = None,
-        cause: Optional[NodeNG] = None,
+        exc: NodeNG | None = None,
+        cause: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -3587,12 +3581,12 @@ class Return(Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3607,7 +3601,7 @@ class Return(Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: Optional[NodeNG] = None  # can be None
+        self.value: NodeNG | None = None  # can be None
         """The value being returned."""
 
         super().__init__(
@@ -3618,7 +3612,7 @@ class Return(Statement):
             parent=parent,
         )
 
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
+    def postinit(self, value: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: The value being returned.
@@ -3669,12 +3663,12 @@ class Slice(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3689,13 +3683,13 @@ class Slice(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.lower: Optional[NodeNG] = None  # can be None
+        self.lower: NodeNG | None = None  # can be None
         """The lower index in the slice."""
 
-        self.upper: Optional[NodeNG] = None  # can be None
+        self.upper: NodeNG | None = None  # can be None
         """The upper index in the slice."""
 
-        self.step: Optional[NodeNG] = None  # can be None
+        self.step: NodeNG | None = None  # can be None
         """The step to take between indexes."""
 
         super().__init__(
@@ -3708,9 +3702,9 @@ class Slice(NodeNG):
 
     def postinit(
         self,
-        lower: Optional[NodeNG] = None,
-        upper: Optional[NodeNG] = None,
-        step: Optional[NodeNG] = None,
+        lower: NodeNG | None = None,
+        upper: NodeNG | None = None,
+        step: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -3791,13 +3785,13 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
 
     def __init__(
         self,
-        ctx: Optional[Context] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        ctx: Context | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param ctx: Whether the list is assigned to or loaded from.
@@ -3814,10 +3808,10 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """What is being unpacked."""
 
-        self.ctx: Optional[Context] = ctx
+        self.ctx: Context | None = ctx
         """Whether the starred item is assigned to or loaded from."""
 
         super().__init__(
@@ -3828,14 +3822,14 @@ class Starred(mixins.ParentAssignTypeMixin, NodeNG):
             parent=parent,
         )
 
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
+    def postinit(self, value: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: What is being unpacked.
         """
         self.value = value
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["Starred"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[Starred]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -3858,13 +3852,13 @@ class Subscript(NodeNG):
 
     def __init__(
         self,
-        ctx: Optional[Context] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        ctx: Context | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param ctx: Whether the subscripted item is assigned to or loaded from.
@@ -3881,13 +3875,13 @@ class Subscript(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: Optional[NodeNG] = None
+        self.value: NodeNG | None = None
         """What is being indexed."""
 
-        self.slice: Optional[NodeNG] = None
+        self.slice: NodeNG | None = None
         """The slice being used to lookup."""
 
-        self.ctx: Optional[Context] = ctx
+        self.ctx: Context | None = ctx
         """Whether the subscripted item is assigned to or loaded from."""
 
         super().__init__(
@@ -3900,7 +3894,7 @@ class Subscript(NodeNG):
 
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(
-        self, value: Optional[NodeNG] = None, slice: Optional[NodeNG] = None
+        self, value: NodeNG | None = None, slice: NodeNG | None = None
     ) -> None:
         """Do some setup after initialisation.
 
@@ -3935,12 +3929,12 @@ class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -3955,13 +3949,13 @@ class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.body: typing.List[NodeNG] = []
+        self.body: list[NodeNG] = []
         """The contents of the block to catch exceptions from."""
 
-        self.handlers: typing.List[ExceptHandler] = []
+        self.handlers: list[ExceptHandler] = []
         """The exception handlers."""
 
-        self.orelse: typing.List[NodeNG] = []
+        self.orelse: list[NodeNG] = []
         """The contents of the ``else`` block."""
 
         super().__init__(
@@ -3974,9 +3968,9 @@ class TryExcept(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def postinit(
         self,
-        body: Optional[typing.List[NodeNG]] = None,
-        handlers: Optional[typing.List[ExceptHandler]] = None,
-        orelse: Optional[typing.List[NodeNG]] = None,
+        body: list[NodeNG] | None = None,
+        handlers: list[ExceptHandler] | None = None,
+        orelse: list[NodeNG] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -4044,12 +4038,12 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4064,10 +4058,10 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.body: typing.List[Union[NodeNG, TryExcept]] = []
+        self.body: list[NodeNG | TryExcept] = []
         """The try-except that the finally is attached to."""
 
-        self.finalbody: typing.List[NodeNG] = []
+        self.finalbody: list[NodeNG] = []
         """The contents of the ``finally`` block."""
 
         super().__init__(
@@ -4080,8 +4074,8 @@ class TryFinally(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def postinit(
         self,
-        body: Optional[typing.List[Union[NodeNG, TryExcept]]] = None,
-        finalbody: Optional[typing.List[NodeNG]] = None,
+        body: list[NodeNG | TryExcept] | None = None,
+        finalbody: list[NodeNG] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -4132,13 +4126,13 @@ class Tuple(BaseContainer):
 
     def __init__(
         self,
-        ctx: Optional[Context] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        ctx: Context | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param ctx: Whether the tuple is assigned to or loaded from.
@@ -4155,7 +4149,7 @@ class Tuple(BaseContainer):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.ctx: Optional[Context] = ctx
+        self.ctx: Context | None = ctx
         """Whether the tuple is assigned to or loaded from."""
 
         super().__init__(
@@ -4166,7 +4160,7 @@ class Tuple(BaseContainer):
             parent=parent,
         )
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["Tuple"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[Tuple]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -4203,13 +4197,13 @@ class UnaryOp(NodeNG):
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: Optional[str] = None,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        op: str | None = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param op: The operator.
@@ -4226,10 +4220,10 @@ class UnaryOp(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.op: Optional[str] = op
+        self.op: str | None = op
         """The operator."""
 
-        self.operand: Optional[NodeNG] = None
+        self.operand: NodeNG | None = None
         """What the unary operator is applied to."""
 
         super().__init__(
@@ -4240,7 +4234,7 @@ class UnaryOp(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, operand: Optional[NodeNG] = None) -> None:
+    def postinit(self, operand: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param operand: What the unary operator is applied to.
@@ -4297,12 +4291,12 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4317,13 +4311,13 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.test: Optional[NodeNG] = None
+        self.test: NodeNG | None = None
         """The condition that the loop tests."""
 
-        self.body: typing.List[NodeNG] = []
+        self.body: list[NodeNG] = []
         """The contents of the loop."""
 
-        self.orelse: typing.List[NodeNG] = []
+        self.orelse: list[NodeNG] = []
         """The contents of the ``else`` block."""
 
         super().__init__(
@@ -4336,9 +4330,9 @@ class While(mixins.MultiLineBlockMixin, mixins.BlockRangeMixIn, Statement):
 
     def postinit(
         self,
-        test: Optional[NodeNG] = None,
-        body: Optional[typing.List[NodeNG]] = None,
-        orelse: Optional[typing.List[NodeNG]] = None,
+        test: NodeNG | None = None,
+        body: list[NodeNG] | None = None,
+        orelse: list[NodeNG] | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -4409,12 +4403,12 @@ class With(
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4429,13 +4423,13 @@ class With(
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.items: typing.List[typing.Tuple[NodeNG, Optional[NodeNG]]] = []
+        self.items: list[tuple[NodeNG, NodeNG | None]] = []
         """The pairs of context managers and the names they are assigned to."""
 
-        self.body: typing.List[NodeNG] = []
+        self.body: list[NodeNG] = []
         """The contents of the ``with`` block."""
 
-        self.type_annotation: Optional[NodeNG] = None  # can be None
+        self.type_annotation: NodeNG | None = None  # can be None
         """If present, this will contain the type annotation passed by a type comment"""
 
         super().__init__(
@@ -4448,9 +4442,9 @@ class With(
 
     def postinit(
         self,
-        items: Optional[typing.List[typing.Tuple[NodeNG, Optional[NodeNG]]]] = None,
-        body: Optional[typing.List[NodeNG]] = None,
-        type_annotation: Optional[NodeNG] = None,
+        items: list[tuple[NodeNG, NodeNG | None]] | None = None,
+        body: list[NodeNG] | None = None,
+        type_annotation: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -4465,7 +4459,7 @@ class With(
             self.body = body
         self.type_annotation = type_annotation
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["With"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[With]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
@@ -4508,12 +4502,12 @@ class Yield(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4528,7 +4522,7 @@ class Yield(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: Optional[NodeNG] = None  # can be None
+        self.value: NodeNG | None = None  # can be None
         """The value to yield."""
 
         super().__init__(
@@ -4539,7 +4533,7 @@ class Yield(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, value: Optional[NodeNG] = None) -> None:
+    def postinit(self, value: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: The value to yield.
@@ -4580,12 +4574,12 @@ class FormattedValue(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4603,14 +4597,14 @@ class FormattedValue(NodeNG):
         self.value: NodeNG
         """The value to be formatted into the string."""
 
-        self.conversion: Optional[int] = None  # can be None
+        self.conversion: int | None = None  # can be None
         """The type of formatting to be applied to the value.
 
         .. seealso::
             :class:`ast.FormattedValue`
         """
 
-        self.format_spec: Optional[NodeNG] = None  # can be None
+        self.format_spec: NodeNG | None = None  # can be None
         """The formatting to be applied to the value.
 
         .. seealso::
@@ -4630,8 +4624,8 @@ class FormattedValue(NodeNG):
     def postinit(
         self,
         value: NodeNG,
-        conversion: Optional[int] = None,
-        format_spec: Optional[NodeNG] = None,
+        conversion: int | None = None,
+        format_spec: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -4666,12 +4660,12 @@ class JoinedStr(NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4686,7 +4680,7 @@ class JoinedStr(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.values: typing.List[NodeNG] = []
+        self.values: list[NodeNG] = []
         """The string expressions to be joined.
 
         :type: list(FormattedValue or Const)
@@ -4700,7 +4694,7 @@ class JoinedStr(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, values: Optional[typing.List[NodeNG]] = None) -> None:
+    def postinit(self, values: list[NodeNG] | None = None) -> None:
         """Do some setup after initialisation.
 
         :param value: The string expressions to be joined.
@@ -4732,12 +4726,12 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -4773,14 +4767,14 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
         self.target = target
         self.value = value
 
-    assigned_stmts: ClassVar[AssignedStmtsCall["NamedExpr"]]
+    assigned_stmts: ClassVar[AssignedStmtsCall[NamedExpr]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
 
     def frame(
         self, *, future: Literal[None, True] = None
-    ) -> Union["nodes.FunctionDef", "nodes.Module", "nodes.ClassDef", "nodes.Lambda"]:
+    ) -> nodes.FunctionDef | nodes.Module | nodes.ClassDef | nodes.Lambda:
         """The first parent frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -4801,7 +4795,7 @@ class NamedExpr(mixins.AssignTypeMixin, NodeNG):
 
         return self.parent.frame(future=True)
 
-    def scope(self) -> "LocalsDictNodeNG":
+    def scope(self) -> LocalsDictNodeNG:
         """The first parent node defining a new scope.
         These can be Module, FunctionDef, ClassDef, Lambda, or GeneratorExp nodes.
 
@@ -4863,12 +4857,12 @@ class EvaluatedObject(NodeNG):
     _other_fields = ("value",)
 
     def __init__(
-        self, original: NodeNG, value: Union[NodeNG, Type[util.Uninferable]]
+        self, original: NodeNG, value: NodeNG | type[util.Uninferable]
     ) -> None:
         self.original: NodeNG = original
         """The original node that has already been evaluated"""
 
-        self.value: Union[NodeNG, Type[util.Uninferable]] = value
+        self.value: NodeNG | type[util.Uninferable] = value
         """The inferred value"""
 
         super().__init__(
@@ -4878,8 +4872,8 @@ class EvaluatedObject(NodeNG):
         )
 
     def _infer(
-        self, context: Optional[InferenceContext] = None
-    ) -> Iterator[Union[NodeNG, Type[util.Uninferable]]]:
+        self, context: InferenceContext | None = None
+    ) -> Iterator[NodeNG | type[util.Uninferable]]:
         yield self.value
 
 
@@ -4905,15 +4899,15 @@ class Match(Statement):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         self.subject: NodeNG
-        self.cases: typing.List["MatchCase"]
+        self.cases: list[MatchCase]
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -4926,7 +4920,7 @@ class Match(Statement):
         self,
         *,
         subject: NodeNG,
-        cases: typing.List["MatchCase"],
+        cases: list[MatchCase],
     ) -> None:
         self.subject = subject
         self.cases = cases
@@ -4957,18 +4951,18 @@ class MatchCase(mixins.MultiLineBlockMixin, NodeNG):
     end_lineno: None
     end_col_offset: None
 
-    def __init__(self, *, parent: Optional[NodeNG] = None) -> None:
+    def __init__(self, *, parent: NodeNG | None = None) -> None:
         self.pattern: Pattern
-        self.guard: Optional[NodeNG]
-        self.body: typing.List[NodeNG]
+        self.guard: NodeNG | None
+        self.body: list[NodeNG]
         super().__init__(parent=parent)
 
     def postinit(
         self,
         *,
         pattern: Pattern,
-        guard: Optional[NodeNG],
-        body: typing.List[NodeNG],
+        guard: NodeNG | None,
+        body: list[NodeNG],
     ) -> None:
         self.pattern = pattern
         self.guard = guard
@@ -4992,12 +4986,12 @@ class MatchValue(Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         self.value: NodeNG
         super().__init__(
@@ -5039,11 +5033,11 @@ class MatchSingleton(Pattern):
         self,
         *,
         value: Literal[True, False, None],
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
+        parent: NodeNG | None = None,
     ) -> None:
         self.value = value
         super().__init__(
@@ -5076,14 +5070,14 @@ class MatchSequence(Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
-        self.patterns: typing.List[Pattern]
+        self.patterns: list[Pattern]
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -5092,7 +5086,7 @@ class MatchSequence(Pattern):
             parent=parent,
         )
 
-    def postinit(self, *, patterns: typing.List[Pattern]) -> None:
+    def postinit(self, *, patterns: list[Pattern]) -> None:
         self.patterns = patterns
 
 
@@ -5113,16 +5107,16 @@ class MatchMapping(mixins.AssignTypeMixin, Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
-        self.keys: typing.List[NodeNG]
-        self.patterns: typing.List[Pattern]
-        self.rest: Optional[AssignName]
+        self.keys: list[NodeNG]
+        self.patterns: list[Pattern]
+        self.rest: AssignName | None
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -5134,9 +5128,9 @@ class MatchMapping(mixins.AssignTypeMixin, Pattern):
     def postinit(
         self,
         *,
-        keys: typing.List[NodeNG],
-        patterns: typing.List[Pattern],
-        rest: Optional[AssignName],
+        keys: list[NodeNG],
+        patterns: list[Pattern],
+        rest: AssignName | None,
     ) -> None:
         self.keys = keys
         self.patterns = patterns
@@ -5145,9 +5139,9 @@ class MatchMapping(mixins.AssignTypeMixin, Pattern):
     assigned_stmts: ClassVar[
         Callable[
             [
-                "MatchMapping",
+                MatchMapping,
                 AssignName,
-                Optional[InferenceContext],
+                InferenceContext | None,
                 None,
             ],
             Generator[NodeNG, None, None],
@@ -5180,17 +5174,17 @@ class MatchClass(Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         self.cls: NodeNG
-        self.patterns: typing.List[Pattern]
-        self.kwd_attrs: typing.List[str]
-        self.kwd_patterns: typing.List[Pattern]
+        self.patterns: list[Pattern]
+        self.kwd_attrs: list[str]
+        self.kwd_patterns: list[Pattern]
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -5203,9 +5197,9 @@ class MatchClass(Pattern):
         self,
         *,
         cls: NodeNG,
-        patterns: typing.List[Pattern],
-        kwd_attrs: typing.List[str],
-        kwd_patterns: typing.List[Pattern],
+        patterns: list[Pattern],
+        kwd_attrs: list[str],
+        kwd_patterns: list[Pattern],
     ) -> None:
         self.cls = cls
         self.patterns = patterns
@@ -5230,14 +5224,14 @@ class MatchStar(mixins.AssignTypeMixin, Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
-        self.name: Optional[AssignName]
+        self.name: AssignName | None
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -5246,15 +5240,15 @@ class MatchStar(mixins.AssignTypeMixin, Pattern):
             parent=parent,
         )
 
-    def postinit(self, *, name: Optional[AssignName]) -> None:
+    def postinit(self, *, name: AssignName | None) -> None:
         self.name = name
 
     assigned_stmts: ClassVar[
         Callable[
             [
-                "MatchStar",
+                MatchStar,
                 AssignName,
-                Optional[InferenceContext],
+                InferenceContext | None,
                 None,
             ],
             Generator[NodeNG, None, None],
@@ -5294,15 +5288,15 @@ class MatchAs(mixins.AssignTypeMixin, Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
-        self.pattern: Optional[Pattern]
-        self.name: Optional[AssignName]
+        self.pattern: Pattern | None
+        self.name: AssignName | None
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -5314,8 +5308,8 @@ class MatchAs(mixins.AssignTypeMixin, Pattern):
     def postinit(
         self,
         *,
-        pattern: Optional[Pattern],
-        name: Optional[AssignName],
+        pattern: Pattern | None,
+        name: AssignName | None,
     ) -> None:
         self.pattern = pattern
         self.name = name
@@ -5323,9 +5317,9 @@ class MatchAs(mixins.AssignTypeMixin, Pattern):
     assigned_stmts: ClassVar[
         Callable[
             [
-                "MatchAs",
+                MatchAs,
                 AssignName,
-                Optional[InferenceContext],
+                InferenceContext | None,
                 None,
             ],
             Generator[NodeNG, None, None],
@@ -5353,14 +5347,14 @@ class MatchOr(Pattern):
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional[NodeNG] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
-        self.patterns: typing.List[Pattern]
+        self.patterns: list[Pattern]
         super().__init__(
             lineno=lineno,
             col_offset=col_offset,
@@ -5369,7 +5363,7 @@ class MatchOr(Pattern):
             parent=parent,
         )
 
-    def postinit(self, *, patterns: typing.List[Pattern]) -> None:
+    def postinit(self, *, patterns: list[Pattern]) -> None:
         self.patterns = patterns
 
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -2,17 +2,16 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import pprint
 import sys
-import typing
 import warnings
 from functools import singledispatch as _singledispatch
 from typing import (
     TYPE_CHECKING,
     ClassVar,
     Iterator,
-    List,
-    Optional,
     Tuple,
     Type,
     TypeVar,
@@ -77,26 +76,26 @@ class NodeNG:
     is_lambda: ClassVar[bool] = False
 
     # Attributes below are set by the builder module or by raw factories
-    _astroid_fields: ClassVar[typing.Tuple[str, ...]] = ()
+    _astroid_fields: ClassVar[tuple[str, ...]] = ()
     """Node attributes that contain child nodes.
 
     This is redefined in most concrete classes.
     """
-    _other_fields: ClassVar[typing.Tuple[str, ...]] = ()
+    _other_fields: ClassVar[tuple[str, ...]] = ()
     """Node attributes that do not contain child nodes."""
-    _other_other_fields: ClassVar[typing.Tuple[str, ...]] = ()
+    _other_other_fields: ClassVar[tuple[str, ...]] = ()
     """Attributes that contain AST-dependent fields."""
     # instance specific inference function infer(node, context)
-    _explicit_inference: Optional[InferFn] = None
+    _explicit_inference: InferFn | None = None
 
     def __init__(
         self,
-        lineno: Optional[int] = None,
-        col_offset: Optional[int] = None,
-        parent: Optional["NodeNG"] = None,
+        lineno: int | None = None,
+        col_offset: int | None = None,
+        parent: NodeNG | None = None,
         *,
-        end_lineno: Optional[int] = None,
-        end_col_offset: Optional[int] = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
     ) -> None:
         """
         :param lineno: The line that this node appears on in the source code.
@@ -111,24 +110,24 @@ class NodeNG:
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.lineno: Optional[int] = lineno
+        self.lineno: int | None = lineno
         """The line that this node appears on in the source code."""
 
-        self.col_offset: Optional[int] = col_offset
+        self.col_offset: int | None = col_offset
         """The column that this node appears on in the source code."""
 
-        self.parent: Optional["NodeNG"] = parent
+        self.parent: NodeNG | None = parent
         """The parent node in the syntax tree."""
 
-        self.end_lineno: Optional[int] = end_lineno
+        self.end_lineno: int | None = end_lineno
         """The last line this node appears on in the source code."""
 
-        self.end_col_offset: Optional[int] = end_col_offset
+        self.end_col_offset: int | None = end_col_offset
         """The end column this node appears on in the source code.
         Note: This is after the last symbol.
         """
 
-        self.position: Optional[Position] = None
+        self.position: Position | None = None
         """Position of keyword(s) and name. Used as fallback for block nodes
         which might not provide good enough positional information.
         E.g. ClassDef, FunctionDef.
@@ -248,7 +247,7 @@ class NodeNG:
         func = getattr(visitor, "visit_" + self.__class__.__name__.lower())
         return func(self)
 
-    def get_children(self) -> Iterator["NodeNG"]:
+    def get_children(self) -> Iterator[NodeNG]:
         """Get the child nodes below this node."""
         for field in self._astroid_fields:
             attr = getattr(self, field)
@@ -260,7 +259,7 @@ class NodeNG:
                 yield attr
         yield from ()
 
-    def last_child(self) -> Optional["NodeNG"]:
+    def last_child(self) -> NodeNG | None:
         """An optimized version of list(get_children())[-1]"""
         for field in self._astroid_fields[::-1]:
             attr = getattr(self, field)
@@ -271,7 +270,7 @@ class NodeNG:
             return attr
         return None
 
-    def node_ancestors(self) -> Iterator["NodeNG"]:
+    def node_ancestors(self) -> Iterator[NodeNG]:
         """Yield parent, grandparent, etc until there are no more."""
         parent = self.parent
         while parent is not None:
@@ -291,18 +290,16 @@ class NodeNG:
         return any(self is parent for parent in node.node_ancestors())
 
     @overload
-    def statement(
-        self, *, future: None = ...
-    ) -> Union["nodes.Statement", "nodes.Module"]:
+    def statement(self, *, future: None = ...) -> nodes.Statement | nodes.Module:
         ...
 
     @overload
-    def statement(self, *, future: Literal[True]) -> "nodes.Statement":
+    def statement(self, *, future: Literal[True]) -> nodes.Statement:
         ...
 
     def statement(
         self, *, future: Literal[None, True] = None
-    ) -> Union["nodes.Statement", "nodes.Module"]:
+    ) -> nodes.Statement | nodes.Module:
         """The first parent node, including self, marked as statement node.
 
         TODO: Deprecate the future parameter and only raise StatementMissing and return
@@ -328,7 +325,7 @@ class NodeNG:
 
     def frame(
         self, *, future: Literal[None, True] = None
-    ) -> Union["nodes.FunctionDef", "nodes.Module", "nodes.ClassDef", "nodes.Lambda"]:
+    ) -> nodes.FunctionDef | nodes.Module | nodes.ClassDef | nodes.Lambda:
         """The first parent frame node.
 
         A frame node is a :class:`Module`, :class:`FunctionDef`,
@@ -350,7 +347,7 @@ class NodeNG:
 
         return self.parent.frame(future=future)
 
-    def scope(self) -> "nodes.LocalsDictNodeNG":
+    def scope(self) -> nodes.LocalsDictNodeNG:
         """The first parent node defining a new scope.
         These can be Module, FunctionDef, ClassDef, Lambda, or GeneratorExp nodes.
 
@@ -445,14 +442,14 @@ class NodeNG:
     # single node, and they rarely get looked at
 
     @cached_property
-    def fromlineno(self) -> Optional[int]:
+    def fromlineno(self) -> int | None:
         """The first line that this node appears on in the source code."""
         if self.lineno is None:
             return self._fixed_source_line()
         return self.lineno
 
     @cached_property
-    def tolineno(self) -> Optional[int]:
+    def tolineno(self) -> int | None:
         """The last line that this node appears on in the source code."""
         if self.end_lineno is not None:
             return self.end_lineno
@@ -465,13 +462,13 @@ class NodeNG:
             return self.fromlineno
         return last_child.tolineno
 
-    def _fixed_source_line(self) -> Optional[int]:
+    def _fixed_source_line(self) -> int | None:
         """Attempt to find the line that this node appears on.
 
         We need this method since not all nodes have :attr:`lineno` set.
         """
         line = self.lineno
-        _node: Optional[NodeNG] = self
+        _node: NodeNG | None = self
         try:
             while line is None:
                 _node = next(_node.get_children())
@@ -513,7 +510,7 @@ class NodeNG:
     @overload
     def nodes_of_class(
         self,
-        klass: Type[_NodesT],
+        klass: type[_NodesT],
         skip_klass: SkipKlassT = None,
     ) -> Iterator[_NodesT]:
         ...
@@ -521,37 +518,37 @@ class NodeNG:
     @overload
     def nodes_of_class(
         self,
-        klass: Tuple[Type[_NodesT], Type[_NodesT2]],
+        klass: tuple[type[_NodesT], type[_NodesT2]],
         skip_klass: SkipKlassT = None,
-    ) -> Union[Iterator[_NodesT], Iterator[_NodesT2]]:
+    ) -> Iterator[_NodesT] | Iterator[_NodesT2]:
         ...
 
     @overload
     def nodes_of_class(
         self,
-        klass: Tuple[Type[_NodesT], Type[_NodesT2], Type[_NodesT3]],
+        klass: tuple[type[_NodesT], type[_NodesT2], type[_NodesT3]],
         skip_klass: SkipKlassT = None,
-    ) -> Union[Iterator[_NodesT], Iterator[_NodesT2], Iterator[_NodesT3]]:
+    ) -> Iterator[_NodesT] | Iterator[_NodesT2] | Iterator[_NodesT3]:
         ...
 
     @overload
     def nodes_of_class(
         self,
-        klass: Tuple[Type[_NodesT], ...],
+        klass: tuple[type[_NodesT], ...],
         skip_klass: SkipKlassT = None,
     ) -> Iterator[_NodesT]:
         ...
 
     def nodes_of_class(  # type: ignore[misc] # mypy doesn't correctly recognize the overloads
         self,
-        klass: Union[
-            Type[_NodesT],
-            Tuple[Type[_NodesT], Type[_NodesT2]],
-            Tuple[Type[_NodesT], Type[_NodesT2], Type[_NodesT3]],
-            Tuple[Type[_NodesT], ...],
-        ],
+        klass: (
+            type[_NodesT]
+            | tuple[type[_NodesT], type[_NodesT2]]
+            | tuple[type[_NodesT], type[_NodesT2], type[_NodesT3]]
+            | tuple[type[_NodesT], ...]
+        ),
         skip_klass: SkipKlassT = None,
-    ) -> Union[Iterator[_NodesT], Iterator[_NodesT2], Iterator[_NodesT3]]:
+    ) -> Iterator[_NodesT] | Iterator[_NodesT2] | Iterator[_NodesT3]:
         """Get the nodes (including this one or below) of the given types.
 
         :param klass: The types of node to search for.
@@ -779,7 +776,7 @@ class NodeNG:
             result.append(")")
             return broken
 
-        result: List[str] = []
+        result: list[str] = []
         _repr_tree(self, result, set())
         return "".join(result)
 

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -3,8 +3,9 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """This module contains mixin classes for scoped nodes."""
+from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from astroid.filter_statements import _filter_stmts
 from astroid.nodes import node_classes, scoped_nodes
@@ -24,7 +25,7 @@ class LocalsDictNodeNG(node_classes.LookupMixIn, node_classes.NodeNG):
 
     # attributes below are set by the builder module or by raw factories
 
-    locals: Dict[str, List["nodes.NodeNG"]] = {}
+    locals: dict[str, list[nodes.NodeNG]] = {}
     """A map of the name of a local variable to the node defining the local."""
 
     def qname(self):
@@ -108,7 +109,7 @@ class LocalsDictNodeNG(node_classes.LookupMixIn, node_classes.NodeNG):
             self._append_node(child_node)
         self.set_local(name or child_node.name, child_node)
 
-    def __getitem__(self, item: str) -> "nodes.NodeNG":
+    def __getitem__(self, item: str) -> nodes.NodeNG:
         """The first node the defines the given local.
 
         :param item: The name of the locally defined object.
@@ -170,5 +171,5 @@ class ComprehensionScope(LocalsDictNodeNG):
 
     scope_lookup = LocalsDictNodeNG._scope_lookup
 
-    generators: List["nodes.Comprehension"]
+    generators: list[nodes.Comprehension]
     """The generators that are looped through."""

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """This module contains mixin classes for scoped nodes."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -7,6 +7,7 @@ This module contains the classes for "scoped" node, i.e. which are opening a
 new local scope in the language definition : Module, ClassDef, FunctionDef (and
 Lambda, GeneratorExp, DictComp and SetComp to some extent).
 """
+
 from __future__ import annotations
 
 import io

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -7,23 +7,15 @@ This module contains the classes for "scoped" node, i.e. which are opening a
 new local scope in the language definition : Module, ClassDef, FunctionDef (and
 Lambda, GeneratorExp, DictComp and SetComp to some extent).
 """
+from __future__ import annotations
+
 import io
 import itertools
 import os
 import sys
 import typing
 import warnings
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    List,
-    NoReturn,
-    Optional,
-    Set,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, NoReturn, TypeVar, overload
 
 from astroid import bases
 from astroid import decorators as decorators_mod
@@ -114,7 +106,7 @@ def _c3_merge(sequences, cls, context):
     return None
 
 
-def clean_typing_generic_mro(sequences: List[List["ClassDef"]]) -> None:
+def clean_typing_generic_mro(sequences: list[list[ClassDef]]) -> None:
     """A class can inherit from typing.Generic directly, as base,
     and as base of bases. The merged MRO must however only contain the last entry.
     To prepare for _c3_merge, remove some typing.Generic entries from
@@ -202,10 +194,10 @@ class Module(LocalsDictNodeNG):
 
     # attributes below are set by the builder module or by raw factories
 
-    file_bytes: Union[str, bytes, None] = None
+    file_bytes: str | bytes | None = None
     """The string/bytes that this ast was built from."""
 
-    file_encoding: Optional[str] = None
+    file_encoding: str | None = None
     """The encoding of the source file.
 
     This is used to get unicode out of a source file.
@@ -239,12 +231,12 @@ class Module(LocalsDictNodeNG):
     def __init__(
         self,
         name: str,
-        doc: Optional[str] = None,
-        file: Optional[str] = None,
-        path: Optional[List[str]] = None,
-        package: Optional[bool] = None,
+        doc: str | None = None,
+        file: str | None = None,
+        path: list[str] | None = None,
+        package: bool | None = None,
         parent: None = None,
-        pure_python: Optional[bool] = True,
+        pure_python: bool | None = True,
     ) -> None:
         """
         :param name: The name of the module.
@@ -282,26 +274,26 @@ class Module(LocalsDictNodeNG):
         self.pure_python = pure_python
         """Whether the ast was built from source."""
 
-        self.globals: Dict[str, List[node_classes.NodeNG]]
+        self.globals: dict[str, list[node_classes.NodeNG]]
         """A map of the name of a global variable to the node defining the global."""
 
         self.locals = self.globals = {}
         """A map of the name of a local variable to the node defining the local."""
 
-        self.body: Optional[List[node_classes.NodeNG]] = []
+        self.body: list[node_classes.NodeNG] | None = []
         """The contents of the module."""
 
-        self.doc_node: Optional[Const] = None
+        self.doc_node: Const | None = None
         """The doc node associated with this node."""
 
-        self.future_imports: Set[str] = set()
+        self.future_imports: set[str] = set()
         """The imports from ``__future__``."""
 
         super().__init__(lineno=0, parent=parent)
 
     # pylint: enable=redefined-builtin
 
-    def postinit(self, body=None, *, doc_node: Optional[Const] = None):
+    def postinit(self, body=None, *, doc_node: Const | None = None):
         """Do some setup after initialisation.
 
         :param body: The contents of the module.
@@ -314,7 +306,7 @@ class Module(LocalsDictNodeNG):
             self._doc = doc_node.value
 
     @property
-    def doc(self) -> Optional[str]:
+    def doc(self) -> str | None:
         """The module docstring."""
         warnings.warn(
             "The 'Module.doc' attribute is deprecated, "
@@ -324,7 +316,7 @@ class Module(LocalsDictNodeNG):
         return self._doc
 
     @doc.setter
-    def doc(self, value: Optional[str]) -> None:
+    def doc(self, value: str | None) -> None:
         warnings.warn(
             "Setting the 'Module.doc' attribute is deprecated, "
             "use 'Module.doc_node' instead.",
@@ -455,16 +447,14 @@ class Module(LocalsDictNodeNG):
         return self.file is not None and self.file.endswith(".py")
 
     @overload
-    def statement(self, *, future: None = ...) -> "Module":
+    def statement(self, *, future: None = ...) -> Module:
         ...
 
     @overload
     def statement(self, *, future: Literal[True]) -> NoReturn:
         ...
 
-    def statement(
-        self, *, future: Literal[None, True] = None
-    ) -> Union["NoReturn", "Module"]:
+    def statement(self, *, future: Literal[None, True] = None) -> Module | NoReturn:
         """The first parent node, including self, marked as statement node.
 
         When called on a :class:`Module` with the future parameter this raises an error.
@@ -723,9 +713,7 @@ class GeneratorExp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(
-        self, elt=None, generators: Optional[List["nodes.Comprehension"]] = None
-    ):
+    def postinit(self, elt=None, generators: list[nodes.Comprehension] | None = None):
         """Do some setup after initialisation.
 
         :param elt: The element that forms the output of the expression.
@@ -821,7 +809,7 @@ class DictComp(ComprehensionScope):
         self,
         key=None,
         value=None,
-        generators: Optional[List["nodes.Comprehension"]] = None,
+        generators: list[nodes.Comprehension] | None = None,
     ):
         """Do some setup after initialisation.
 
@@ -914,9 +902,7 @@ class SetComp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(
-        self, elt=None, generators: Optional[List["nodes.Comprehension"]] = None
-    ):
+    def postinit(self, elt=None, generators: list[nodes.Comprehension] | None = None):
         """Do some setup after initialisation.
 
         :param elt: The element that forms the output of the expression.
@@ -986,9 +972,7 @@ class ListComp(ComprehensionScope):
             parent=parent,
         )
 
-    def postinit(
-        self, elt=None, generators: Optional[List["nodes.Comprehension"]] = None
-    ):
+    def postinit(self, elt=None, generators: list[nodes.Comprehension] | None = None):
         """Do some setup after initialisation.
 
         :param elt: The element that forms the output of the expression.
@@ -1129,7 +1113,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         :type: list(NodeNG)
         """
 
-        self.instance_attrs: Dict[str, List[NodeNG]] = {}
+        self.instance_attrs: dict[str, list[NodeNG]] = {}
 
         super().__init__(
             lineno=lineno,
@@ -1180,7 +1164,7 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         """
         return True
 
-    def argnames(self) -> List[str]:
+    def argnames(self) -> list[str]:
         """Get the names of each of the arguments, including that
         of the collections of variable-length arguments ("args", "kwargs",
         etc.), as well as positional-only and keyword-only arguments.
@@ -1262,8 +1246,8 @@ class Lambda(mixins.FilterStmtsMixin, LocalsDictNodeNG):
         return self
 
     def getattr(
-        self, name: str, context: Optional[InferenceContext] = None
-    ) -> List[NodeNG]:
+        self, name: str, context: InferenceContext | None = None
+    ) -> list[NodeNG]:
         if not name:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 
@@ -1292,7 +1276,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
     _astroid_fields = ("decorators", "args", "returns", "doc_node", "body")
     _multi_line_block_fields = ("body",)
     returns = None
-    decorators: Optional[node_classes.Decorators] = None
+    decorators: node_classes.Decorators | None = None
     """The decorators that are applied to this method or function."""
 
     is_function = True
@@ -1328,7 +1312,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
     def __init__(
         self,
         name=None,
-        doc: Optional[str] = None,
+        doc: str | None = None,
         lineno=None,
         col_offset=None,
         parent=None,
@@ -1368,7 +1352,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         self._doc = doc
         """The function docstring."""
 
-        self.doc_node: Optional[Const] = None
+        self.doc_node: Const | None = None
         """The doc node associated with this node."""
 
         self.instance_attrs = {}
@@ -1387,13 +1371,13 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         self,
         args: Arguments,
         body,
-        decorators: Optional[node_classes.Decorators] = None,
+        decorators: node_classes.Decorators | None = None,
         returns=None,
         type_comment_returns=None,
         type_comment_args=None,
         *,
-        position: Optional[Position] = None,
-        doc_node: Optional[Const] = None,
+        position: Position | None = None,
+        doc_node: Const | None = None,
     ):
         """Do some setup after initialisation.
 
@@ -1426,7 +1410,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
             self._doc = doc_node.value
 
     @property
-    def doc(self) -> Optional[str]:
+    def doc(self) -> str | None:
         """The function docstring."""
         warnings.warn(
             "The 'FunctionDef.doc' attribute is deprecated, "
@@ -1436,7 +1420,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         return self._doc
 
     @doc.setter
-    def doc(self, value: Optional[str]) -> None:
+    def doc(self, value: str | None) -> None:
         warnings.warn(
             "Setting the 'FunctionDef.doc' attribute is deprecated, "
             "use 'FunctionDef.doc_node' instead.",
@@ -1445,7 +1429,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         self._doc = value
 
     @cached_property
-    def extra_decorators(self) -> List[node_classes.Call]:
+    def extra_decorators(self) -> list[node_classes.Call]:
         """The extra decorators that this function can have.
 
         Additional decorators are considered when they are used as
@@ -1457,7 +1441,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         if not isinstance(frame, ClassDef):
             return []
 
-        decorators: List[node_classes.Call] = []
+        decorators: list[node_classes.Call] = []
         for assign in frame._get_assign_nodes():
             if isinstance(assign.value, node_classes.Call) and isinstance(
                 assign.value.func, node_classes.Name
@@ -1558,7 +1542,7 @@ class FunctionDef(mixins.MultiLineBlockMixin, node_classes.Statement, Lambda):
         return type_name
 
     @cached_property
-    def fromlineno(self) -> Optional[int]:
+    def fromlineno(self) -> int | None:
         """The first line that this node appears on in the source code."""
         # lineno is the line number of the first decorator, we want the def
         # statement lineno. Similar to 'ClassDef.fromlineno'
@@ -1830,7 +1814,7 @@ class AsyncFunctionDef(FunctionDef):
     """
 
 
-def _rec_get_names(args, names: Optional[List[str]] = None) -> List[str]:
+def _rec_get_names(args, names: list[str] | None = None) -> list[str]:
     """return a list of all argument names"""
     if names is None:
         names = []
@@ -1979,7 +1963,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     def __init__(
         self,
         name=None,
-        doc: Optional[str] = None,
+        doc: str | None = None,
         lineno=None,
         col_offset=None,
         parent=None,
@@ -2046,7 +2030,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         self._doc = doc
         """The class docstring."""
 
-        self.doc_node: Optional[Const] = None
+        self.doc_node: Const | None = None
         """The doc node associated with this node."""
 
         self.is_dataclass: bool = False
@@ -2066,7 +2050,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             self.add_local_node(node, local_name)
 
     @property
-    def doc(self) -> Optional[str]:
+    def doc(self) -> str | None:
         """The class docstring."""
         warnings.warn(
             "The 'ClassDef.doc' attribute is deprecated, "
@@ -2076,7 +2060,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         return self._doc
 
     @doc.setter
-    def doc(self, value: Optional[str]) -> None:
+    def doc(self, value: str | None) -> None:
         warnings.warn(
             "Setting the 'ClassDef.doc' attribute is deprecated, "
             "use 'ClassDef.doc_node.value' instead.",
@@ -2108,8 +2092,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         metaclass=None,
         keywords=None,
         *,
-        position: Optional[Position] = None,
-        doc_node: Optional[Const] = None,
+        position: Position | None = None,
+        doc_node: Const | None = None,
     ):
         """Do some setup after initialisation.
 
@@ -2174,7 +2158,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
     )
 
     @cached_property
-    def fromlineno(self) -> Optional[int]:
+    def fromlineno(self) -> int | None:
         """The first line that this node appears on in the source code."""
         if not PY38_PLUS or PY38 and IS_PYPY:
             # For Python < 3.8 the lineno is the line number of the first decorator.
@@ -2973,8 +2957,8 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         """
 
         def grouped_slots(
-            mro: List["ClassDef"],
-        ) -> typing.Iterator[Optional[node_classes.NodeNG]]:
+            mro: list[ClassDef],
+        ) -> typing.Iterator[node_classes.NodeNG | None]:
             # Not interested in object, since it can't have slots.
             for cls in mro[:-1]:
                 try:
@@ -3067,7 +3051,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
         clean_typing_generic_mro(unmerged_mro)
         return _c3_merge(unmerged_mro, self, context)
 
-    def mro(self, context=None) -> List["ClassDef"]:
+    def mro(self, context=None) -> list[ClassDef]:
         """Get the method resolution order, using C3 linearization.
 
         :returns: The list of ancestors, sorted by the mro.

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -5,9 +5,10 @@
 """
 This module contains utility functions for scoped nodes.
 """
+from __future__ import annotations
 
 import builtins
-from typing import TYPE_CHECKING, Sequence, Tuple
+from typing import TYPE_CHECKING, Sequence
 
 from astroid.manager import AstroidManager
 
@@ -15,10 +16,10 @@ if TYPE_CHECKING:
     from astroid import nodes
 
 
-_builtin_astroid: "nodes.Module | None" = None
+_builtin_astroid: nodes.Module | None = None
 
 
-def builtin_lookup(name: str) -> Tuple["nodes.Module", Sequence["nodes.NodeNG"]]:
+def builtin_lookup(name: str) -> tuple[nodes.Module, Sequence[nodes.NodeNG]]:
     """Lookup a name in the builtin module.
 
     Return the list of matching statements and the ast for the builtin module
@@ -30,7 +31,7 @@ def builtin_lookup(name: str) -> Tuple["nodes.Module", Sequence["nodes.NodeNG"]]
     if name == "__dict__":
         return _builtin_astroid, ()
     try:
-        stmts: Sequence["nodes.NodeNG"] = _builtin_astroid.locals[name]
+        stmts: Sequence[nodes.NodeNG] = _builtin_astroid.locals[name]
     except KeyError:
         stmts = ()
     return _builtin_astroid, stmts

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -5,6 +5,7 @@
 """
 This module contains utility functions for scoped nodes.
 """
+
 from __future__ import annotations
 
 import builtins

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -10,6 +10,7 @@ leads to an inferred FrozenSet:
 
     Call(func=Name('frozenset'), args=Tuple(...))
 """
+
 from __future__ import annotations
 
 import sys

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -10,9 +10,10 @@ leads to an inferred FrozenSet:
 
     Call(func=Name('frozenset'), args=Tuple(...))
 """
+from __future__ import annotations
 
 import sys
-from typing import Iterator, Optional, TypeVar
+from typing import Iterator, TypeVar
 
 from astroid import bases, decorators, util
 from astroid.context import InferenceContext
@@ -328,5 +329,5 @@ class Property(scoped_nodes.FunctionDef):
     def infer_call_result(self, caller=None, context=None):
         raise InferenceError("Properties are not callable")
 
-    def _infer(self: _T, context: Optional[InferenceContext] = None) -> Iterator[_T]:
+    def _infer(self: _T, context: InferenceContext | None = None) -> Iterator[_T]:
         yield self

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -5,11 +5,12 @@
 """this module contains a set of functions to handle python protocols for nodes
 where it makes sense.
 """
+from __future__ import annotations
 
 import collections
 import itertools
 import operator as operator_mod
-from typing import Any, Generator, List, Optional, Union
+from typing import Any, Generator
 
 from astroid import arguments, bases, decorators, helpers, nodes, util
 from astroid.const import Context
@@ -262,10 +263,10 @@ def _resolve_looppart(parts, assign_path, context):
 
 @decorators.raise_if_nothing_inferred
 def for_assigned_stmts(
-    self: Union[nodes.For, nodes.Comprehension],
+    self: nodes.For | nodes.Comprehension,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     if isinstance(self, nodes.AsyncFor) or getattr(self, "is_async", False):
         # Skip inferring of async code for now
@@ -284,10 +285,10 @@ nodes.Comprehension.assigned_stmts = for_assigned_stmts
 
 
 def sequence_assigned_stmts(
-    self: Union[nodes.Tuple, nodes.List],
+    self: nodes.Tuple | nodes.List,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     if assign_path is None:
         assign_path = []
@@ -312,10 +313,10 @@ nodes.List.assigned_stmts = sequence_assigned_stmts
 
 
 def assend_assigned_stmts(
-    self: Union[nodes.AssignName, nodes.AssignAttr],
+    self: nodes.AssignName | nodes.AssignAttr,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     return self.parent.assigned_stmts(node=self, context=context)
 
@@ -386,8 +387,8 @@ def _arguments_infer_argname(self, name, context):
 def arguments_assigned_stmts(
     self: nodes.Arguments,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     if context.callcontext:
         callee = context.callcontext.callee
@@ -414,10 +415,10 @@ nodes.Arguments.assigned_stmts = arguments_assigned_stmts
 
 @decorators.raise_if_nothing_inferred
 def assign_assigned_stmts(
-    self: Union[nodes.AugAssign, nodes.Assign, nodes.AnnAssign],
+    self: nodes.AugAssign | nodes.Assign | nodes.AnnAssign,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     if not assign_path:
         yield self.value
@@ -432,8 +433,8 @@ def assign_assigned_stmts(
 def assign_annassigned_stmts(
     self: nodes.AnnAssign,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     for inferred in assign_assigned_stmts(self, node, context, assign_path):
         if inferred is None:
@@ -491,8 +492,8 @@ def _resolve_assignment_parts(parts, assign_path, context):
 def excepthandler_assigned_stmts(
     self: nodes.ExceptHandler,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     for assigned in node_classes.unpack_infer(self.type):
         if isinstance(assigned, nodes.ClassDef):
@@ -547,8 +548,8 @@ def _infer_context_manager(self, mgr, context):
 def with_assigned_stmts(
     self: nodes.With,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     """Infer names and other nodes from a *with* statement.
 
@@ -625,8 +626,8 @@ nodes.With.assigned_stmts = with_assigned_stmts
 def named_expr_assigned_stmts(
     self: nodes.NamedExpr,
     node: node_classes.AssignedStmtsPossibleNode,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     """Infer names and other nodes from an assignment expression"""
     if self.target == node:
@@ -647,8 +648,8 @@ nodes.NamedExpr.assigned_stmts = named_expr_assigned_stmts
 def starred_assigned_stmts(
     self: nodes.Starred,
     node: node_classes.AssignedStmtsPossibleNode = None,
-    context: Optional[InferenceContext] = None,
-    assign_path: Optional[List[int]] = None,
+    context: InferenceContext | None = None,
+    assign_path: list[int] | None = None,
 ) -> Any:
     """
     Arguments:
@@ -843,7 +844,7 @@ nodes.Starred.assigned_stmts = starred_assigned_stmts
 def match_mapping_assigned_stmts(
     self: nodes.MatchMapping,
     node: nodes.AssignName,
-    context: Optional[InferenceContext] = None,
+    context: InferenceContext | None = None,
     assign_path: None = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Return empty generator (return -> raises StopIteration) so inferred value
@@ -860,7 +861,7 @@ nodes.MatchMapping.assigned_stmts = match_mapping_assigned_stmts
 def match_star_assigned_stmts(
     self: nodes.MatchStar,
     node: nodes.AssignName,
-    context: Optional[InferenceContext] = None,
+    context: InferenceContext | None = None,
     assign_path: None = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Return empty generator (return -> raises StopIteration) so inferred value
@@ -877,7 +878,7 @@ nodes.MatchStar.assigned_stmts = match_star_assigned_stmts
 def match_as_assigned_stmts(
     self: nodes.MatchAs,
     node: nodes.AssignName,
-    context: Optional[InferenceContext] = None,
+    context: InferenceContext | None = None,
     assign_path: None = None,
 ) -> Generator[nodes.NodeNG, None, None]:
     """Infer MatchAs as the Match subject if it's the only MatchCase pattern

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -5,6 +5,7 @@
 """this module contains a set of functions to handle python protocols for nodes
 where it makes sense.
 """
+
 from __future__ import annotations
 
 import collections

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -5,6 +5,7 @@
 """this module contains a set of functions to create astroid trees from scratch
 (build_* functions) or from living object (object_build_* functions)
 """
+from __future__ import annotations
 
 import builtins
 import inspect
@@ -12,7 +13,7 @@ import os
 import sys
 import types
 import warnings
-from typing import Iterable, List, Optional
+from typing import Iterable
 
 from astroid import bases, nodes
 from astroid.manager import AstroidManager
@@ -77,7 +78,7 @@ def attach_import_node(node, modname, membername):
     _attach_local_node(node, from_node, membername)
 
 
-def build_module(name: str, doc: Optional[str] = None) -> nodes.Module:
+def build_module(name: str, doc: str | None = None) -> nodes.Module:
     """create and initialize an astroid Module node"""
     node = nodes.Module(name, pure_python=False, package=False)
     node.postinit(
@@ -88,7 +89,7 @@ def build_module(name: str, doc: Optional[str] = None) -> nodes.Module:
 
 
 def build_class(
-    name: str, basenames: Iterable[str] = (), doc: Optional[str] = None
+    name: str, basenames: Iterable[str] = (), doc: str | None = None
 ) -> nodes.ClassDef:
     """Create and initialize an astroid ClassDef node."""
     node = nodes.ClassDef(name)
@@ -103,11 +104,11 @@ def build_class(
 
 def build_function(
     name,
-    args: Optional[List[str]] = None,
-    posonlyargs: Optional[List[str]] = None,
+    args: list[str] | None = None,
+    posonlyargs: list[str] | None = None,
     defaults=None,
-    doc: Optional[str] = None,
-    kwonlyargs: Optional[List[str]] = None,
+    doc: str | None = None,
+    kwonlyargs: list[str] | None = None,
 ) -> nodes.FunctionDef:
     """create and initialize an astroid FunctionDef node"""
     # first argument is now a list of decorators
@@ -288,8 +289,8 @@ class InspectBuilder:
     def inspect_build(
         self,
         module: types.ModuleType,
-        modname: Optional[str] = None,
-        path: Optional[str] = None,
+        modname: str | None = None,
+        path: str | None = None,
     ) -> nodes.Module:
         """build astroid from a living module (i.e. using inspect)
         this is used when there is no python source code available (either

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -5,6 +5,7 @@
 """this module contains a set of functions to create astroid trees from scratch
 (build_* functions) or from living object (object_build_* functions)
 """
+
 from __future__ import annotations
 
 import builtins

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -5,26 +5,14 @@
 """this module contains utilities for rebuilding an _ast tree in
 order to get a single Astroid representation
 """
+from __future__ import annotations
 
 import ast
 import sys
 import token
 from io import StringIO
 from tokenize import TokenInfo, generate_tokens
-from typing import (
-    Callable,
-    Dict,
-    Generator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Callable, Generator, TypeVar, Union, cast, overload
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment
@@ -39,7 +27,7 @@ else:
     from typing_extensions import Final
 
 
-REDIRECT: Final[Dict[str, str]] = {
+REDIRECT: Final[dict[str, str]] = {
     "arguments": "Arguments",
     "comprehension": "Comprehension",
     "ListCompFor": "Comprehension",
@@ -69,17 +57,15 @@ class TreeRebuilder:
     def __init__(
         self,
         manager: AstroidManager,
-        parser_module: Optional[ParserModule] = None,
-        data: Optional[str] = None,
+        parser_module: ParserModule | None = None,
+        data: str | None = None,
     ) -> None:
         self._manager = manager
         self._data = data.split("\n") if data else None
-        self._global_names: List[Dict[str, List[nodes.Global]]] = []
-        self._import_from_nodes: List[nodes.ImportFrom] = []
-        self._delayed_assattr: List[nodes.AssignAttr] = []
-        self._visit_meths: Dict[
-            Type["ast.AST"], Callable[["ast.AST", NodeNG], NodeNG]
-        ] = {}
+        self._global_names: list[dict[str, list[nodes.Global]]] = []
+        self._import_from_nodes: list[nodes.ImportFrom] = []
+        self._delayed_assattr: list[nodes.AssignAttr] = []
+        self._visit_meths: dict[type[ast.AST], Callable[[ast.AST, NodeNG], NodeNG]] = {}
 
         if parser_module is None:
             self._parser_module = get_parser_module()
@@ -87,7 +73,7 @@ class TreeRebuilder:
             self._parser_module = parser_module
         self._module = self._parser_module.module
 
-    def _get_doc(self, node: T_Doc) -> Tuple[T_Doc, Optional["ast.Constant | ast.Str"]]:
+    def _get_doc(self, node: T_Doc) -> tuple[T_Doc, ast.Constant | ast.Str | None]:
         """Return the doc ast node."""
         try:
             if node.body and isinstance(node.body[0], self._module.Expr):
@@ -110,22 +96,22 @@ class TreeRebuilder:
 
     def _get_context(
         self,
-        node: Union[
-            "ast.Attribute",
-            "ast.List",
-            "ast.Name",
-            "ast.Subscript",
-            "ast.Starred",
-            "ast.Tuple",
-        ],
+        node: (
+            ast.Attribute
+            | ast.List
+            | ast.Name
+            | ast.Subscript
+            | ast.Starred
+            | ast.Tuple
+        ),
     ) -> Context:
         return self._parser_module.context_classes.get(type(node.ctx), Context.Load)
 
     def _get_position_info(
         self,
-        node: Union["ast.ClassDef", "ast.FunctionDef", "ast.AsyncFunctionDef"],
-        parent: Union[nodes.ClassDef, nodes.FunctionDef, nodes.AsyncFunctionDef],
-    ) -> Optional[Position]:
+        node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+        parent: nodes.ClassDef | nodes.FunctionDef | nodes.AsyncFunctionDef,
+    ) -> Position | None:
         """Return position information for ClassDef and FunctionDef nodes.
 
         In contrast to AST positions, these only include the actual keyword(s)
@@ -137,14 +123,14 @@ class TreeRebuilder:
         """
         if not self._data:
             return None
-        end_lineno: Optional[int] = getattr(node, "end_lineno", None)
+        end_lineno: int | None = getattr(node, "end_lineno", None)
         if node.body:
             end_lineno = node.body[0].lineno
         # pylint: disable-next=unsubscriptable-object
         data = "\n".join(self._data[node.lineno - 1 : end_lineno])
 
-        start_token: Optional[TokenInfo] = None
-        keyword_tokens: Tuple[int, ...] = (token.NAME,)
+        start_token: TokenInfo | None = None
+        keyword_tokens: tuple[int, ...] = (token.NAME,)
         if isinstance(parent, nodes.AsyncFunctionDef):
             search_token = "async"
         elif isinstance(parent, nodes.FunctionDef):
@@ -185,7 +171,7 @@ class TreeRebuilder:
             return
 
         lineno = node.lineno or 1  # lineno of modules is 0
-        end_range: Optional[int] = node.doc_node.lineno
+        end_range: int | None = node.doc_node.lineno
         if IS_PYPY and not PY39_PLUS:
             end_range = None
         # pylint: disable-next=unsubscriptable-object
@@ -193,7 +179,7 @@ class TreeRebuilder:
 
         found_start, found_end = False, False
         open_brackets = 0
-        skip_token: Set[int] = {token.NEWLINE, token.INDENT, token.NL, token.COMMENT}
+        skip_token: set[int] = {token.NEWLINE, token.INDENT, token.NL, token.COMMENT}
 
         if isinstance(node, nodes.Module):
             found_end = True
@@ -249,7 +235,7 @@ class TreeRebuilder:
             self._reset_end_lineno(child_node)
 
     def visit_module(
-        self, node: "ast.Module", modname: str, modpath: str, package: bool
+        self, node: ast.Module, modname: str, modpath: str, package: bool
     ) -> nodes.Module:
         """visit a Module node by returning a fresh instance of it
 
@@ -273,332 +259,330 @@ class TreeRebuilder:
         return newnode
 
     @overload
-    def visit(self, node: "ast.arg", parent: NodeNG) -> nodes.AssignName:
+    def visit(self, node: ast.arg, parent: NodeNG) -> nodes.AssignName:
         ...
 
     @overload
-    def visit(self, node: "ast.arguments", parent: NodeNG) -> nodes.Arguments:
+    def visit(self, node: ast.arguments, parent: NodeNG) -> nodes.Arguments:
         ...
 
     @overload
-    def visit(self, node: "ast.Assert", parent: NodeNG) -> nodes.Assert:
+    def visit(self, node: ast.Assert, parent: NodeNG) -> nodes.Assert:
         ...
 
     @overload
     def visit(
-        self, node: "ast.AsyncFunctionDef", parent: NodeNG
+        self, node: ast.AsyncFunctionDef, parent: NodeNG
     ) -> nodes.AsyncFunctionDef:
         ...
 
     @overload
-    def visit(self, node: "ast.AsyncFor", parent: NodeNG) -> nodes.AsyncFor:
+    def visit(self, node: ast.AsyncFor, parent: NodeNG) -> nodes.AsyncFor:
         ...
 
     @overload
-    def visit(self, node: "ast.Await", parent: NodeNG) -> nodes.Await:
+    def visit(self, node: ast.Await, parent: NodeNG) -> nodes.Await:
         ...
 
     @overload
-    def visit(self, node: "ast.AsyncWith", parent: NodeNG) -> nodes.AsyncWith:
+    def visit(self, node: ast.AsyncWith, parent: NodeNG) -> nodes.AsyncWith:
         ...
 
     @overload
-    def visit(self, node: "ast.Assign", parent: NodeNG) -> nodes.Assign:
+    def visit(self, node: ast.Assign, parent: NodeNG) -> nodes.Assign:
         ...
 
     @overload
-    def visit(self, node: "ast.AnnAssign", parent: NodeNG) -> nodes.AnnAssign:
+    def visit(self, node: ast.AnnAssign, parent: NodeNG) -> nodes.AnnAssign:
         ...
 
     @overload
-    def visit(self, node: "ast.AugAssign", parent: NodeNG) -> nodes.AugAssign:
+    def visit(self, node: ast.AugAssign, parent: NodeNG) -> nodes.AugAssign:
         ...
 
     @overload
-    def visit(self, node: "ast.BinOp", parent: NodeNG) -> nodes.BinOp:
+    def visit(self, node: ast.BinOp, parent: NodeNG) -> nodes.BinOp:
         ...
 
     @overload
-    def visit(self, node: "ast.BoolOp", parent: NodeNG) -> nodes.BoolOp:
+    def visit(self, node: ast.BoolOp, parent: NodeNG) -> nodes.BoolOp:
         ...
 
     @overload
-    def visit(self, node: "ast.Break", parent: NodeNG) -> nodes.Break:
+    def visit(self, node: ast.Break, parent: NodeNG) -> nodes.Break:
         ...
 
     @overload
-    def visit(self, node: "ast.Call", parent: NodeNG) -> nodes.Call:
+    def visit(self, node: ast.Call, parent: NodeNG) -> nodes.Call:
         ...
 
     @overload
-    def visit(self, node: "ast.ClassDef", parent: NodeNG) -> nodes.ClassDef:
+    def visit(self, node: ast.ClassDef, parent: NodeNG) -> nodes.ClassDef:
         ...
 
     @overload
-    def visit(self, node: "ast.Continue", parent: NodeNG) -> nodes.Continue:
+    def visit(self, node: ast.Continue, parent: NodeNG) -> nodes.Continue:
         ...
 
     @overload
-    def visit(self, node: "ast.Compare", parent: NodeNG) -> nodes.Compare:
+    def visit(self, node: ast.Compare, parent: NodeNG) -> nodes.Compare:
         ...
 
     @overload
-    def visit(self, node: "ast.comprehension", parent: NodeNG) -> nodes.Comprehension:
+    def visit(self, node: ast.comprehension, parent: NodeNG) -> nodes.Comprehension:
         ...
 
     @overload
-    def visit(self, node: "ast.Delete", parent: NodeNG) -> nodes.Delete:
+    def visit(self, node: ast.Delete, parent: NodeNG) -> nodes.Delete:
         ...
 
     @overload
-    def visit(self, node: "ast.Dict", parent: NodeNG) -> nodes.Dict:
+    def visit(self, node: ast.Dict, parent: NodeNG) -> nodes.Dict:
         ...
 
     @overload
-    def visit(self, node: "ast.DictComp", parent: NodeNG) -> nodes.DictComp:
+    def visit(self, node: ast.DictComp, parent: NodeNG) -> nodes.DictComp:
         ...
 
     @overload
-    def visit(self, node: "ast.Expr", parent: NodeNG) -> nodes.Expr:
+    def visit(self, node: ast.Expr, parent: NodeNG) -> nodes.Expr:
         ...
 
     @overload
-    def visit(self, node: "ast.ExceptHandler", parent: NodeNG) -> nodes.ExceptHandler:
+    def visit(self, node: ast.ExceptHandler, parent: NodeNG) -> nodes.ExceptHandler:
         ...
 
     @overload
-    def visit(self, node: "ast.For", parent: NodeNG) -> nodes.For:
+    def visit(self, node: ast.For, parent: NodeNG) -> nodes.For:
         ...
 
     @overload
-    def visit(self, node: "ast.ImportFrom", parent: NodeNG) -> nodes.ImportFrom:
+    def visit(self, node: ast.ImportFrom, parent: NodeNG) -> nodes.ImportFrom:
         ...
 
     @overload
-    def visit(self, node: "ast.FunctionDef", parent: NodeNG) -> nodes.FunctionDef:
+    def visit(self, node: ast.FunctionDef, parent: NodeNG) -> nodes.FunctionDef:
         ...
 
     @overload
-    def visit(self, node: "ast.GeneratorExp", parent: NodeNG) -> nodes.GeneratorExp:
+    def visit(self, node: ast.GeneratorExp, parent: NodeNG) -> nodes.GeneratorExp:
         ...
 
     @overload
-    def visit(self, node: "ast.Attribute", parent: NodeNG) -> nodes.Attribute:
+    def visit(self, node: ast.Attribute, parent: NodeNG) -> nodes.Attribute:
         ...
 
     @overload
-    def visit(self, node: "ast.Global", parent: NodeNG) -> nodes.Global:
+    def visit(self, node: ast.Global, parent: NodeNG) -> nodes.Global:
         ...
 
     @overload
-    def visit(self, node: "ast.If", parent: NodeNG) -> nodes.If:
+    def visit(self, node: ast.If, parent: NodeNG) -> nodes.If:
         ...
 
     @overload
-    def visit(self, node: "ast.IfExp", parent: NodeNG) -> nodes.IfExp:
+    def visit(self, node: ast.IfExp, parent: NodeNG) -> nodes.IfExp:
         ...
 
     @overload
-    def visit(self, node: "ast.Import", parent: NodeNG) -> nodes.Import:
+    def visit(self, node: ast.Import, parent: NodeNG) -> nodes.Import:
         ...
 
     @overload
-    def visit(self, node: "ast.JoinedStr", parent: NodeNG) -> nodes.JoinedStr:
+    def visit(self, node: ast.JoinedStr, parent: NodeNG) -> nodes.JoinedStr:
         ...
 
     @overload
-    def visit(self, node: "ast.FormattedValue", parent: NodeNG) -> nodes.FormattedValue:
+    def visit(self, node: ast.FormattedValue, parent: NodeNG) -> nodes.FormattedValue:
         ...
 
     if sys.version_info >= (3, 8):
 
         @overload
-        def visit(self, node: "ast.NamedExpr", parent: NodeNG) -> nodes.NamedExpr:
+        def visit(self, node: ast.NamedExpr, parent: NodeNG) -> nodes.NamedExpr:
             ...
 
     if sys.version_info < (3, 9):
         # Not used in Python 3.9+
         @overload
-        def visit(self, node: "ast.ExtSlice", parent: nodes.Subscript) -> nodes.Tuple:
+        def visit(self, node: ast.ExtSlice, parent: nodes.Subscript) -> nodes.Tuple:
             ...
 
         @overload
-        def visit(self, node: "ast.Index", parent: nodes.Subscript) -> NodeNG:
+        def visit(self, node: ast.Index, parent: nodes.Subscript) -> NodeNG:
             ...
 
     @overload
-    def visit(self, node: "ast.keyword", parent: NodeNG) -> nodes.Keyword:
+    def visit(self, node: ast.keyword, parent: NodeNG) -> nodes.Keyword:
         ...
 
     @overload
-    def visit(self, node: "ast.Lambda", parent: NodeNG) -> nodes.Lambda:
+    def visit(self, node: ast.Lambda, parent: NodeNG) -> nodes.Lambda:
         ...
 
     @overload
-    def visit(self, node: "ast.List", parent: NodeNG) -> nodes.List:
+    def visit(self, node: ast.List, parent: NodeNG) -> nodes.List:
         ...
 
     @overload
-    def visit(self, node: "ast.ListComp", parent: NodeNG) -> nodes.ListComp:
+    def visit(self, node: ast.ListComp, parent: NodeNG) -> nodes.ListComp:
         ...
 
     @overload
     def visit(
-        self, node: "ast.Name", parent: NodeNG
-    ) -> Union[nodes.Name, nodes.Const, nodes.AssignName, nodes.DelName]:
+        self, node: ast.Name, parent: NodeNG
+    ) -> nodes.Name | nodes.Const | nodes.AssignName | nodes.DelName:
         ...
 
     @overload
-    def visit(self, node: "ast.Nonlocal", parent: NodeNG) -> nodes.Nonlocal:
+    def visit(self, node: ast.Nonlocal, parent: NodeNG) -> nodes.Nonlocal:
         ...
 
     if sys.version_info < (3, 8):
         # Not used in Python 3.8+
         @overload
-        def visit(self, node: "ast.Ellipsis", parent: NodeNG) -> nodes.Const:
+        def visit(self, node: ast.Ellipsis, parent: NodeNG) -> nodes.Const:
             ...
 
         @overload
-        def visit(self, node: "ast.NameConstant", parent: NodeNG) -> nodes.Const:
+        def visit(self, node: ast.NameConstant, parent: NodeNG) -> nodes.Const:
             ...
 
         @overload
-        def visit(self, node: "ast.Str", parent: NodeNG) -> nodes.Const:
+        def visit(self, node: ast.Str, parent: NodeNG) -> nodes.Const:
             ...
 
         @overload
-        def visit(self, node: "ast.Bytes", parent: NodeNG) -> nodes.Const:
+        def visit(self, node: ast.Bytes, parent: NodeNG) -> nodes.Const:
             ...
 
         @overload
-        def visit(self, node: "ast.Num", parent: NodeNG) -> nodes.Const:
+        def visit(self, node: ast.Num, parent: NodeNG) -> nodes.Const:
             ...
 
     @overload
-    def visit(self, node: "ast.Constant", parent: NodeNG) -> nodes.Const:
+    def visit(self, node: ast.Constant, parent: NodeNG) -> nodes.Const:
         ...
 
     @overload
-    def visit(self, node: "ast.Pass", parent: NodeNG) -> nodes.Pass:
+    def visit(self, node: ast.Pass, parent: NodeNG) -> nodes.Pass:
         ...
 
     @overload
-    def visit(self, node: "ast.Raise", parent: NodeNG) -> nodes.Raise:
+    def visit(self, node: ast.Raise, parent: NodeNG) -> nodes.Raise:
         ...
 
     @overload
-    def visit(self, node: "ast.Return", parent: NodeNG) -> nodes.Return:
+    def visit(self, node: ast.Return, parent: NodeNG) -> nodes.Return:
         ...
 
     @overload
-    def visit(self, node: "ast.Set", parent: NodeNG) -> nodes.Set:
+    def visit(self, node: ast.Set, parent: NodeNG) -> nodes.Set:
         ...
 
     @overload
-    def visit(self, node: "ast.SetComp", parent: NodeNG) -> nodes.SetComp:
+    def visit(self, node: ast.SetComp, parent: NodeNG) -> nodes.SetComp:
         ...
 
     @overload
-    def visit(self, node: "ast.Slice", parent: nodes.Subscript) -> nodes.Slice:
+    def visit(self, node: ast.Slice, parent: nodes.Subscript) -> nodes.Slice:
         ...
 
     @overload
-    def visit(self, node: "ast.Subscript", parent: NodeNG) -> nodes.Subscript:
+    def visit(self, node: ast.Subscript, parent: NodeNG) -> nodes.Subscript:
         ...
 
     @overload
-    def visit(self, node: "ast.Starred", parent: NodeNG) -> nodes.Starred:
+    def visit(self, node: ast.Starred, parent: NodeNG) -> nodes.Starred:
         ...
 
     @overload
     def visit(
-        self, node: "ast.Try", parent: NodeNG
-    ) -> Union[nodes.TryExcept, nodes.TryFinally]:
+        self, node: ast.Try, parent: NodeNG
+    ) -> nodes.TryExcept | nodes.TryFinally:
         ...
 
     @overload
-    def visit(self, node: "ast.Tuple", parent: NodeNG) -> nodes.Tuple:
+    def visit(self, node: ast.Tuple, parent: NodeNG) -> nodes.Tuple:
         ...
 
     @overload
-    def visit(self, node: "ast.UnaryOp", parent: NodeNG) -> nodes.UnaryOp:
+    def visit(self, node: ast.UnaryOp, parent: NodeNG) -> nodes.UnaryOp:
         ...
 
     @overload
-    def visit(self, node: "ast.While", parent: NodeNG) -> nodes.While:
+    def visit(self, node: ast.While, parent: NodeNG) -> nodes.While:
         ...
 
     @overload
-    def visit(self, node: "ast.With", parent: NodeNG) -> nodes.With:
+    def visit(self, node: ast.With, parent: NodeNG) -> nodes.With:
         ...
 
     @overload
-    def visit(self, node: "ast.Yield", parent: NodeNG) -> nodes.Yield:
+    def visit(self, node: ast.Yield, parent: NodeNG) -> nodes.Yield:
         ...
 
     @overload
-    def visit(self, node: "ast.YieldFrom", parent: NodeNG) -> nodes.YieldFrom:
+    def visit(self, node: ast.YieldFrom, parent: NodeNG) -> nodes.YieldFrom:
         ...
 
     if sys.version_info >= (3, 10):
 
         @overload
-        def visit(self, node: "ast.Match", parent: NodeNG) -> nodes.Match:
+        def visit(self, node: ast.Match, parent: NodeNG) -> nodes.Match:
             ...
 
         @overload
-        def visit(self, node: "ast.match_case", parent: NodeNG) -> nodes.MatchCase:
+        def visit(self, node: ast.match_case, parent: NodeNG) -> nodes.MatchCase:
             ...
 
         @overload
-        def visit(self, node: "ast.MatchValue", parent: NodeNG) -> nodes.MatchValue:
+        def visit(self, node: ast.MatchValue, parent: NodeNG) -> nodes.MatchValue:
             ...
 
         @overload
         def visit(
-            self, node: "ast.MatchSingleton", parent: NodeNG
+            self, node: ast.MatchSingleton, parent: NodeNG
         ) -> nodes.MatchSingleton:
             ...
 
         @overload
-        def visit(
-            self, node: "ast.MatchSequence", parent: NodeNG
-        ) -> nodes.MatchSequence:
+        def visit(self, node: ast.MatchSequence, parent: NodeNG) -> nodes.MatchSequence:
             ...
 
         @overload
-        def visit(self, node: "ast.MatchMapping", parent: NodeNG) -> nodes.MatchMapping:
+        def visit(self, node: ast.MatchMapping, parent: NodeNG) -> nodes.MatchMapping:
             ...
 
         @overload
-        def visit(self, node: "ast.MatchClass", parent: NodeNG) -> nodes.MatchClass:
+        def visit(self, node: ast.MatchClass, parent: NodeNG) -> nodes.MatchClass:
             ...
 
         @overload
-        def visit(self, node: "ast.MatchStar", parent: NodeNG) -> nodes.MatchStar:
+        def visit(self, node: ast.MatchStar, parent: NodeNG) -> nodes.MatchStar:
             ...
 
         @overload
-        def visit(self, node: "ast.MatchAs", parent: NodeNG) -> nodes.MatchAs:
+        def visit(self, node: ast.MatchAs, parent: NodeNG) -> nodes.MatchAs:
             ...
 
         @overload
-        def visit(self, node: "ast.MatchOr", parent: NodeNG) -> nodes.MatchOr:
+        def visit(self, node: ast.MatchOr, parent: NodeNG) -> nodes.MatchOr:
             ...
 
         @overload
-        def visit(self, node: "ast.pattern", parent: NodeNG) -> nodes.Pattern:
+        def visit(self, node: ast.pattern, parent: NodeNG) -> nodes.Pattern:
             ...
 
     @overload
-    def visit(self, node: "ast.AST", parent: NodeNG) -> NodeNG:
+    def visit(self, node: ast.AST, parent: NodeNG) -> NodeNG:
         ...
 
     @overload
     def visit(self, node: None, parent: NodeNG) -> None:
         ...
 
-    def visit(self, node: Optional["ast.AST"], parent: NodeNG) -> Optional[NodeNG]:
+    def visit(self, node: ast.AST | None, parent: NodeNG) -> NodeNG | None:
         if node is None:
             return None
         cls = node.__class__
@@ -611,7 +595,7 @@ class TreeRebuilder:
             self._visit_meths[cls] = visit_method
         return visit_method(node, parent)
 
-    def _save_assignment(self, node: Union[nodes.AssignName, nodes.DelName]) -> None:
+    def _save_assignment(self, node: nodes.AssignName | nodes.DelName) -> None:
         """save assignment situation since node.parent is not available yet"""
         if self._global_names and node.name in self._global_names[-1]:
             node.root().set_local(node.name, node)
@@ -619,14 +603,14 @@ class TreeRebuilder:
             assert node.parent
             node.parent.set_local(node.name, node)
 
-    def visit_arg(self, node: "ast.arg", parent: NodeNG) -> nodes.AssignName:
+    def visit_arg(self, node: ast.arg, parent: NodeNG) -> nodes.AssignName:
         """visit an arg node by returning a fresh AssName instance"""
         return self.visit_assignname(node, parent, node.arg)
 
-    def visit_arguments(self, node: "ast.arguments", parent: NodeNG) -> nodes.Arguments:
+    def visit_arguments(self, node: ast.arguments, parent: NodeNG) -> nodes.Arguments:
         """visit an Arguments node by returning a fresh instance of it"""
-        vararg: Optional[str] = None
-        kwarg: Optional[str] = None
+        vararg: str | None = None
+        kwarg: str | None = None
         newnode = nodes.Arguments(
             node.vararg.arg if node.vararg else None,
             node.kwarg.arg if node.kwarg else None,
@@ -634,9 +618,9 @@ class TreeRebuilder:
         )
         args = [self.visit(child, newnode) for child in node.args]
         defaults = [self.visit(child, newnode) for child in node.defaults]
-        varargannotation: Optional[NodeNG] = None
-        kwargannotation: Optional[NodeNG] = None
-        posonlyargs: List[nodes.AssignName] = []
+        varargannotation: NodeNG | None = None
+        kwargannotation: NodeNG | None = None
+        posonlyargs: list[nodes.AssignName] = []
         if node.vararg:
             vararg = node.vararg.arg
             varargannotation = self.visit(node.vararg.annotation, newnode)
@@ -659,7 +643,7 @@ class TreeRebuilder:
             self.visit(arg.annotation, newnode) for arg in node.kwonlyargs
         ]
 
-        posonlyargs_annotations: List[Optional[NodeNG]] = []
+        posonlyargs_annotations: list[NodeNG | None] = []
         if PY38_PLUS:
             posonlyargs = [self.visit(child, newnode) for child in node.posonlyargs]
             posonlyargs_annotations = [
@@ -671,7 +655,7 @@ class TreeRebuilder:
         type_comment_kwonlyargs = [
             self.check_type_comment(child, parent=newnode) for child in node.kwonlyargs
         ]
-        type_comment_posonlyargs: List[Optional[NodeNG]] = []
+        type_comment_posonlyargs: list[NodeNG | None] = []
         if PY38_PLUS:
             type_comment_posonlyargs = [
                 self.check_type_comment(child, parent=newnode)
@@ -701,7 +685,7 @@ class TreeRebuilder:
             newnode.parent.set_local(kwarg, newnode)
         return newnode
 
-    def visit_assert(self, node: "ast.Assert", parent: NodeNG) -> nodes.Assert:
+    def visit_assert(self, node: ast.Assert, parent: NodeNG) -> nodes.Assert:
         """visit a Assert node by returning a fresh instance of it"""
         newnode = nodes.Assert(
             lineno=node.lineno,
@@ -711,7 +695,7 @@ class TreeRebuilder:
             end_col_offset=getattr(node, "end_col_offset", None),
             parent=parent,
         )
-        msg: Optional[NodeNG] = None
+        msg: NodeNG | None = None
         if node.msg:
             msg = self.visit(node.msg, newnode)
         newnode.postinit(self.visit(node.test, newnode), msg)
@@ -719,23 +703,18 @@ class TreeRebuilder:
 
     def check_type_comment(
         self,
-        node: Union[
-            "ast.Assign",
-            "ast.arg",
-            "ast.For",
-            "ast.AsyncFor",
-            "ast.With",
-            "ast.AsyncWith",
-        ],
-        parent: Union[
-            nodes.Assign,
-            nodes.Arguments,
-            nodes.For,
-            nodes.AsyncFor,
-            nodes.With,
-            nodes.AsyncWith,
-        ],
-    ) -> Optional[NodeNG]:
+        node: (
+            ast.Assign | ast.arg | ast.For | ast.AsyncFor | ast.With | ast.AsyncWith
+        ),
+        parent: (
+            nodes.Assign
+            | nodes.Arguments
+            | nodes.For
+            | nodes.AsyncFor
+            | nodes.With
+            | nodes.AsyncWith
+        ),
+    ) -> NodeNG | None:
         type_comment = getattr(node, "type_comment", None)  # Added in Python 3.8
         if not type_comment:
             return None
@@ -753,8 +732,8 @@ class TreeRebuilder:
         return type_object.value
 
     def check_function_type_comment(
-        self, node: Union["ast.FunctionDef", "ast.AsyncFunctionDef"], parent: NodeNG
-    ) -> Optional[Tuple[Optional[NodeNG], List[NodeNG]]]:
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef, parent: NodeNG
+    ) -> tuple[NodeNG | None, list[NodeNG]] | None:
         type_comment = getattr(node, "type_comment", None)  # Added in Python 3.8
         if not type_comment:
             return None
@@ -768,8 +747,8 @@ class TreeRebuilder:
         if not type_comment_ast:
             return None
 
-        returns: Optional[NodeNG] = None
-        argtypes: List[NodeNG] = [
+        returns: NodeNG | None = None
+        argtypes: list[NodeNG] = [
             self.visit(elem, parent) for elem in (type_comment_ast.argtypes or [])
         ]
         if type_comment_ast.returns:
@@ -778,14 +757,14 @@ class TreeRebuilder:
         return returns, argtypes
 
     def visit_asyncfunctiondef(
-        self, node: "ast.AsyncFunctionDef", parent: NodeNG
+        self, node: ast.AsyncFunctionDef, parent: NodeNG
     ) -> nodes.AsyncFunctionDef:
         return self._visit_functiondef(nodes.AsyncFunctionDef, node, parent)
 
-    def visit_asyncfor(self, node: "ast.AsyncFor", parent: NodeNG) -> nodes.AsyncFor:
+    def visit_asyncfor(self, node: ast.AsyncFor, parent: NodeNG) -> nodes.AsyncFor:
         return self._visit_for(nodes.AsyncFor, node, parent)
 
-    def visit_await(self, node: "ast.Await", parent: NodeNG) -> nodes.Await:
+    def visit_await(self, node: ast.Await, parent: NodeNG) -> nodes.Await:
         newnode = nodes.Await(
             lineno=node.lineno,
             col_offset=node.col_offset,
@@ -797,10 +776,10 @@ class TreeRebuilder:
         newnode.postinit(value=self.visit(node.value, newnode))
         return newnode
 
-    def visit_asyncwith(self, node: "ast.AsyncWith", parent: NodeNG) -> nodes.AsyncWith:
+    def visit_asyncwith(self, node: ast.AsyncWith, parent: NodeNG) -> nodes.AsyncWith:
         return self._visit_with(nodes.AsyncWith, node, parent)
 
-    def visit_assign(self, node: "ast.Assign", parent: NodeNG) -> nodes.Assign:
+    def visit_assign(self, node: ast.Assign, parent: NodeNG) -> nodes.Assign:
         """visit a Assign node by returning a fresh instance of it"""
         newnode = nodes.Assign(
             lineno=node.lineno,
@@ -818,7 +797,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_annassign(self, node: "ast.AnnAssign", parent: NodeNG) -> nodes.AnnAssign:
+    def visit_annassign(self, node: ast.AnnAssign, parent: NodeNG) -> nodes.AnnAssign:
         """visit an AnnAssign node by returning a fresh instance of it"""
         newnode = nodes.AnnAssign(
             lineno=node.lineno,
@@ -838,19 +817,17 @@ class TreeRebuilder:
 
     @overload
     def visit_assignname(
-        self, node: "ast.AST", parent: NodeNG, node_name: str
+        self, node: ast.AST, parent: NodeNG, node_name: str
     ) -> nodes.AssignName:
         ...
 
     @overload
-    def visit_assignname(
-        self, node: "ast.AST", parent: NodeNG, node_name: None
-    ) -> None:
+    def visit_assignname(self, node: ast.AST, parent: NodeNG, node_name: None) -> None:
         ...
 
     def visit_assignname(
-        self, node: "ast.AST", parent: NodeNG, node_name: Optional[str]
-    ) -> Optional[nodes.AssignName]:
+        self, node: ast.AST, parent: NodeNG, node_name: str | None
+    ) -> nodes.AssignName | None:
         """visit a node and return a AssignName node
 
         Note: Method not called by 'visit'
@@ -869,7 +846,7 @@ class TreeRebuilder:
         self._save_assignment(newnode)
         return newnode
 
-    def visit_augassign(self, node: "ast.AugAssign", parent: NodeNG) -> nodes.AugAssign:
+    def visit_augassign(self, node: ast.AugAssign, parent: NodeNG) -> nodes.AugAssign:
         """visit a AugAssign node by returning a fresh instance of it"""
         newnode = nodes.AugAssign(
             op=self._parser_module.bin_op_classes[type(node.op)] + "=",
@@ -885,7 +862,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_binop(self, node: "ast.BinOp", parent: NodeNG) -> nodes.BinOp:
+    def visit_binop(self, node: ast.BinOp, parent: NodeNG) -> nodes.BinOp:
         """visit a BinOp node by returning a fresh instance of it"""
         newnode = nodes.BinOp(
             op=self._parser_module.bin_op_classes[type(node.op)],
@@ -901,7 +878,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_boolop(self, node: "ast.BoolOp", parent: NodeNG) -> nodes.BoolOp:
+    def visit_boolop(self, node: ast.BoolOp, parent: NodeNG) -> nodes.BoolOp:
         """visit a BoolOp node by returning a fresh instance of it"""
         newnode = nodes.BoolOp(
             op=self._parser_module.bool_op_classes[type(node.op)],
@@ -915,7 +892,7 @@ class TreeRebuilder:
         newnode.postinit([self.visit(child, newnode) for child in node.values])
         return newnode
 
-    def visit_break(self, node: "ast.Break", parent: NodeNG) -> nodes.Break:
+    def visit_break(self, node: ast.Break, parent: NodeNG) -> nodes.Break:
         """visit a Break node by returning a fresh instance of it"""
         return nodes.Break(
             lineno=node.lineno,
@@ -926,7 +903,7 @@ class TreeRebuilder:
             parent=parent,
         )
 
-    def visit_call(self, node: "ast.Call", parent: NodeNG) -> nodes.Call:
+    def visit_call(self, node: ast.Call, parent: NodeNG) -> nodes.Call:
         """visit a CallFunc node by returning a fresh instance of it"""
         newnode = nodes.Call(
             lineno=node.lineno,
@@ -944,7 +921,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_classdef(
-        self, node: "ast.ClassDef", parent: NodeNG, newstyle: bool = True
+        self, node: ast.ClassDef, parent: NodeNG, newstyle: bool = True
     ) -> nodes.ClassDef:
         """visit a ClassDef node to become astroid"""
         node, doc_ast_node = self._get_doc(node)
@@ -980,7 +957,7 @@ class TreeRebuilder:
         self._fix_doc_node_position(newnode)
         return newnode
 
-    def visit_continue(self, node: "ast.Continue", parent: NodeNG) -> nodes.Continue:
+    def visit_continue(self, node: ast.Continue, parent: NodeNG) -> nodes.Continue:
         """visit a Continue node by returning a fresh instance of it"""
         return nodes.Continue(
             lineno=node.lineno,
@@ -991,7 +968,7 @@ class TreeRebuilder:
             parent=parent,
         )
 
-    def visit_compare(self, node: "ast.Compare", parent: NodeNG) -> nodes.Compare:
+    def visit_compare(self, node: ast.Compare, parent: NodeNG) -> nodes.Compare:
         """visit a Compare node by returning a fresh instance of it"""
         newnode = nodes.Compare(
             lineno=node.lineno,
@@ -1014,7 +991,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_comprehension(
-        self, node: "ast.comprehension", parent: NodeNG
+        self, node: ast.comprehension, parent: NodeNG
     ) -> nodes.Comprehension:
         """visit a Comprehension node by returning a fresh instance of it"""
         newnode = nodes.Comprehension(parent)
@@ -1028,9 +1005,9 @@ class TreeRebuilder:
 
     def visit_decorators(
         self,
-        node: Union["ast.ClassDef", "ast.FunctionDef", "ast.AsyncFunctionDef"],
+        node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
         parent: NodeNG,
-    ) -> Optional[nodes.Decorators]:
+    ) -> nodes.Decorators | None:
         """visit a Decorators node by returning a fresh instance of it
 
         Note: Method not called by 'visit'
@@ -1058,7 +1035,7 @@ class TreeRebuilder:
         newnode.postinit([self.visit(child, newnode) for child in node.decorator_list])
         return newnode
 
-    def visit_delete(self, node: "ast.Delete", parent: NodeNG) -> nodes.Delete:
+    def visit_delete(self, node: ast.Delete, parent: NodeNG) -> nodes.Delete:
         """visit a Delete node by returning a fresh instance of it"""
         newnode = nodes.Delete(
             lineno=node.lineno,
@@ -1072,8 +1049,8 @@ class TreeRebuilder:
         return newnode
 
     def _visit_dict_items(
-        self, node: "ast.Dict", parent: NodeNG, newnode: nodes.Dict
-    ) -> Generator[Tuple[NodeNG, NodeNG], None, None]:
+        self, node: ast.Dict, parent: NodeNG, newnode: nodes.Dict
+    ) -> Generator[tuple[NodeNG, NodeNG], None, None]:
         for key, value in zip(node.keys, node.values):
             rebuilt_key: NodeNG
             rebuilt_value = self.visit(value, newnode)
@@ -1091,7 +1068,7 @@ class TreeRebuilder:
                 rebuilt_key = self.visit(key, newnode)
             yield rebuilt_key, rebuilt_value
 
-    def visit_dict(self, node: "ast.Dict", parent: NodeNG) -> nodes.Dict:
+    def visit_dict(self, node: ast.Dict, parent: NodeNG) -> nodes.Dict:
         """visit a Dict node by returning a fresh instance of it"""
         newnode = nodes.Dict(
             lineno=node.lineno,
@@ -1105,7 +1082,7 @@ class TreeRebuilder:
         newnode.postinit(items)
         return newnode
 
-    def visit_dictcomp(self, node: "ast.DictComp", parent: NodeNG) -> nodes.DictComp:
+    def visit_dictcomp(self, node: ast.DictComp, parent: NodeNG) -> nodes.DictComp:
         """visit a DictComp node by returning a fresh instance of it"""
         newnode = nodes.DictComp(
             lineno=node.lineno,
@@ -1122,7 +1099,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_expr(self, node: "ast.Expr", parent: NodeNG) -> nodes.Expr:
+    def visit_expr(self, node: ast.Expr, parent: NodeNG) -> nodes.Expr:
         """visit a Expr node by returning a fresh instance of it"""
         newnode = nodes.Expr(
             lineno=node.lineno,
@@ -1136,7 +1113,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_excepthandler(
-        self, node: "ast.ExceptHandler", parent: NodeNG
+        self, node: ast.ExceptHandler, parent: NodeNG
     ) -> nodes.ExceptHandler:
         """visit an ExceptHandler node by returning a fresh instance of it"""
         newnode = nodes.ExceptHandler(
@@ -1156,18 +1133,18 @@ class TreeRebuilder:
 
     @overload
     def _visit_for(
-        self, cls: Type[nodes.For], node: "ast.For", parent: NodeNG
+        self, cls: type[nodes.For], node: ast.For, parent: NodeNG
     ) -> nodes.For:
         ...
 
     @overload
     def _visit_for(
-        self, cls: Type[nodes.AsyncFor], node: "ast.AsyncFor", parent: NodeNG
+        self, cls: type[nodes.AsyncFor], node: ast.AsyncFor, parent: NodeNG
     ) -> nodes.AsyncFor:
         ...
 
     def _visit_for(
-        self, cls: Type[_ForT], node: Union["ast.For", "ast.AsyncFor"], parent: NodeNG
+        self, cls: type[_ForT], node: ast.For | ast.AsyncFor, parent: NodeNG
     ) -> _ForT:
         """visit a For node by returning a fresh instance of it"""
         col_offset = node.col_offset
@@ -1193,11 +1170,11 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_for(self, node: "ast.For", parent: NodeNG) -> nodes.For:
+    def visit_for(self, node: ast.For, parent: NodeNG) -> nodes.For:
         return self._visit_for(nodes.For, node, parent)
 
     def visit_importfrom(
-        self, node: "ast.ImportFrom", parent: NodeNG
+        self, node: ast.ImportFrom, parent: NodeNG
     ) -> nodes.ImportFrom:
         """visit an ImportFrom node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
@@ -1218,23 +1195,23 @@ class TreeRebuilder:
 
     @overload
     def _visit_functiondef(
-        self, cls: Type[nodes.FunctionDef], node: "ast.FunctionDef", parent: NodeNG
+        self, cls: type[nodes.FunctionDef], node: ast.FunctionDef, parent: NodeNG
     ) -> nodes.FunctionDef:
         ...
 
     @overload
     def _visit_functiondef(
         self,
-        cls: Type[nodes.AsyncFunctionDef],
-        node: "ast.AsyncFunctionDef",
+        cls: type[nodes.AsyncFunctionDef],
+        node: ast.AsyncFunctionDef,
         parent: NodeNG,
     ) -> nodes.AsyncFunctionDef:
         ...
 
     def _visit_functiondef(
         self,
-        cls: Type[_FunctionT],
-        node: Union["ast.FunctionDef", "ast.AsyncFunctionDef"],
+        cls: type[_FunctionT],
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
         parent: NodeNG,
     ) -> _FunctionT:
         """visit an FunctionDef node to become astroid"""
@@ -1262,7 +1239,7 @@ class TreeRebuilder:
             parent=parent,
         )
         decorators = self.visit_decorators(node, newnode)
-        returns: Optional[NodeNG]
+        returns: NodeNG | None
         if node.returns:
             returns = self.visit(node.returns, newnode)
         else:
@@ -1287,12 +1264,12 @@ class TreeRebuilder:
         return newnode
 
     def visit_functiondef(
-        self, node: "ast.FunctionDef", parent: NodeNG
+        self, node: ast.FunctionDef, parent: NodeNG
     ) -> nodes.FunctionDef:
         return self._visit_functiondef(nodes.FunctionDef, node, parent)
 
     def visit_generatorexp(
-        self, node: "ast.GeneratorExp", parent: NodeNG
+        self, node: ast.GeneratorExp, parent: NodeNG
     ) -> nodes.GeneratorExp:
         """visit a GeneratorExp node by returning a fresh instance of it"""
         newnode = nodes.GeneratorExp(
@@ -1310,11 +1287,11 @@ class TreeRebuilder:
         return newnode
 
     def visit_attribute(
-        self, node: "ast.Attribute", parent: NodeNG
-    ) -> Union[nodes.Attribute, nodes.AssignAttr, nodes.DelAttr]:
+        self, node: ast.Attribute, parent: NodeNG
+    ) -> nodes.Attribute | nodes.AssignAttr | nodes.DelAttr:
         """visit an Attribute node by returning a fresh instance of it"""
         context = self._get_context(node)
-        newnode: Union[nodes.Attribute, nodes.AssignAttr, nodes.DelAttr]
+        newnode: nodes.Attribute | nodes.AssignAttr | nodes.DelAttr
         if context == Context.Del:
             # FIXME : maybe we should reintroduce and visit_delattr ?
             # for instance, deactivating assign_ctx
@@ -1355,7 +1332,7 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
-    def visit_global(self, node: "ast.Global", parent: NodeNG) -> nodes.Global:
+    def visit_global(self, node: ast.Global, parent: NodeNG) -> nodes.Global:
         """visit a Global node to become astroid"""
         newnode = nodes.Global(
             names=node.names,
@@ -1371,7 +1348,7 @@ class TreeRebuilder:
                 self._global_names[-1].setdefault(name, []).append(newnode)
         return newnode
 
-    def visit_if(self, node: "ast.If", parent: NodeNG) -> nodes.If:
+    def visit_if(self, node: ast.If, parent: NodeNG) -> nodes.If:
         """visit an If node by returning a fresh instance of it"""
         newnode = nodes.If(
             lineno=node.lineno,
@@ -1388,7 +1365,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_ifexp(self, node: "ast.IfExp", parent: NodeNG) -> nodes.IfExp:
+    def visit_ifexp(self, node: ast.IfExp, parent: NodeNG) -> nodes.IfExp:
         """visit a IfExp node by returning a fresh instance of it"""
         newnode = nodes.IfExp(
             lineno=node.lineno,
@@ -1405,7 +1382,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_import(self, node: "ast.Import", parent: NodeNG) -> nodes.Import:
+    def visit_import(self, node: ast.Import, parent: NodeNG) -> nodes.Import:
         """visit a Import node by returning a fresh instance of it"""
         names = [(alias.name, alias.asname) for alias in node.names]
         newnode = nodes.Import(
@@ -1423,7 +1400,7 @@ class TreeRebuilder:
             parent.set_local(name.split(".")[0], newnode)
         return newnode
 
-    def visit_joinedstr(self, node: "ast.JoinedStr", parent: NodeNG) -> nodes.JoinedStr:
+    def visit_joinedstr(self, node: ast.JoinedStr, parent: NodeNG) -> nodes.JoinedStr:
         newnode = nodes.JoinedStr(
             lineno=node.lineno,
             col_offset=node.col_offset,
@@ -1436,7 +1413,7 @@ class TreeRebuilder:
         return newnode
 
     def visit_formattedvalue(
-        self, node: "ast.FormattedValue", parent: NodeNG
+        self, node: ast.FormattedValue, parent: NodeNG
     ) -> nodes.FormattedValue:
         newnode = nodes.FormattedValue(
             lineno=node.lineno,
@@ -1456,7 +1433,7 @@ class TreeRebuilder:
     if sys.version_info >= (3, 8):
 
         def visit_namedexpr(
-            self, node: "ast.NamedExpr", parent: NodeNG
+            self, node: ast.NamedExpr, parent: NodeNG
         ) -> nodes.NamedExpr:
             newnode = nodes.NamedExpr(
                 lineno=node.lineno,
@@ -1474,7 +1451,7 @@ class TreeRebuilder:
     if sys.version_info < (3, 9):
         # Not used in Python 3.9+.
         def visit_extslice(
-            self, node: "ast.ExtSlice", parent: nodes.Subscript
+            self, node: ast.ExtSlice, parent: nodes.Subscript
         ) -> nodes.Tuple:
             """visit an ExtSlice node by returning a fresh instance of Tuple"""
             # ExtSlice doesn't have lineno or col_offset information
@@ -1482,11 +1459,11 @@ class TreeRebuilder:
             newnode.postinit([self.visit(dim, newnode) for dim in node.dims])
             return newnode
 
-        def visit_index(self, node: "ast.Index", parent: nodes.Subscript) -> NodeNG:
+        def visit_index(self, node: ast.Index, parent: nodes.Subscript) -> NodeNG:
             """visit a Index node by returning a fresh instance of NodeNG"""
             return self.visit(node.value, parent)
 
-    def visit_keyword(self, node: "ast.keyword", parent: NodeNG) -> nodes.Keyword:
+    def visit_keyword(self, node: ast.keyword, parent: NodeNG) -> nodes.Keyword:
         """visit a Keyword node by returning a fresh instance of it"""
         newnode = nodes.Keyword(
             arg=node.arg,
@@ -1500,7 +1477,7 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
-    def visit_lambda(self, node: "ast.Lambda", parent: NodeNG) -> nodes.Lambda:
+    def visit_lambda(self, node: ast.Lambda, parent: NodeNG) -> nodes.Lambda:
         """visit a Lambda node by returning a fresh instance of it"""
         newnode = nodes.Lambda(
             lineno=node.lineno,
@@ -1513,7 +1490,7 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.args, newnode), self.visit(node.body, newnode))
         return newnode
 
-    def visit_list(self, node: "ast.List", parent: NodeNG) -> nodes.List:
+    def visit_list(self, node: ast.List, parent: NodeNG) -> nodes.List:
         """visit a List node by returning a fresh instance of it"""
         context = self._get_context(node)
         newnode = nodes.List(
@@ -1528,7 +1505,7 @@ class TreeRebuilder:
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
-    def visit_listcomp(self, node: "ast.ListComp", parent: NodeNG) -> nodes.ListComp:
+    def visit_listcomp(self, node: ast.ListComp, parent: NodeNG) -> nodes.ListComp:
         """visit a ListComp node by returning a fresh instance of it"""
         newnode = nodes.ListComp(
             lineno=node.lineno,
@@ -1545,11 +1522,11 @@ class TreeRebuilder:
         return newnode
 
     def visit_name(
-        self, node: "ast.Name", parent: NodeNG
-    ) -> Union[nodes.Name, nodes.AssignName, nodes.DelName]:
+        self, node: ast.Name, parent: NodeNG
+    ) -> nodes.Name | nodes.AssignName | nodes.DelName:
         """visit a Name node by returning a fresh instance of it"""
         context = self._get_context(node)
-        newnode: Union[nodes.Name, nodes.AssignName, nodes.DelName]
+        newnode: nodes.Name | nodes.AssignName | nodes.DelName
         if context == Context.Del:
             newnode = nodes.DelName(
                 name=node.id,
@@ -1586,7 +1563,7 @@ class TreeRebuilder:
             self._save_assignment(newnode)
         return newnode
 
-    def visit_nonlocal(self, node: "ast.Nonlocal", parent: NodeNG) -> nodes.Nonlocal:
+    def visit_nonlocal(self, node: ast.Nonlocal, parent: NodeNG) -> nodes.Nonlocal:
         """visit a Nonlocal node and return a new instance of it"""
         return nodes.Nonlocal(
             names=node.names,
@@ -1598,7 +1575,7 @@ class TreeRebuilder:
             parent=parent,
         )
 
-    def visit_constant(self, node: "ast.Constant", parent: NodeNG) -> nodes.Const:
+    def visit_constant(self, node: ast.Constant, parent: NodeNG) -> nodes.Const:
         """visit a Constant node by returning a fresh instance of Const"""
         return nodes.Const(
             value=node.value,
@@ -1613,7 +1590,7 @@ class TreeRebuilder:
 
     if sys.version_info < (3, 8):
         # Not used in Python 3.8+.
-        def visit_ellipsis(self, node: "ast.Ellipsis", parent: NodeNG) -> nodes.Const:
+        def visit_ellipsis(self, node: ast.Ellipsis, parent: NodeNG) -> nodes.Const:
             """visit an Ellipsis node by returning a fresh instance of Const"""
             return nodes.Const(
                 value=Ellipsis,
@@ -1623,7 +1600,7 @@ class TreeRebuilder:
             )
 
         def visit_nameconstant(
-            self, node: "ast.NameConstant", parent: NodeNG
+            self, node: ast.NameConstant, parent: NodeNG
         ) -> nodes.Const:
             # For singleton values True / False / None
             return nodes.Const(
@@ -1633,9 +1610,7 @@ class TreeRebuilder:
                 parent,
             )
 
-        def visit_str(
-            self, node: Union["ast.Str", "ast.Bytes"], parent: NodeNG
-        ) -> nodes.Const:
+        def visit_str(self, node: ast.Str | ast.Bytes, parent: NodeNG) -> nodes.Const:
             """visit a String/Bytes node by returning a fresh instance of Const"""
             return nodes.Const(
                 node.s,
@@ -1646,7 +1621,7 @@ class TreeRebuilder:
 
         visit_bytes = visit_str
 
-        def visit_num(self, node: "ast.Num", parent: NodeNG) -> nodes.Const:
+        def visit_num(self, node: ast.Num, parent: NodeNG) -> nodes.Const:
             """visit a Num node by returning a fresh instance of Const"""
             return nodes.Const(
                 node.n,
@@ -1655,7 +1630,7 @@ class TreeRebuilder:
                 parent,
             )
 
-    def visit_pass(self, node: "ast.Pass", parent: NodeNG) -> nodes.Pass:
+    def visit_pass(self, node: ast.Pass, parent: NodeNG) -> nodes.Pass:
         """visit a Pass node by returning a fresh instance of it"""
         return nodes.Pass(
             lineno=node.lineno,
@@ -1666,7 +1641,7 @@ class TreeRebuilder:
             parent=parent,
         )
 
-    def visit_raise(self, node: "ast.Raise", parent: NodeNG) -> nodes.Raise:
+    def visit_raise(self, node: ast.Raise, parent: NodeNG) -> nodes.Raise:
         """visit a Raise node by returning a fresh instance of it"""
         newnode = nodes.Raise(
             lineno=node.lineno,
@@ -1683,7 +1658,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_return(self, node: "ast.Return", parent: NodeNG) -> nodes.Return:
+    def visit_return(self, node: ast.Return, parent: NodeNG) -> nodes.Return:
         """visit a Return node by returning a fresh instance of it"""
         newnode = nodes.Return(
             lineno=node.lineno,
@@ -1697,7 +1672,7 @@ class TreeRebuilder:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
-    def visit_set(self, node: "ast.Set", parent: NodeNG) -> nodes.Set:
+    def visit_set(self, node: ast.Set, parent: NodeNG) -> nodes.Set:
         """visit a Set node by returning a fresh instance of it"""
         newnode = nodes.Set(
             lineno=node.lineno,
@@ -1710,7 +1685,7 @@ class TreeRebuilder:
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
-    def visit_setcomp(self, node: "ast.SetComp", parent: NodeNG) -> nodes.SetComp:
+    def visit_setcomp(self, node: ast.SetComp, parent: NodeNG) -> nodes.SetComp:
         """visit a SetComp node by returning a fresh instance of it"""
         newnode = nodes.SetComp(
             lineno=node.lineno,
@@ -1726,7 +1701,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_slice(self, node: "ast.Slice", parent: nodes.Subscript) -> nodes.Slice:
+    def visit_slice(self, node: ast.Slice, parent: nodes.Subscript) -> nodes.Slice:
         """visit a Slice node by returning a fresh instance of it"""
         newnode = nodes.Slice(
             # position attributes added in 3.9
@@ -1743,7 +1718,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_subscript(self, node: "ast.Subscript", parent: NodeNG) -> nodes.Subscript:
+    def visit_subscript(self, node: ast.Subscript, parent: NodeNG) -> nodes.Subscript:
         """visit a Subscript node by returning a fresh instance of it"""
         context = self._get_context(node)
         newnode = nodes.Subscript(
@@ -1760,7 +1735,7 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_starred(self, node: "ast.Starred", parent: NodeNG) -> nodes.Starred:
+    def visit_starred(self, node: ast.Starred, parent: NodeNG) -> nodes.Starred:
         """visit a Starred node and return a new instance of it"""
         context = self._get_context(node)
         newnode = nodes.Starred(
@@ -1775,7 +1750,7 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
-    def visit_tryexcept(self, node: "ast.Try", parent: NodeNG) -> nodes.TryExcept:
+    def visit_tryexcept(self, node: ast.Try, parent: NodeNG) -> nodes.TryExcept:
         """visit a TryExcept node by returning a fresh instance of it"""
         if sys.version_info >= (3, 8):
             # TryExcept excludes the 'finally' but that will be included in the
@@ -1783,7 +1758,7 @@ class TreeRebuilder:
             # children to find the correct end_lineno and column.
             end_lineno = node.end_lineno
             end_col_offset = node.end_col_offset
-            all_children: List["ast.AST"] = [*node.body, *node.handlers, *node.orelse]
+            all_children: list[ast.AST] = [*node.body, *node.handlers, *node.orelse]
             for child in reversed(all_children):
                 end_lineno = child.end_lineno
                 end_col_offset = child.end_col_offset
@@ -1805,8 +1780,8 @@ class TreeRebuilder:
         return newnode
 
     def visit_try(
-        self, node: "ast.Try", parent: NodeNG
-    ) -> Union[nodes.TryExcept, nodes.TryFinally, None]:
+        self, node: ast.Try, parent: NodeNG
+    ) -> nodes.TryExcept | nodes.TryFinally | None:
         # python 3.3 introduce a new Try node replacing
         # TryFinally/TryExcept nodes
         if node.finalbody:
@@ -1818,7 +1793,7 @@ class TreeRebuilder:
                 end_col_offset=getattr(node, "end_col_offset", None),
                 parent=parent,
             )
-            body: List[Union[NodeNG, nodes.TryExcept]]
+            body: list[NodeNG | nodes.TryExcept]
             if node.handlers:
                 body = [self.visit_tryexcept(node, newnode)]
             else:
@@ -1829,7 +1804,7 @@ class TreeRebuilder:
             return self.visit_tryexcept(node, parent)
         return None
 
-    def visit_tuple(self, node: "ast.Tuple", parent: NodeNG) -> nodes.Tuple:
+    def visit_tuple(self, node: ast.Tuple, parent: NodeNG) -> nodes.Tuple:
         """visit a Tuple node by returning a fresh instance of it"""
         context = self._get_context(node)
         newnode = nodes.Tuple(
@@ -1844,7 +1819,7 @@ class TreeRebuilder:
         newnode.postinit([self.visit(child, newnode) for child in node.elts])
         return newnode
 
-    def visit_unaryop(self, node: "ast.UnaryOp", parent: NodeNG) -> nodes.UnaryOp:
+    def visit_unaryop(self, node: ast.UnaryOp, parent: NodeNG) -> nodes.UnaryOp:
         """visit a UnaryOp node by returning a fresh instance of it"""
         newnode = nodes.UnaryOp(
             op=self._parser_module.unary_op_classes[node.op.__class__],
@@ -1858,7 +1833,7 @@ class TreeRebuilder:
         newnode.postinit(self.visit(node.operand, newnode))
         return newnode
 
-    def visit_while(self, node: "ast.While", parent: NodeNG) -> nodes.While:
+    def visit_while(self, node: ast.While, parent: NodeNG) -> nodes.While:
         """visit a While node by returning a fresh instance of it"""
         newnode = nodes.While(
             lineno=node.lineno,
@@ -1877,20 +1852,20 @@ class TreeRebuilder:
 
     @overload
     def _visit_with(
-        self, cls: Type[nodes.With], node: "ast.With", parent: NodeNG
+        self, cls: type[nodes.With], node: ast.With, parent: NodeNG
     ) -> nodes.With:
         ...
 
     @overload
     def _visit_with(
-        self, cls: Type[nodes.AsyncWith], node: "ast.AsyncWith", parent: NodeNG
+        self, cls: type[nodes.AsyncWith], node: ast.AsyncWith, parent: NodeNG
     ) -> nodes.AsyncWith:
         ...
 
     def _visit_with(
         self,
-        cls: Type[_WithT],
-        node: Union["ast.With", "ast.AsyncWith"],
+        cls: type[_WithT],
+        node: ast.With | ast.AsyncWith,
         parent: NodeNG,
     ) -> _WithT:
         col_offset = node.col_offset
@@ -1907,7 +1882,7 @@ class TreeRebuilder:
             parent=parent,
         )
 
-        def visit_child(child: "ast.withitem") -> Tuple[NodeNG, Optional[NodeNG]]:
+        def visit_child(child: ast.withitem) -> tuple[NodeNG, NodeNG | None]:
             expr = self.visit(child.context_expr, newnode)
             var = self.visit(child.optional_vars, newnode)
             return expr, var
@@ -1920,10 +1895,10 @@ class TreeRebuilder:
         )
         return newnode
 
-    def visit_with(self, node: "ast.With", parent: NodeNG) -> NodeNG:
+    def visit_with(self, node: ast.With, parent: NodeNG) -> NodeNG:
         return self._visit_with(nodes.With, node, parent)
 
-    def visit_yield(self, node: "ast.Yield", parent: NodeNG) -> NodeNG:
+    def visit_yield(self, node: ast.Yield, parent: NodeNG) -> NodeNG:
         """visit a Yield node by returning a fresh instance of it"""
         newnode = nodes.Yield(
             lineno=node.lineno,
@@ -1937,7 +1912,7 @@ class TreeRebuilder:
             newnode.postinit(self.visit(node.value, newnode))
         return newnode
 
-    def visit_yieldfrom(self, node: "ast.YieldFrom", parent: NodeNG) -> NodeNG:
+    def visit_yieldfrom(self, node: ast.YieldFrom, parent: NodeNG) -> NodeNG:
         newnode = nodes.YieldFrom(
             lineno=node.lineno,
             col_offset=node.col_offset,
@@ -1952,7 +1927,7 @@ class TreeRebuilder:
 
     if sys.version_info >= (3, 10):
 
-        def visit_match(self, node: "ast.Match", parent: NodeNG) -> nodes.Match:
+        def visit_match(self, node: ast.Match, parent: NodeNG) -> nodes.Match:
             newnode = nodes.Match(
                 lineno=node.lineno,
                 col_offset=node.col_offset,
@@ -1967,7 +1942,7 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchcase(
-            self, node: "ast.match_case", parent: NodeNG
+            self, node: ast.match_case, parent: NodeNG
         ) -> nodes.MatchCase:
             newnode = nodes.MatchCase(parent=parent)
             newnode.postinit(
@@ -1978,7 +1953,7 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchvalue(
-            self, node: "ast.MatchValue", parent: NodeNG
+            self, node: ast.MatchValue, parent: NodeNG
         ) -> nodes.MatchValue:
             newnode = nodes.MatchValue(
                 lineno=node.lineno,
@@ -1991,7 +1966,7 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchsingleton(
-            self, node: "ast.MatchSingleton", parent: NodeNG
+            self, node: ast.MatchSingleton, parent: NodeNG
         ) -> nodes.MatchSingleton:
             return nodes.MatchSingleton(
                 value=node.value,
@@ -2003,7 +1978,7 @@ class TreeRebuilder:
             )
 
         def visit_matchsequence(
-            self, node: "ast.MatchSequence", parent: NodeNG
+            self, node: ast.MatchSequence, parent: NodeNG
         ) -> nodes.MatchSequence:
             newnode = nodes.MatchSequence(
                 lineno=node.lineno,
@@ -2018,7 +1993,7 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchmapping(
-            self, node: "ast.MatchMapping", parent: NodeNG
+            self, node: ast.MatchMapping, parent: NodeNG
         ) -> nodes.MatchMapping:
             newnode = nodes.MatchMapping(
                 lineno=node.lineno,
@@ -2037,7 +2012,7 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchclass(
-            self, node: "ast.MatchClass", parent: NodeNG
+            self, node: ast.MatchClass, parent: NodeNG
         ) -> nodes.MatchClass:
             newnode = nodes.MatchClass(
                 lineno=node.lineno,
@@ -2057,7 +2032,7 @@ class TreeRebuilder:
             return newnode
 
         def visit_matchstar(
-            self, node: "ast.MatchStar", parent: NodeNG
+            self, node: ast.MatchStar, parent: NodeNG
         ) -> nodes.MatchStar:
             newnode = nodes.MatchStar(
                 lineno=node.lineno,
@@ -2071,7 +2046,7 @@ class TreeRebuilder:
             newnode.postinit(name=self.visit_assignname(node, newnode, node.name))
             return newnode
 
-        def visit_matchas(self, node: "ast.MatchAs", parent: NodeNG) -> nodes.MatchAs:
+        def visit_matchas(self, node: ast.MatchAs, parent: NodeNG) -> nodes.MatchAs:
             newnode = nodes.MatchAs(
                 lineno=node.lineno,
                 col_offset=node.col_offset,
@@ -2087,7 +2062,7 @@ class TreeRebuilder:
             )
             return newnode
 
-        def visit_matchor(self, node: "ast.MatchOr", parent: NodeNG) -> nodes.MatchOr:
+        def visit_matchor(self, node: ast.MatchOr, parent: NodeNG) -> nodes.MatchOr:
             newnode = nodes.MatchOr(
                 lineno=node.lineno,
                 col_offset=node.col_offset,

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -5,6 +5,7 @@
 """this module contains utilities for rebuilding an _ast tree in
 order to get a single Astroid representation
 """
+
 from __future__ import annotations
 
 import ast

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -3,11 +3,13 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Utility functions for test code that uses astroid ASTs as input."""
+from __future__ import annotations
+
 import contextlib
 import functools
 import sys
 import warnings
-from typing import Callable, Tuple
+from typing import Callable
 
 import pytest
 
@@ -19,7 +21,7 @@ def require_version(minver: str = "0.0.0", maxver: str = "4.0.0") -> Callable:
     Skip the test if older.
     """
 
-    def parse(python_version: str) -> Tuple[int, ...]:
+    def parse(python_version: str) -> tuple[int, ...]:
         try:
             return tuple(int(v) for v in python_version.split("."))
         except ValueError as e:
@@ -30,7 +32,7 @@ def require_version(minver: str = "0.0.0", maxver: str = "4.0.0") -> Callable:
     max_version = parse(maxver)
 
     def check_require_version(f):
-        current: Tuple[int, int, int] = sys.version_info[:3]
+        current: tuple[int, int, int] = sys.version_info[:3]
         if min_version < current <= max_version:
             return f
 

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Utility functions for test code that uses astroid ASTs as input."""
+
 from __future__ import annotations
 
 import contextlib

--- a/astroid/transforms.py
+++ b/astroid/transforms.py
@@ -2,6 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import collections
 from typing import TYPE_CHECKING
 
@@ -23,7 +25,7 @@ class TransformVisitor:
     def __init__(self):
         self.transforms = collections.defaultdict(list)
 
-    def _transform(self, node: "NodeNG") -> "NodeNG":
+    def _transform(self, node: NodeNG) -> NodeNG:
         """Call matching transforms for the given node if any and return the
         transformed node.
         """

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -2,8 +2,10 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Set
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from astroid import nodes, transforms
@@ -20,8 +22,8 @@ class InferenceErrorInfo(TypedDict):
     raised with StopIteration exception.
     """
 
-    node: "nodes.NodeNG"
-    context: "InferenceContext | None"
+    node: nodes.NodeNG
+    context: InferenceContext | None
 
 
 InferFn = Callable[..., Any]
@@ -30,10 +32,10 @@ InferFn = Callable[..., Any]
 class AstroidManagerBrain(TypedDict):
     """Dictionary to store relevant information for a AstroidManager class."""
 
-    astroid_cache: Dict
-    _mod_file_cache: Dict
-    _failed_import_hooks: List
+    astroid_cache: dict
+    _mod_file_cache: dict
+    _failed_import_hooks: list
     always_load_extensions: bool
     optimize_ast: bool
-    extension_package_whitelist: Set
-    _transform: "transforms.TransformVisitor"
+    extension_package_whitelist: set
+    _transform: transforms.TransformVisitor

--- a/pylintrc
+++ b/pylintrc
@@ -310,7 +310,7 @@ mixin-class-rgx=.*Mix[Ii]n
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
-generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace
+generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace,ast\.([mM]atch.*|pattern)
 
 
 [VARIABLES]

--- a/pylintrc
+++ b/pylintrc
@@ -310,6 +310,7 @@ mixin-class-rgx=.*Mix[Ii]n
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
+# TODO: Remove ast.Match pattern once https://github.com/PyCQA/pylint/issues/6594 is fixed
 generated-members=REQUEST,acl_users,aq_parent,argparse.Namespace,ast\.([mM]atch.*|pattern)
 
 

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -6,6 +6,7 @@
 This script permits to upgrade the changelog in astroid or pylint when releasing a version.
 """
 # pylint: disable=logging-fstring-interpolation
+
 from __future__ import annotations
 
 import argparse

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -6,12 +6,13 @@
 This script permits to upgrade the changelog in astroid or pylint when releasing a version.
 """
 # pylint: disable=logging-fstring-interpolation
+from __future__ import annotations
+
 import argparse
 import enum
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import List
 
 DEFAULT_CHANGELOG_PATH = Path("ChangeLog")
 
@@ -58,7 +59,7 @@ def get_next_version(version: str, version_type: VersionType) -> str:
     return ".".join(new_version)
 
 
-def get_next_versions(version: str, version_type: VersionType) -> List[str]:
+def get_next_versions(version: str, version_type: VersionType) -> list[str]:
     if version_type == VersionType.PATCH:
         # "2.6.1" => ["2.6.2"]
         return [get_next_version(version, VersionType.PATCH)]

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -2,10 +2,11 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from astroid import builder
 from astroid.manager import AstroidManager
@@ -19,7 +20,7 @@ def find(name: str) -> str:
     return os.path.normpath(os.path.join(os.path.dirname(__file__), DATA_DIR, name))
 
 
-def build_file(path: str, modname: Optional[str] = None) -> Module:
+def build_file(path: str, modname: str | None = None) -> Module:
     return builder.AstroidBuilder().file_build(find(path), modname)
 
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Tests for basic functionality in astroid.brain."""
+
 from __future__ import annotations
 
 import io

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3,12 +3,14 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Tests for basic functionality in astroid.brain."""
+from __future__ import annotations
+
 import io
 import queue
 import re
 import sys
 import unittest
-from typing import Any, List
+from typing import Any
 
 import pytest
 
@@ -60,7 +62,7 @@ except ImportError:
     HAS_SIX = False
 
 
-def assertEqualMro(klass: ClassDef, expected_mro: List[str]) -> None:
+def assertEqualMro(klass: ClassDef, expected_mro: list[str]) -> None:
     """Check mro names."""
     assert [member.qname() for member in klass.mro()] == expected_mro
 

--- a/tests/unittest_brain_numpy_core_numeric.py
+++ b/tests/unittest_brain_numpy_core_numeric.py
@@ -2,8 +2,9 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import unittest
-from typing import List
 
 import pytest
 
@@ -70,7 +71,7 @@ class BrainNumpyCoreNumericTest(unittest.TestCase):
         ("ones", ["shape", "dtype", "order"]),
     ],
 )
-def test_function_parameters(method: str, expected_args: List[str]) -> None:
+def test_function_parameters(method: str, expected_args: list[str]) -> None:
     instance = builder.extract_node(
         f"""
     import numpy

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Tests for the astroid inference capabilities"""
+
 from __future__ import annotations
 
 import textwrap

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3,13 +3,14 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Tests for the astroid inference capabilities"""
+from __future__ import annotations
 
 import textwrap
 import unittest
 from abc import ABCMeta
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable
 from unittest.mock import patch
 
 import pytest
@@ -66,9 +67,9 @@ class InferenceUtilsTest(unittest.TestCase):
 
 def _assertInferElts(
     node_type: ABCMeta,
-    self: "InferenceTest",
+    self: InferenceTest,
     node: Any,
-    elts: Union[List[int], List[str]],
+    elts: list[int] | list[str],
 ) -> None:
     inferred = next(node.infer())
     self.assertIsInstance(inferred, node_type)
@@ -92,7 +93,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(inferred.value, expected)
 
     def assertInferDict(
-        self, node: Union[nodes.Call, nodes.Dict, nodes.NodeNG], expected: Any
+        self, node: nodes.Call | nodes.Dict | nodes.NodeNG, expected: Any
     ) -> None:
         inferred = next(node.infer())
         self.assertIsInstance(inferred, nodes.Dict)
@@ -943,9 +944,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred[0], nodes.FunctionDef)
         self.assertEqual(inferred[0].name, "exists")
 
-    def _test_const_inferred(
-        self, node: nodes.AssignName, value: Union[float, str]
-    ) -> None:
+    def _test_const_inferred(self, node: nodes.AssignName, value: float | str) -> None:
         inferred = list(node.infer())
         self.assertEqual(len(inferred), 1)
         self.assertIsInstance(inferred[0], nodes.Const)
@@ -3451,19 +3450,19 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
 
     def _slicing_test_helper(
         self,
-        pairs: Tuple[
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
-            Tuple[str, Union[List[int], str]],
+        pairs: tuple[
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
+            tuple[str, list[int] | str],
         ],
-        cls: Union[ABCMeta, type],
+        cls: ABCMeta | type,
         get_elts: Callable,
     ) -> None:
         for code, expected in pairs:
@@ -4668,13 +4667,13 @@ class TestType(unittest.TestCase):
 class ArgumentsTest(unittest.TestCase):
     @staticmethod
     def _get_dict_value(
-        inferred: Dict,
-    ) -> Union[List[Tuple[str, int]], List[Tuple[str, str]]]:
+        inferred: dict,
+    ) -> list[tuple[str, int]] | list[tuple[str, str]]:
         items = inferred.items
         return sorted((key.value, value.value) for key, value in items)
 
     @staticmethod
-    def _get_tuple_value(inferred: Tuple) -> Tuple[int, ...]:
+    def _get_tuple_value(inferred: tuple) -> tuple[int, ...]:
         elts = inferred.elts
         return tuple(elt.value for elt in elts)
 
@@ -4996,7 +4995,7 @@ class CallSiteTest(unittest.TestCase):
         return arguments.CallSite.from_call(call)
 
     def _test_call_site_pair(
-        self, code: str, expected_args: List[int], expected_keywords: Dict[str, int]
+        self, code: str, expected_args: list[int], expected_keywords: dict[str, int]
     ) -> None:
         ast_node = extract_node(code)
         call_site = self._call_site_from_call(ast_node)
@@ -5010,7 +5009,7 @@ class CallSiteTest(unittest.TestCase):
             self.assertEqual(call_site.keyword_arguments[keyword].value, value)
 
     def _test_call_site(
-        self, pairs: List[Tuple[str, List[int], Dict[str, int]]]
+        self, pairs: list[tuple[str, list[int], dict[str, int]]]
     ) -> None:
         for pair in pairs:
             self._test_call_site_pair(*pair)
@@ -5040,7 +5039,7 @@ class CallSiteTest(unittest.TestCase):
         ]
         self._test_call_site(pairs)
 
-    def _test_call_site_valid_arguments(self, values: List[str], invalid: bool) -> None:
+    def _test_call_site_valid_arguments(self, values: list[str], invalid: bool) -> None:
         for value in values:
             ast_node = extract_node(value)
             call_site = self._call_site_from_call(ast_node)

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -4,12 +4,14 @@
 
 """tests for specific behaviour of astroid nodes
 """
+from __future__ import annotations
+
 import copy
 import os
 import sys
 import textwrap
 import unittest
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -998,13 +1000,13 @@ class AliasesTest(unittest.TestCase):
             node.name = "another_test"
             return node
 
-        def test_callfunc(node: Call) -> Optional[Call]:
+        def test_callfunc(node: Call) -> Call | None:
             if node.func.name == "Foo":
                 node.func.name = "Bar"
                 return node
             return None
 
-        def test_assname(node: AssignName) -> Optional[AssignName]:
+        def test_assname(node: AssignName) -> AssignName | None:
             if node.name == "foo":
                 return nodes.AssignName(
                     "bar", node.lineno, node.col_offset, node.parent

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -4,6 +4,7 @@
 
 """tests for specific behaviour of astroid nodes
 """
+
 from __future__ import annotations
 
 import copy

--- a/tests/unittest_nodes_position.py
+++ b/tests/unittest_nodes_position.py
@@ -2,8 +2,9 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import textwrap
-from typing import List
 
 from astroid import builder, nodes
 
@@ -41,7 +42,7 @@ class TestNodePosition:
             ...
         """
         ).strip()
-        ast_nodes: List[nodes.NodeNG] = builder.extract_node(code)  # type: ignore[assignment]
+        ast_nodes: list[nodes.NodeNG] = builder.extract_node(code)  # type: ignore[assignment]
 
         a = ast_nodes[0]
         assert isinstance(a, nodes.ClassDef)
@@ -93,7 +94,7 @@ class TestNodePosition:
             ...
         """
         ).strip()
-        ast_nodes: List[nodes.NodeNG] = builder.extract_node(code)  # type: ignore[assignment]
+        ast_nodes: list[nodes.NodeNG] = builder.extract_node(code)  # type: ignore[assignment]
 
         a = ast_nodes[0]
         assert isinstance(a, nodes.FunctionDef)
@@ -141,7 +142,7 @@ class TestNodePosition:
             ...
         """
         ).strip()
-        ast_nodes: List[nodes.NodeNG] = builder.extract_node(code)  # type: ignore[assignment]
+        ast_nodes: list[nodes.NodeNG] = builder.extract_node(code)  # type: ignore[assignment]
 
         a = ast_nodes[0]
         assert isinstance(a, nodes.FunctionDef)

--- a/tests/unittest_objects.py
+++ b/tests/unittest_objects.py
@@ -2,8 +2,9 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import unittest
-from typing import List
 
 from astroid import bases, builder, nodes, objects
 from astroid.exceptions import AttributeInferenceError, InferenceError, SuperError
@@ -435,7 +436,7 @@ class SuperTests(unittest.TestCase):
         selfclass = third.getattr("__self_class__")[0]
         self.assertEqual(selfclass.name, "A")
 
-    def assertEqualMro(self, klass: Super, expected_mro: List[str]) -> None:
+    def assertEqualMro(self, klass: Super, expected_mro: list[str]) -> None:
         self.assertEqual([member.name for member in klass.super_mro()], expected_mro)
 
     def test_super_mro(self) -> None:

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -2,9 +2,11 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import contextlib
 import unittest
-from typing import Any, Callable, Iterator, List, Optional, Union
+from typing import Any, Callable, Iterator
 
 import pytest
 
@@ -21,7 +23,7 @@ def _add_transform(
     manager: AstroidManager,
     node: type,
     transform: Callable,
-    predicate: Optional[Any] = None,
+    predicate: Any | None = None,
 ) -> Iterator:
     manager.register_transform(node, transform, predicate)
     try:
@@ -32,7 +34,7 @@ def _add_transform(
 
 class ProtocolTests(unittest.TestCase):
     def assertConstNodesEqual(
-        self, nodes_list_expected: List[int], nodes_list_got: List[nodes.Const]
+        self, nodes_list_expected: list[int], nodes_list_got: list[nodes.Const]
     ) -> None:
         self.assertEqual(len(nodes_list_expected), len(nodes_list_got))
         for node in nodes_list_got:
@@ -41,7 +43,7 @@ class ProtocolTests(unittest.TestCase):
             self.assertEqual(expected_value, node.value)
 
     def assertNameNodesEqual(
-        self, nodes_list_expected: List[str], nodes_list_got: List[nodes.Name]
+        self, nodes_list_expected: list[str], nodes_list_got: list[nodes.Name]
     ) -> None:
         self.assertEqual(len(nodes_list_expected), len(nodes_list_got))
         for node in nodes_list_got:
@@ -80,12 +82,12 @@ class ProtocolTests(unittest.TestCase):
         assert isinstance(assigned, astroid.List)
         assert assigned.as_string() == "[1, 2]"
 
-    def _get_starred_stmts(self, code: str) -> Union[List, Uninferable]:
+    def _get_starred_stmts(self, code: str) -> list | Uninferable:
         assign_stmt = extract_node(f"{code} #@")
         starred = next(assign_stmt.nodes_of_class(nodes.Starred))
         return next(starred.assigned_stmts())
 
-    def _helper_starred_expected_const(self, code: str, expected: List[int]) -> None:
+    def _helper_starred_expected_const(self, code: str, expected: list[int]) -> None:
         stmts = self._get_starred_stmts(code)
         self.assertIsInstance(stmts, nodes.List)
         stmts = stmts.elts
@@ -201,7 +203,7 @@ class ProtocolTests(unittest.TestCase):
 
     def test_not_passing_uninferable_in_seq_inference(self) -> None:
         class Visitor:
-            def visit(self, node: Union[nodes.Assign, nodes.BinOp, nodes.List]) -> Any:
+            def visit(self, node: nodes.Assign | nodes.BinOp | nodes.List) -> Any:
                 for child in node.get_children():
                     child.accept(self)
 

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -5,6 +5,8 @@
 """tests for specific behaviour of astroid scoped nodes (i.e. module, class and
 function)
 """
+from __future__ import annotations
+
 import datetime
 import os
 import sys
@@ -12,7 +14,7 @@ import textwrap
 import unittest
 import warnings
 from functools import partial
-from typing import Any, List, Union
+from typing import Any
 
 import pytest
 
@@ -53,7 +55,7 @@ except ImportError:
 
 def _test_dict_interface(
     self: Any,
-    node: Union[nodes.ClassDef, nodes.FunctionDef, nodes.Module],
+    node: nodes.ClassDef | nodes.FunctionDef | nodes.Module,
     test_attr: str,
 ) -> None:
     self.assertIs(node[test_attr], node[test_attr])
@@ -889,7 +891,7 @@ class FunctionNodeTest(ModuleLoader, unittest.TestCase):
             'Hello World'
         """
         )
-        ast_nodes: List[nodes.FunctionDef] = builder.extract_node(code)  # type: ignore[assignment]
+        ast_nodes: list[nodes.FunctionDef] = builder.extract_node(code)  # type: ignore[assignment]
         assert len(ast_nodes) == 4
 
         assert isinstance(ast_nodes[0].doc_node, nodes.Const)
@@ -1549,11 +1551,11 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         assert len(slots) == 3, slots
         assert [slot.value for slot in slots] == ["a", "b", "c"]
 
-    def assertEqualMro(self, klass: nodes.ClassDef, expected_mro: List[str]) -> None:
+    def assertEqualMro(self, klass: nodes.ClassDef, expected_mro: list[str]) -> None:
         self.assertEqual([member.name for member in klass.mro()], expected_mro)
 
     def assertEqualMroQName(
-        self, klass: nodes.ClassDef, expected_mro: List[str]
+        self, klass: nodes.ClassDef, expected_mro: list[str]
     ) -> None:
         self.assertEqual([member.qname() for member in klass.mro()], expected_mro)
 

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -5,6 +5,7 @@
 """tests for specific behaviour of astroid scoped nodes (i.e. module, class and
 function)
 """
+
 from __future__ import annotations
 
 import datetime

--- a/tests/unittest_transforms.py
+++ b/tests/unittest_transforms.py
@@ -2,10 +2,12 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import contextlib
 import time
 import unittest
-from typing import Callable, Iterator, Optional
+from typing import Callable, Iterator
 
 from astroid import MANAGER, builder, nodes, parse, transforms
 from astroid.manager import AstroidManager
@@ -18,7 +20,7 @@ def add_transform(
     manager: AstroidManager,
     node: type,
     transform: Callable,
-    predicate: Optional[Callable] = None,
+    predicate: Callable | None = None,
 ) -> Iterator:
     manager.register_transform(node, transform, predicate)
     try:


### PR DESCRIPTION
## Description
Part 1 of 3 to update the typing in astroid following the bump to Python 3.7.2

Part 1: Replace `typing` aliases for builtin types
Part 2: Replace `typing` aliases for `collections.abc` classes.
Part 3: Update `py-version` in `pylintrc`