### PR TITLE
Revert #1575 and catch further `KeyError`s

### DIFF
--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -29,9 +29,9 @@ def is_namespace(modname: str) -> bool:
         working_modname = ".".join(processed_components)
         try:
             # the path search is not recursive, so that's why we are iterating
-            # and using the last parent path
+            # to incorporate each submodule search path, e.g. a, a/b, a/b/c
             found_spec = _find_spec_from_path(
-                working_modname, last_submodule_search_locations
+                working_modname, path=last_submodule_search_locations
             )
         except ValueError:
             # executed .pth files may not have __spec__
@@ -53,6 +53,8 @@ def is_namespace(modname: str) -> bool:
                     last_item = last_submodule_search_locations[-1]
                 except TypeError:
                     last_item = last_submodule_search_locations._recalculate()[-1]
+                # e.g. for failure example above, add 'a/b' and keep going
+                # so that find_spec('a.b.c', path=['a', 'a/b']) succeeds
                 assumed_location = pathlib.Path(last_item) / component
                 last_submodule_search_locations.append(str(assumed_location))
             continue

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -28,8 +28,8 @@ def is_namespace(modname: str) -> bool:
         processed_components.append(component)
         working_modname = ".".join(processed_components)
         try:
-            # the path search is not recursive, so that's why we are iterating
-            # to incorporate each submodule search path, e.g. a, a/b, a/b/c
+            # Both the modname and the path are built iteratively, with the
+            # path (e.g. ['a', 'a/b', 'a/b/c']) lagging the modname by one
             found_spec = _find_spec_from_path(
                 working_modname, path=last_submodule_search_locations
             )

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -49,7 +49,8 @@ def is_namespace(modname: str) -> bool:
             if last_submodule_search_locations:
                 assumed_location = (
                     # pylint: disable=unsubscriptable-object
-                    pathlib.Path(last_submodule_search_locations[-1])
+                    # TODO: py38: directly access last_submodule_search_locations
+                    pathlib.Path(last_submodule_search_locations._path[-1])
                     / component
                 )
                 last_submodule_search_locations.append(str(assumed_location))

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -47,12 +47,13 @@ def is_namespace(modname: str) -> bool:
 
             # Repair last_submodule_search_locations
             if last_submodule_search_locations:
-                assumed_location = (
+                # TODO: py38: remove except
+                try:
                     # pylint: disable=unsubscriptable-object
-                    # TODO: py38: directly access last_submodule_search_locations
-                    pathlib.Path(last_submodule_search_locations._path[-1])
-                    / component
-                )
+                    last_item = last_submodule_search_locations[-1]
+                except TypeError:
+                    last_item = last_submodule_search_locations._recalculate()[-1]
+                assumed_location = pathlib.Path(last_item) / component
                 last_submodule_search_locations.append(str(assumed_location))
             continue
 

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -125,6 +125,9 @@ class AstroidManagerTest(
             util.is_namespace("tests.testdata.python3.data.parent_of_homonym.doc")
         )
 
+    def test_module_is_not_namespace(self) -> None:
+        self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
+
     def test_implicit_namespace_package(self) -> None:
         data_dir = os.path.dirname(resources.find("data/namespace_pep_420"))
         contribute = os.path.join(data_dir, "contribute_to_namespace")


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Chaotic, I know, but I found additional `KeyError`s, and when I compared the behavior after importing the packages, it suggested the original approach before #1575 was right. Any and all feedback welcome, I still find my footing uncertain.

For the tree a > b > c.py:
```python
>>> from importlib.machinery import PathFinder
>>> PathFinder.find_spec('a.b', ['a'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<frozen importlib._bootstrap_external>", line 1439, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1218, in __init__
  File "<frozen importlib._bootstrap_external>", line 1233, in _get_parent_path
KeyError: 'a'
>>> import a.b.c  # now it's on sys.path
>>> a.b.c
<module 'a.b.c' from '/Users/jwalls/cpython/a/b/c.py'>
>>> PathFinder.find_spec('a')
ModuleSpec(name='a', loader=None, submodule_search_locations=_NamespacePath(['/Users/jwalls/cpython/a']))
>>> PathFinder.find_spec('a.b', path=['a'])
ModuleSpec(name='a.b', loader=None, submodule_search_locations=_NamespacePath(['/Users/jwalls/cpython/a/b']))
>>> PathFinder.find_spec('a.b.c', path=['a', 'a/b'])
ModuleSpec(name='a.b.c', loader=<_frozen_importlib_external.SourceFileLoader object at 0x104841420>, origin='/Users/jwalls/cpython/a/b/c.py')
origin='/Users/jwalls/cpython/a/b/c.py')
>>> PathFinder.find_spec('a.b.c', path=['a'])  # uh-oh, none! suggests #1575 was wrong
```


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
#1575 


