### PR TITLE
Special case `__main__` in `is_namespace()`

### DIFF
--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -34,8 +34,8 @@ def is_namespace(modname: str) -> bool:
                 working_modname, path=last_submodule_search_locations
             )
         except ValueError:
-            # executed .pth files may not have __spec__
-            return True
+            # Assume it's a .pth file, unless it's __main__
+            return modname != "__main__"
         except KeyError:
             # Intermediate steps might raise KeyErrors
             # https://github.com/python/cpython/issues/93334

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -127,6 +127,7 @@ class AstroidManagerTest(
 
     def test_module_is_not_namespace(self) -> None:
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
+        self.assertFalse(util.is_namespace("__main__"))
 
     def test_implicit_namespace_package(self) -> None:
         data_dir = os.path.dirname(resources.find("data/namespace_pep_420"))


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Glad that this one was not a head scratcher. `__main__` is a [special case](https://docs.python.org/3/reference/import.html?highlight=__main__%20__spec__#main-spec) where `__spec__` might be None.

Resolves primer failure in pylint. Caused very recently (unreleased) in #1536, so not documented.
