### PR TITLE
Revert #893: Avoid setting a Call as a base for classes from `six.with_metaclass()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,10 @@ Release date: TBA
 
 * ``astroid`` now requires Python 3.7.2 to run.
 
+* Avoid setting a Call as a base for classes created using ``six.with_metaclass()``.
+
+  Refs PyCQA/pylint#5935
+
 * Fix detection of builtins on ``PyPy`` 3.9.
 
 * Fix ``re`` brain on Python ``3.11``. The flags now come from ``re._compile``.

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -219,6 +219,7 @@ def transform_six_with_metaclass(node):
     """
     call = node.bases[0]
     node._metaclass = call.args[0]
+    node.bases = call.args[1:]
     return node
 
 


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
#893 intended to fix a false positive for `unused-import` of `six` in a pattern like `class Thing(six.with_metaclass(meta, ancestor))` by making the `nodes.Call` containing `six.with_metaclass` into a base. Then, this violated assumptions elsewhere, leading to the crash in PyCQA/pylint#5935.

#893 was itself a partial reversion of #841, a fix for #713. #713 is essentially the same issue as PyCQA/pylint#5935. So what I'm suggesting is that we revert to #841, and then find another way to deal with the `unused-import` in pylint, if at all.

(I'd much rather have a false positive than a crash. And the class of false positives is larger than anything to do with `six.with_metaclass` anyway: see PyCQA/pylint#1630. So we shouldn't treat `six` as more special.)

Let's not backport this, to give us time to make a decision about what to do in pylint with PyCQA/pylint#1630.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Refs https://github.com/PyCQA/pylint/issues/5935
