### PR TITLE
Fix 3.11 test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,9 @@ Release date: TBA
 
   Closes #1403
 
+* Fix test for Python ``3.11``. In some instances ``err.__traceback__`` will
+  be uninferable now.
+
 What's New in astroid 2.11.6?
 =============================
 Release date: TBA


### PR DESCRIPTION
## Description
Not the ideal solution I was hoping for tbh, but it should work.
As suspected, the test failure is causes by https://github.com/python/cpython/pull/92202. In particular, inside the `__exit__` method there is the following assignment
```py
def __exit__(self, typ, value, traceback):
    ...
    exc.__traceback__ = traceback
```
Previously, astroid couldn't infer `__traceback__` and so defaulted to our fallback method.
https://github.com/PyCQA/astroid/blob/fd102d45a3552c00d951a07b02c49d278a7a69a2/astroid/interpreter/objectmodel.py#L644-L648
Now, with we have an assignment, which later gets inferred as `Uninferable`. However, that means we don't use the fallback anymore. I haven't quite figured out why an assignment in `contextlib` is applied to `__builtins__.BaseException` but that might be related the initial bootstrapping 🤷🏻‍♂️

Anyway, the test change should work and a fallback to `Uninferable` isn't the end of the world IMO.

Closes: #1551