### PR TITLE
Pin Python 3.11.0b1 [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11.0-beta.1"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -130,61 +130,11 @@ jobs:
           name: coverage-${{ matrix.python-version }}
           path: .coverage
 
-  tests-linux-dev:
-    name: tests / run / ${{ matrix.python-version }} / Linux
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        python-version: ["3.11-dev"]
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.0.2
-      - name: Set up Python ${{ matrix.python-version }}
-        id: python
-        uses: actions/setup-python@v3.1.2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Generate partial Python venv restore key
-        id: generate-python-key
-        run: >-
-          echo "::set-output name=key::venv-${{ env.CACHE_VERSION }}-${{
-            hashFiles('setup.cfg', 'requirements_test.txt', 'requirements_test_min.txt',
-          'requirements_test_brain.txt') }}"
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.0.2
-        with:
-          path: venv
-          key: >-
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            steps.generate-python-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ env.CACHE_VERSION }}-
-      - name: Create Python virtual environment
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          python -m venv venv
-          . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt -r requirements_test_brain.txt
-          pip install -e .
-      - name: Run pytest
-        run: |
-          . venv/bin/activate
-          pytest --cov --cov-report= tests/
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3.0.0
-        with:
-          name: coverage-${{ matrix.python-version }}
-          path: .coverage
-
   coverage:
     name: tests / process / coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: ["tests-linux", "tests-linux-dev"]
-    if: always() # remove together with tests-linux-dev
+    needs: "tests-linux"
     strategy:
       matrix:
         python-version: [3.8]
@@ -233,7 +183,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11.0-beta.1"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV


### PR DESCRIPTION
## Description
Pin `3.11.0b1` for CI runs. Initially we added `3.11-dev` as CI version. That helped a lot with addressing all open issues. However now that all have been fixed, it might be better to pin a specific beta / rc version. That way the CI pipeline can't break accidentally with the next update. We would have full control when we update and can address issues as they pop up.

The obvious downside of course is that version updates would be manual.