### PR TITLE
Revert "Add a bound to the inference tips cache (#1565)"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,10 +24,6 @@ Release date: TBA
 
   Refs PyCQA/pylint#5113
 
-* Add a bound to the inference tips cache.
-
-  Closes #1150
-
 * Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``,
   and ``frozenset``.
 

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import typing
-from collections import OrderedDict
 from collections.abc import Iterator
 
 import wrapt
@@ -21,7 +20,7 @@ InferOptions = typing.Union[
     NodeNG, bases.Instance, bases.UnboundMethod, typing.Type[util.Uninferable]
 ]
 
-_cache: OrderedDict[tuple[InferFn, NodeNG], list[InferOptions] | None] = OrderedDict()
+_cache: dict[tuple[InferFn, NodeNG], list[InferOptions] | None] = {}
 
 
 def clear_inference_tip_cache():
@@ -37,14 +36,11 @@ def _inference_tip_cached(
     node = args[0]
     try:
         result = _cache[func, node]
-        _cache.move_to_end((func, node))
         # If through recursion we end up trying to infer the same
         # func + node we raise here.
         if result is None:
             raise UseInferenceDefault()
     except KeyError:
-        if len(_cache) > 127:
-            _cache.popitem(last=False)
         _cache[func, node] = None
         result = _cache[func, node] = list(func(*args, **kwargs))
         assert result


### PR DESCRIPTION
This reverts commit 95bbd5ed58da9e56da8d705e1893a804787f1998 (#1565).

@cdce8p reported a [regression](https://github.com/PyCQA/astroid/pull/1565#issuecomment-1127586743) with that commit, and after moving the `popitem()` call out of the `except`, and also trying without `--jobs=n`, I saw no improvement. So reverting.

Despite that, I feel like it's a similar class of issue to the several issues in `pylint` with `--jobs`: we need a better understanding on how the global states are managed and interact with `--init-hook` and the rest. E.g. PyCQA/pylint#4874