### PR TITLE
Update typing for Python 3.7 (2)

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -7,8 +7,8 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterator
 from functools import partial
-from typing import Iterator
 
 from astroid import arguments, helpers, inference_tip, nodes, objects, util
 from astroid.builder import AstroidBuilder

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -16,7 +16,8 @@ dataclasses. References:
 from __future__ import annotations
 
 import sys
-from typing import Generator, Tuple, Union
+from collections.abc import Generator
+from typing import Tuple, Union
 
 from astroid import context, inference_tip
 from astroid.builder import parse

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -6,9 +6,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from functools import partial
 from itertools import chain
-from typing import Iterator
 
 from astroid import BoundMethod, arguments, extract_node, helpers, nodes, objects
 from astroid.context import InferenceContext

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import functools
 import keyword
+from collections.abc import Iterator
 from textwrap import dedent
-from typing import Iterator
 
 import astroid
 from astroid import arguments, inference_tip, nodes, util

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import Iterator
 from functools import partial
 
 from astroid import context, extract_node, inference_tip
@@ -144,7 +145,7 @@ def _looks_like_typing_subscript(node):
 
 def infer_typing_attr(
     node: Subscript, ctx: context.InferenceContext | None = None
-) -> typing.Iterator[ClassDef]:
+) -> Iterator[ClassDef]:
     """Infer a typing.X[...] subscript"""
     try:
         value = next(node.value.infer())  # type: ignore[union-attr] # value shouldn't be None for Subscript.
@@ -190,7 +191,7 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
 
 def infer_old_typedDict(  # pylint: disable=invalid-name
     node: ClassDef, ctx: context.InferenceContext | None = None
-) -> typing.Iterator[ClassDef]:
+) -> Iterator[ClassDef]:
     func_to_add = _extract_single_node("dict")
     node.locals["__call__"] = [func_to_add]
     return iter([node])
