### PR TITLE
Add a bound to the inference tips cache

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,10 @@ Release date: TBA
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 
+* Add a bound to the inference tips cache.
+
+  Closes #1150
+
 * Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``,
   and ``frozenset``.
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -44,6 +44,9 @@ def _inference_tip_cached(
         _cache[func, node] = None
         result = _cache[func, node] = list(func(*args, **kwargs))
         assert result
+        # Django can be linted without exceeding this value; next value is 9296
+        if _cache.__sizeof__() > 4680:
+            clear_inference_tip_cache()
     return iter(result)
 
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -41,12 +41,11 @@ def _inference_tip_cached(
         if result is None:
             raise UseInferenceDefault()
     except KeyError:
+        if len(_cache) > 127:
+            clear_inference_tip_cache()
         _cache[func, node] = None
         result = _cache[func, node] = list(func(*args, **kwargs))
         assert result
-        # Django can be linted without exceeding this value; next value is 9296
-        if _cache.__sizeof__() > 4680:
-            clear_inference_tip_cache()
     return iter(result)
 
 


### PR DESCRIPTION


## Description
Add a bound to the size of the inference tips cache.

I explored making this user-configurable, but I don't really see a compelling use case. It's also difficult because of the inaccessibility of manipulating the `inference_tip` module at runtime: `inference_tip()` is imported over the module name.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #1150

