### PR TITLE
Add test for inferring stdout

### DIFF
--- a/tests/unittest_builder.py
+++ b/tests/unittest_builder.py
@@ -952,6 +952,17 @@ def test_arguments_of_signature() -> None:
     assert all(i.args.args is None for i in classdef.getattr("__dir__"))
 
 
+@staticmethod
+def test_infer_stdout():
+    n = builder.extract_node(
+        """
+    import sys
+    sys.stdout
+    """
+    )
+    assert isinstance(next(n.infer()), Instance)
+
+
 class HermeticInterpreterTest(unittest.TestCase):
     """Modeled on https://github.com/PyCQA/astroid/pull/1207#issuecomment-951455588"""
 


### PR DESCRIPTION
## Description
A crash when inferring `sys.stdout` was reported against a stale branch (2.0) six years ago. Let's just merge a test and then close the issue.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes #346

