### PR TITLE
Permit subscripting additional builtin classes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ Release date: TBA
 
   Closes #1559
 
-* On Python versions >= 3.9, ``astroid`` now understands (dubiously) subscripting
+* On Python versions >= 3.9, ``astroid`` now understands subscripting
   builtin classes such as ``enumerate`` or ``staticmethod``.
 
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,9 @@ Release date: TBA
 
   Closes #1559
 
+* On Python versions >= 3.9, ``astroid`` now understands (dubiously) subscripting
+  builtin classes such as ``enumerate`` or ``staticmethod``.
+
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2763,7 +2763,7 @@ class ClassDef(mixins.FilterStmtsMixin, LocalsDictNodeNG, node_classes.Statement
             # AttributeError
             if (
                 isinstance(method, node_classes.EmptyNode)
-                and self.name in {"list", "dict", "set", "tuple", "frozenset"}
+                and self.pytype() == "builtins.type"
                 and PY39_PLUS
             ):
                 return self

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1272,7 +1272,7 @@ class TypeBrain(unittest.TestCase):
     @test_utils.require_version(minver="3.9")
     def test_builtin_subscriptable(self):
         """Starting with python3.9 builtin types such as list are subscriptable.
-        Builtins such as "enumerate" and "staticmethod" also work, although dubious."""
+        Any builtin class such as "enumerate" or "staticmethod" also works."""
         for typename in ("tuple", "list", "dict", "set", "frozenset", "enumerate"):
             src = f"""
             {typename:s}[int]

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1271,10 +1271,9 @@ class TypeBrain(unittest.TestCase):
 
     @test_utils.require_version(minver="3.9")
     def test_builtin_subscriptable(self):
-        """
-        Starting with python3.9 builtin type such as list are subscriptable
-        """
-        for typename in ("tuple", "list", "dict", "set", "frozenset"):
+        """Starting with python3.9 builtin types such as list are subscriptable.
+        Builtins such as "enumerate" and "staticmethod" also work, although dubious."""
+        for typename in ("tuple", "list", "dict", "set", "frozenset", "enumerate"):
             src = f"""
             {typename:s}[int]
             """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3579,12 +3579,6 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             node = extract_node(code)
             self.assertRaises(InferenceError, next, node.infer())
 
-    @test_utils.require_version(minver="3.9")
-    def test_subscripting_builtin(self) -> None:
-        subscript_node = extract_node("enumerate[2]")
-        subscript_inferred = next(subscript_node.infer())
-        self.assertIsInstance(subscript_inferred, nodes.ClassDef)
-
     def test_instance_slicing(self) -> None:
         ast_nodes = extract_node(
             """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3574,11 +3574,16 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             "(1, 2, 3)[a:]",
             "(1, 2, 3)[object:object]",
             "(1, 2, 3)[1:object]",
-            "enumerate[2]",
         ]
         for code in examples:
             node = extract_node(code)
             self.assertRaises(InferenceError, next, node.infer())
+
+    @test_utils.require_version(minver="3.9")
+    def test_subscripting_builtin(self) -> None:
+        subscript_node = extract_node("enumerate[2]")
+        subscript_inferred = next(subscript_node.infer())
+        self.assertIsInstance(subscript_inferred, nodes.ClassDef)
 
     def test_instance_slicing(self) -> None:
         ast_nodes = extract_node(


### PR DESCRIPTION
## Description
Treat other classes such as `enumerate` and `staticmethod` identically to list, dict, tuple, set, frozenset.

```python
>>> enumerate[2]  # not sure why, but...
enumerate[2]
>>> type(enumerate[2])
<class 'types.GenericAlias'>
```
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Related Issue
Noticed while working on #1567.
