### PR TITLE
Fix inference of ``Enums`` when they are imported under an alias

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,10 @@ Release date: TBA
 * On Python versions >= 3.9, ``astroid`` now understands subscripting
   builtin classes such as ``enumerate`` or ``staticmethod``.
 
+* Fixed inference of ``Enums`` when they are imported under an alias.
+
+  Closes PyCQA/pylint#5776
+
 * Rename ``ModuleSpec`` -> ``module_type`` constructor parameter to match attribute
   name and improve typing. Use ``type`` instead.
 

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -349,7 +349,7 @@ INT_FLAG_ADDITION_METHODS = """
 """
 
 
-def infer_enum_class(node):
+def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
     """Specific inference for enums."""
     for basename in (b for cls in node.mro() for b in cls.basenames):
         if basename not in ENUM_BASE_NAMES:

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1156,6 +1156,20 @@ class EnumBrainTest(unittest.TestCase):
         self.assertIsInstance(inferred, astroid.Dict)
         self.assertTrue(inferred.locals)
 
+    def test_enum_as_renamed_import(self) -> None:
+        """Originally reported in https://github.com/PyCQA/pylint/issues/5776."""
+        ast_node: nodes.Attribute = builder.extract_node(
+            """
+        from enum import Enum as PyEnum
+        class MyEnum(PyEnum):
+            ENUM_KEY = "enum_value"
+        MyEnum.ENUM_KEY
+        """
+        )
+        inferred = next(ast_node.infer())
+        assert isinstance(inferred, bases.Instance)
+        assert inferred._proxied.name == "ENUM_KEY"
+
 
 @unittest.skipUnless(HAS_DATEUTIL, "This test requires the dateutil library.")
 class DateutilBrainTest(unittest.TestCase):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Relates to PyCQA/pylint#5776.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

