### PR TITLE
Avoid performing `**` operations on values greater than 1e5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -62,6 +62,11 @@ Release date: TBA
 
   Closes PyCQA/pylint#5783
 
+* Avoid inferring the results of ``**`` operations involving values greater than ``1e5``
+  to avoid expensive computation.
+
+  Closes PyCQA/pylint#6745
+
 * Fix test for Python ``3.11``. In some instances ``err.__traceback__`` will
   be uninferable now.
 

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -113,6 +113,13 @@ for _KEY, _IMPL in list(BIN_OP_IMPL.items()):
 def const_infer_binary_op(self, opnode, operator, other, context, _):
     not_implemented = nodes.Const(NotImplemented)
     if isinstance(other, nodes.Const):
+        if (
+            operator == "**"
+            and isinstance(self, nodes.Const)
+            and (self.value > 1e5 or other.value > 1e5)
+        ):
+            yield not_implemented
+            return
         try:
             impl = BIN_OP_IMPL[operator]
             try:

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -269,6 +269,12 @@ class ProtocolTests(unittest.TestCase):
         )
         parsed.accept(Visitor())
 
+    @staticmethod
+    def test_uninferable_exponents() -> None:
+        """Attempting to calculate the result is prohibitively expensive."""
+        parsed = extract_node("15 ** 20220609")
+        assert parsed.inferred() == [Uninferable]
+
 
 @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
 def test_named_expr_inference() -> None:


### PR DESCRIPTION

## Description
Avoid actually calculating `**` operations on values greater than 1e5.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Closes PyCQA/pylint#6745