@@ -198,7 +199,7 @@ def infer_old_typedDict(  # pylint: disable=invalid-name
 
 def infer_typedDict(  # pylint: disable=invalid-name
     node: FunctionDef, ctx: context.InferenceContext | None = None
-) -> typing.Iterator[ClassDef]:
+) -> Iterator[ClassDef]:
     """Replace TypedDict FunctionDef with ClassDef."""
     class_def = ClassDef(
         name="TypedDict",
@@ -258,7 +259,7 @@ def _forbid_class_getitem_access(node: ClassDef) -> None:
 
 def infer_typing_alias(
     node: Call, ctx: context.InferenceContext | None = None
-) -> typing.Iterator[ClassDef]:
+) -> Iterator[ClassDef]:
     """
     Infers the call to _alias function
     Insert ClassDef, with same name as aliased class,
@@ -346,7 +347,7 @@ def _looks_like_special_alias(node: Call) -> bool:
 
 def infer_special_alias(
     node: Call, ctx: context.InferenceContext | None = None
-) -> typing.Iterator[ClassDef]:
+) -> Iterator[ClassDef]:
     """Infer call to tuple alias as new subscriptable class typing.Tuple."""
     if not (
         isinstance(node.parent, Assign)
@@ -381,7 +382,7 @@ def _looks_like_typing_cast(node: Call) -> bool:
 
 def infer_typing_cast(
     node: Call, ctx: context.InferenceContext | None = None
-) -> typing.Iterator[NodeNG]:
+) -> Iterator[NodeNG]:
     """Infer call to cast() returning same type as casted-from var"""
     if not isinstance(node.func, (Name, Attribute)):
         raise UseInferenceDefault

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """ A few useful function/method decorators."""
+
 from __future__ import annotations
 
 import functools

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -3,12 +3,14 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """ A few useful function/method decorators."""
+from __future__ import annotations
 
 import functools
 import inspect
 import sys
 import warnings
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 import wrapt
 

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -11,7 +11,8 @@ import ast
 import functools
 import itertools
 import operator
-from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Iterator, TypeVar
+from collections.abc import Callable, Generator, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from astroid import bases, decorators, helpers, nodes, protocols, util
 from astroid.context import (

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import Iterator
 
 import wrapt
 
@@ -30,7 +31,7 @@ def clear_inference_tip_cache():
 @wrapt.decorator
 def _inference_tip_cached(
     func: InferFn, instance: None, args: typing.Any, kwargs: typing.Any
-) -> typing.Iterator[InferOptions]:
+) -> Iterator[InferOptions]:
     """Cache decorator used for inference tips"""
     node = args[0]
     try:

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -12,9 +12,10 @@ import importlib.util
 import os
 import sys
 import zipimport
+from collections.abc import Sequence
 from functools import lru_cache
 from pathlib import Path
-from typing import NamedTuple, Sequence
+from typing import NamedTuple
 
 from astroid.modutils import EXT_LIB_DIRS
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -11,18 +11,9 @@ import itertools
 import sys
 import typing
 import warnings
+from collections.abc import Generator, Iterator
 from functools import lru_cache
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Generator,
-    Iterator,
-    Optional,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, TypeVar, Union
 
 from astroid import decorators, mixins, util
 from astroid.bases import Instance, _infer_stmts

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -7,18 +7,9 @@ from __future__ import annotations
 import pprint
 import sys
 import warnings
+from collections.abc import Iterator
 from functools import singledispatch as _singledispatch
-from typing import (
-    TYPE_CHECKING,
-    ClassVar,
-    Iterator,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, ClassVar, Tuple, Type, TypeVar, Union, cast, overload
 
 from astroid import decorators, util
 from astroid.exceptions import (

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -14,8 +14,8 @@ import io
 import itertools
 import os
 import sys
-import typing
 import warnings
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, NoReturn, TypeVar, overload
 
 from astroid import bases
@@ -2959,7 +2959,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
 
         def grouped_slots(
             mro: list[ClassDef],
-        ) -> typing.Iterator[node_classes.NodeNG | None]:
+        ) -> Iterator[node_classes.NodeNG | None]:
             # Not interested in object, since it can't have slots.
             for cls in mro[:-1]:
                 try:

--- a/astroid/nodes/scoped_nodes/utils.py
+++ b/astroid/nodes/scoped_nodes/utils.py
@@ -9,7 +9,8 @@ This module contains utility functions for scoped nodes.
 from __future__ import annotations
 
 import builtins
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from astroid.manager import AstroidManager
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -14,7 +14,8 @@ leads to an inferred FrozenSet:
 from __future__ import annotations
 
 import sys
-from typing import Iterator, TypeVar
+from collections.abc import Iterator
+from typing import TypeVar
 
 from astroid import bases, decorators, util
 from astroid.context import InferenceContext

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import collections
 import itertools
 import operator as operator_mod
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from astroid import arguments, bases, decorators, helpers, nodes, util
 from astroid.const import Context

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -14,7 +14,7 @@ import os
 import sys
 import types
 import warnings
-from typing import Iterable
+from collections.abc import Iterable
 
 from astroid import bases, nodes
 from astroid.manager import AstroidManager

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import ast
 import sys
 import token
+from collections.abc import Callable, Generator
 from io import StringIO
 from tokenize import TokenInfo, generate_tokens
-from typing import Callable, Generator, TypeVar, Union, cast, overload
+from typing import TypeVar, Union, cast, overload
 
 from astroid import nodes
 from astroid._ast import ParserModule, get_parser_module, parse_function_type_comment

--- a/astroid/test_utils.py
+++ b/astroid/test_utils.py
@@ -10,7 +10,7 @@ import contextlib
 import functools
 import sys
 import warnings
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/pylintrc
+++ b/pylintrc
@@ -40,7 +40,7 @@ unsafe-load-any-extension=no
 extension-pkg-whitelist=
 
 # Minimum supported python version
-py-version = 3.6.2
+py-version = 3.7.2
 
 
 [REPORTS]

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import textwrap
 import unittest
 from abc import ABCMeta
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import patch
 
 import pytest

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -7,8 +7,8 @@ import site
 import sys
 import time
 import unittest
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator
 
 import pkg_resources
 

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import contextlib
 import unittest
-from typing import Any, Callable, Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import pytest
 

--- a/tests/unittest_transforms.py
+++ b/tests/unittest_transforms.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import contextlib
 import time
 import unittest
-from typing import Callable, Iterator
+from collections.abc import Callable, Iterator
 
 from astroid import MANAGER, builder, nodes, parse, transforms
 from astroid.manager import AstroidManager


### PR DESCRIPTION
## Description
Followup to #1555

Part 2 **and** 3 to update the typing in astroid following the bump to Python 3.7.2

Part 1: Replace typing aliases for builtin types
Part 2: Replace typing aliases for collections.abc classes.
Part 3: Update py-version in pylintrc