### PR TITLE
Infer instances of builtins created by `__new__()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,8 @@ Release date: TBA
 
   Refs PyCQA/pylint#5113
 
+* Instances of builtins created with ``__new__(cls, value)`` are now inferred.
+
 * Infer the return value of the ``.copy()`` method on ``dict``, ``list``, ``set``,
   and ``frozenset``.
 

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -5,8 +5,12 @@
 """This module contains base classes and functions for the nodes and some
 inference utils.
 """
+from __future__ import annotations
 
 import collections
+from typing import TYPE_CHECKING
+from typing import Generator as GenT  # Generator is a class in this module
+from typing import Type, TypeVar
 
 from astroid import decorators
 from astroid.const import PY310_PLUS
@@ -338,6 +342,12 @@ class Instance(BaseInstance):
         return next(method.infer_call_result(self, new_context), None)
 
 
+if TYPE_CHECKING:
+    from astroid.nodes import Call, Const
+
+    _BuiltinNewT = TypeVar("_BuiltinNewT", Type[Uninferable], Const, Instance)
+
+
 class UnboundMethod(Proxy):
     """a special node representing a method not bound to an instance"""
 
@@ -386,7 +396,9 @@ class UnboundMethod(Proxy):
                 return self._infer_builtin_new(caller, context)
         return self._proxied.infer_call_result(caller, context)
 
-    def _infer_builtin_new(self, caller, context):
+    def _infer_builtin_new(
+        self, caller: Call, context: InferenceContext
+    ) -> GenT[_BuiltinNewT, None, None]:
         # pylint: disable-next=import-outside-toplevel; circular import
         from astroid.nodes import Const, const_factory
 

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -8,6 +8,7 @@ inference utils.
 from __future__ import annotations
 
 import collections
+import collections.abc
 from typing import TYPE_CHECKING
 
 from astroid import decorators
@@ -399,21 +400,21 @@ class UnboundMethod(Proxy):
         nodes.Const | Instance | type[Uninferable], None, None
     ]:
         # pylint: disable-next=import-outside-toplevel; circular import
-        from astroid.nodes import Const, const_factory
+        from astroid import nodes
 
         if not caller.args:
             return
         # Attempt to create a constant
         if len(caller.args) > 1:
             value = None
-            if isinstance(caller.args[1], Const):
+            if isinstance(caller.args[1], nodes.Const):
                 value = caller.args[1].value
             else:
                 inferred_arg = next(caller.args[1].infer(), None)
-                if isinstance(inferred_arg, Const):
+                if isinstance(inferred_arg, nodes.Const):
                     value = inferred_arg.value
             if value is not None:
-                yield const_factory(value)
+                yield nodes.const_factory(value)
                 return
 
         node_context = context.extra_context.get(caller.args[0])

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3779,7 +3779,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         inferred2 = next(ast_node2.infer())
         assert isinstance(inferred2, Instance)
         assert not isinstance(inferred2, nodes.Const)
-        assert inferred._proxied is inferred._proxied
+        assert inferred2._proxied is inferred._proxied
 
         ast_node3 = extract_node(
             """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3768,7 +3768,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ]
         self.assertEqual(titles, ["Catch 22", "Ubik", "Grimus"])
 
-    def test_builtin_new(self):
+    def test_builtin_new(self) -> None:
         ast_node = extract_node("int.__new__(int, 42)")
         inferred = next(ast_node.infer())
         self.assertIsInstance(inferred, nodes.Const)

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3768,17 +3768,18 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ]
         self.assertEqual(titles, ["Catch 22", "Ubik", "Grimus"])
 
-    def test_builtin_new(self) -> None:
+    @staticmethod
+    def test_builtin_new() -> None:
         ast_node = extract_node("int.__new__(int, 42)")
         inferred = next(ast_node.infer())
-        self.assertIsInstance(inferred, nodes.Const)
-        self.assertEqual(inferred.value, 42)
+        assert isinstance(inferred, nodes.Const)
+        assert inferred.value == 42
 
         ast_node2 = extract_node("int.__new__(int)")
         inferred2 = next(ast_node2.infer())
-        self.assertIsInstance(inferred2, Instance)
-        self.assertNotIsInstance(inferred2, nodes.Const)
-        self.assertIs(inferred._proxied, inferred._proxied)
+        assert isinstance(inferred2, Instance)
+        assert not isinstance(inferred2, nodes.Const)
+        assert inferred._proxied is inferred._proxied
 
         ast_node3 = extract_node(
             """
@@ -3787,11 +3788,11 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         """
         )
         inferred3 = next(ast_node3.infer())
-        self.assertIsInstance(inferred3, nodes.Const)
-        self.assertEqual(inferred3.value, 43)
+        assert isinstance(inferred3, nodes.Const)
+        assert inferred3.value == 43
 
-        ast_node4 = extract_node("int.__new__()")  # invalid
-        with self.assertRaises(InferenceError):
+        ast_node4 = extract_node("int.__new__()")
+        with pytest.raises(InferenceError):
             next(ast_node4.infer())
 
     @pytest.mark.xfail(reason="Does not support function metaclasses")

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3768,6 +3768,28 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         ]
         self.assertEqual(titles, ["Catch 22", "Ubik", "Grimus"])
 
+    def test_builtin_new(self):
+        ast_node = extract_node("int.__new__(int, 42)")
+        inferred = next(ast_node.infer())
+        self.assertIsInstance(inferred, nodes.Const)
+        self.assertEqual(inferred.value, 42)
+
+        ast_node2 = extract_node("int.__new__(int)")
+        inferred2 = next(ast_node2.infer())
+        self.assertIsInstance(inferred2, Instance)
+        self.assertNotIsInstance(inferred2, nodes.Const)
+        self.assertIs(inferred._proxied, inferred._proxied)
+
+        ast_node3 = extract_node(
+            """
+        x = 43
+        int.__new__(int, x)  #@
+        """
+        )
+        inferred3 = next(ast_node3.infer())
+        self.assertIsInstance(inferred3, nodes.Const)
+        self.assertEqual(inferred3.value, 43)
+
     @pytest.mark.xfail(reason="Does not support function metaclasses")
     def test_function_metaclasses(self):
         # These are not supported right now, although

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3790,6 +3790,10 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred3, nodes.Const)
         self.assertEqual(inferred3.value, 43)
 
+        ast_node4 = extract_node("int.__new__()")  # invalid
+        with self.assertRaises(InferenceError):
+            next(ast_node4.infer())
+
     @pytest.mark.xfail(reason="Does not support function metaclasses")
     def test_function_metaclasses(self):
         # These are not supported right now, although


### PR DESCRIPTION


## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Before, instances of builtins created with `__new__()`, e.g. `int.__new__(int, 42)` were inferred as `Uninferable`.
Now, a `Const` node is created, or at the very least, an `Instance`.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Related Issue

Ref https://github.com/PyCQA/pylint/pull/6822#discussion_r888859802
