### PR TITLE
Allow passing arguments as ``None`` to ``FunctionDef`` builder

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -646,8 +646,11 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
 
         Can be None if the associated function does not have a retrievable
         signature and the arguments are therefore unknown.
-        This happens with builtin functions implemented in C.
+        This can happen with (builtin) functions implemented in C that have
+        incomplete signature information.
         """
+        # TODO: Check if other attributes should also be None when
+        # .args is None.
 
         self.defaults: list[NodeNG]
         """The default values for arguments that can be passed positionally."""
@@ -700,7 +703,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
     # pylint: disable=too-many-arguments
     def postinit(
         self,
-        args: list[AssignName],
+        args: list[AssignName] | None,
         defaults: list[NodeNG],
         kwonlyargs: list[AssignName],
         kw_defaults: list[NodeNG | None],

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -126,8 +126,17 @@ def build_function(
     # first argument is now a list of decorators
     func = nodes.FunctionDef(name)
     argsnode = nodes.Arguments(parent=func)
+
+    # If args is None we don't have any information about the signature
+    # (in contrast to when there are no arguments and args == []). We pass
+    # this to the builder to indicate this.
+    if args is not None:
+        arguments = [nodes.AssignName(name=arg, parent=argsnode) for arg in args]
+    else:
+        arguments = None
+
     argsnode.postinit(
-        args=[nodes.AssignName(name=arg, parent=argsnode) for arg in args or ()],
+        args=arguments,
         defaults=[],
         kwonlyargs=[
             nodes.AssignName(name=arg, parent=argsnode) for arg in kwonlyargs or ()
@@ -248,9 +257,6 @@ def object_build_methoddescriptor(
     func = build_function(
         getattr(member, "__name__", None) or localname, doc=member.__doc__
     )
-    # set node's arguments to None to notice that we have no information, not
-    # and empty argument list
-    func.args.args = None
     node.add_local_node(func, localname)
     _add_dunder_class(func, member)
 

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -945,6 +945,13 @@ def test_parse_module_with_invalid_type_comments_does_not_crash():
     assert isinstance(node, nodes.Module)
 
 
+def test_arguments_of_signature() -> None:
+    """Test that arguments is None for function without an inferable signature."""
+    node = builder.extract_node("int")
+    classdef: nodes.ClassDef = next(node.infer())
+    assert all(i.args.args is None for i in classdef.getattr("__dir__"))
+
+
 class HermeticInterpreterTest(unittest.TestCase):
     """Modeled on https://github.com/PyCQA/astroid/pull/1207#issuecomment-951455588"""
 


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

We don't need to assignment later on, just change what the `postinit` accepts.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |


Ref. https://github.com/PyCQA/astroid/pull/1593