### PR TITLE
Fix coverage performance issue with Python 3.11

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 -r requirements_test_pre_commit.txt
 contributors-txt>=0.7.4
 coveralls~=3.3
-coverage~=6.3
+coverage~=6.3.3
 pre-commit~=2.19
 pytest-cov~=3.0
 contributors-txt>=0.7.3


### PR DESCRIPTION
## Description
Pin coverage to `~=6.3.3`.
Changelog: https://github.com/nedbat/coveragepy/releases/tag/6.3.3