### PR TITLE
More conservative interpretation of `PathFinder.find_spec()` failures

### DIFF
--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -34,8 +34,17 @@ def is_namespace(modname: str) -> bool:
                 working_modname, path=last_submodule_search_locations
             )
         except ValueError:
-            # Assume it's a .pth file, unless it's __main__
-            return modname != "__main__"
+            if modname == "__main__":
+                return False
+            try:
+                # .pth files will be on sys.modules
+                return sys.modules[modname].__spec__ is None
+            except KeyError:
+                return False
+            except AttributeError:
+                # Workaround for "py" module
+                # https://github.com/pytest-dev/apipkg/issues/13
+                return False
         except KeyError:
             # Intermediate steps might raise KeyErrors
             # https://github.com/python/cpython/issues/93334

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -129,6 +129,15 @@ class AstroidManagerTest(
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
 
+    def test_module_unexpectedly_missing_spec(self) -> None:
+        astroid_module = sys.modules["astroid"]
+        original_spec = astroid_module.__spec__
+        del astroid_module.__spec__
+        try:
+            self.assertFalse(util.is_namespace("astroid"))
+        finally:
+            astroid_module.__spec__ = original_spec
+
     def test_implicit_namespace_package(self) -> None:
         data_dir = os.path.dirname(resources.find("data/namespace_pep_420"))
         contribute = os.path.join(data_dir, "contribute_to_namespace")


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.


## Description
First of all, there was just an issue in `pytest` to work around. See https://github.com/pytest-dev/apipkg/issues/13.

Second, I think it was wrong to assume that any `ValueError` from `importlib` signified a namespace package. I was originally just trying to pass the astroid test case that promises support for the very old `pkg_resources` namespace package protocol, i.e. `.pth` files. When `.pth` files are executed, they're in `sys.modules`, so here I just check for that.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Follow up to #1536. Resolves issue in `pandas` revealed by pylint primer.
