### PR TITLE
Make ``Arguments.defaults`` ``None`` for uninferable signatures

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,8 @@ Release date: TBA
 
   Closes #1559
 
+* ``Arguments.defaults`` is now ``None`` for uninferable signatures.
+
 * On Python versions >= 3.9, ``astroid`` now understands subscripting
   builtin classes such as ``enumerate`` or ``staticmethod``.
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -652,7 +652,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
         # TODO: Check if other attributes should also be None when
         # .args is None.
 
-        self.defaults: list[NodeNG]
+        self.defaults: list[NodeNG] | None
         """The default values for arguments that can be passed positionally."""
 
         self.kwonlyargs: list[AssignName]
@@ -704,7 +704,7 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
     def postinit(
         self,
         args: list[AssignName] | None,
-        defaults: list[NodeNG],
+        defaults: list[NodeNG] | None,
         kwonlyargs: list[AssignName],
         kw_defaults: list[NodeNG | None],
         annotations: list[NodeNG | None],
@@ -914,7 +914,8 @@ class Arguments(mixins.AssignTypeMixin, NodeNG):
 
         yield from self.args or ()
 
-        yield from self.defaults
+        if self.defaults is not None:
+            yield from self.defaults
         yield from self.kwonlyargs
 
         for elt in self.kw_defaults:

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -138,10 +138,7 @@ def build_function(
     default_nodes: list[nodes.NodeNG] | None = []
     if defaults is not None:
         for default in defaults:
-            if isinstance(default, nodes.NodeNG):
-                default_node = default
-            else:
-                default_node = nodes.const_factory(default)
+            default_node = nodes.const_factory(default)
             default_node.parent = argsnode
             default_nodes.append(default_node)
     else:

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -135,9 +135,21 @@ def build_function(
     else:
         arguments = None
 
+    default_nodes: list[nodes.NodeNG] | None = []
+    if defaults is not None:
+        for default in defaults:
+            if isinstance(default, nodes.NodeNG):
+                default_node = default
+            else:
+                default_node = nodes.const_factory(default)
+            default_node.parent = argsnode
+            default_nodes.append(default_node)
+    else:
+        default_nodes = None
+
     argsnode.postinit(
         args=arguments,
-        defaults=[],
+        defaults=default_nodes,
         kwonlyargs=[
             nodes.AssignName(name=arg, parent=argsnode) for arg in kwonlyargs or ()
         ],
@@ -152,9 +164,6 @@ def build_function(
         body=[],
         doc_node=nodes.Const(value=doc) if doc else None,
     )
-    for default in defaults or ():
-        argsnode.defaults.append(nodes.const_factory(default))
-        argsnode.defaults[-1].parent = argsnode
     if args:
         register_arguments(func)
     return func
@@ -194,7 +203,7 @@ def object_build_class(
 
 def _get_args_info_from_callable(
     member: _FunctionTypes,
-) -> tuple[list[str], list[Any], list[str], list[str]]:
+) -> tuple[list[str], list[str], list[Any], list[str]]:
     """Returns args, posonlyargs, defaults, kwonlyargs.
 
     :note: currently ignores the return annotation.

--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -450,7 +450,7 @@ class BuilderTest(unittest.TestCase):
     def test_inspect_build1(self) -> None:
         time_ast = self.manager.ast_from_module_name("time")
         self.assertTrue(time_ast)
-        self.assertEqual(time_ast["time"].args.defaults, [])
+        self.assertEqual(time_ast["time"].args.defaults, None)
 
     def test_inspect_build3(self) -> None:
         self.builder.inspect_build(unittest)


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

**This is a breaking change**.

However, ``Arguments.args`` is already ``None`` for uninferable live objects. So I think there should already be an ``if node.args is None: continue`` line in most use-cases of this node.

The ultimate benefit of this is #1593 which allows us to get info about calls to `int.__dir__` etc. All C objects that have signatures that `inspect` can find will now become readable by us.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

Ref https://github.com/PyCQA/astroid/pull/1593.