### PR TITLE
Use new Pypy version identifier for setup-python action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,7 +232,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python-version: ["pypy3.7", "pypy3.8", "pypy3.9"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
## Description
Followup to #1607
With `v4.0.0` the `setup-python` action changed the Pypi identifier. `pypy3.9` instead of `pypy-3.9`. The old was kept for backwards compatibility. However, I do still think that we should update those.
https://github.com/actions/setup-python/releases/tag/v4.0.0

/CC: @DanielNoord