### PR TITLE
Add a second test for simple augmented assignments

### DIFF
--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1414,6 +1414,20 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertEqual(len(inferred), 1)
         self.assertIsInstance(inferred[0], nodes.Const)
         self.assertEqual(inferred[0].value, 3)
+    
+    def test_augassign_multi(self) -> None:
+        code = """
+            a = 1
+            a += 1
+            a += 1
+            print (a)
+        """
+        ast = parse(code, __name__)
+        inferred = list(test_utils.get_name_node(ast, "a").infer())
+
+        self.assertEqual(len(inferred), 1)
+        self.assertIsInstance(inferred[0], nodes.Const)
+        self.assertEqual(inferred[0].value, 3)
 
     def test_nonregr_func_arg(self) -> None:
         code = """


### PR DESCRIPTION

## Description

This PR adds a test for with two augmented assignments, I believe there is a flaw in the logic, so creating a failing test for it.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | Adds a test          |

## Related Issue

#192