### PR TITLE
Add ``typing-extensions`` to test dependencies

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,1 +1,2 @@
 pytest
+typing-extensions>=3.10

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -30,7 +30,7 @@ from astroid import (
     util,
 )
 from astroid.bases import BoundMethod, Generator, Instance, UnboundMethod
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY310_PLUS, WIN32
+from astroid.const import IS_PYPY, PY38, PY38_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     DuplicateBasesError,
@@ -1896,10 +1896,6 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
             "object",
         ]
         if not PY38_PLUS:
-            class_names.pop(-2)
-        # typing_extensions is not installed on this combination of version
-        # and platform
-        if PY310_PLUS and WIN32:
             class_names.pop(-2)
 
         final_def = module.body[-1]


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes https://github.com/PyCQA/astroid/issues/1585.

We ran into similar issues with `pylint`. It should just be a test dependency on all platforms.