### PR TITLE
[RFC] Yield self when inferring `GeneratorExp`

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -43,6 +43,7 @@ objects = util.lazy_import("objects")
 
 
 _FunctionDefT = TypeVar("_FunctionDefT", bound=nodes.FunctionDef)
+_GeneratorExpT = TypeVar("_GeneratorExpT", bound=nodes.GeneratorExp)
 
 
 # .infer method ###############################################################
@@ -1068,3 +1069,12 @@ def infer_functiondef(
 
 
 nodes.FunctionDef._infer = infer_functiondef  # type: ignore[assignment]
+
+
+def infer_generator_exp(
+    self: _GeneratorExpT, context: InferenceContext | None = None
+) -> Generator[Property | _GeneratorExpT, None, InferenceErrorInfo]:
+    yield self
+
+
+nodes.GeneratorExp._infer = infer_generator_exp


### PR DESCRIPTION
## Description
```python
import astroid
code = """
def get_generator():
    return (x for x in range(0))
x = get_generator()  #@
if x:
  pass
"""
x = astroid.extract_node(code)
x.value.inferred()
```
Before: `[Uninferable]`
Now: `[<GeneratorExp l.3 at 0x103e80880>]`


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue
See https://github.com/PyCQA/pylint/issues/6909#issuecomment-1152723978