### PR TITLE
Only initialize importers when they are required

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,8 @@ Release date: TBA
 * On Python versions >= 3.9, ``astroid`` now understands subscripting
   builtin classes such as ``enumerate`` or ``staticmethod``.
 
+* Speed up discovery of modules by initializing importers only when they are required.
+
 * Fixed inference of ``Enums`` when they are imported under an alias.
 
   Closes PyCQA/pylint#5776

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,8 +44,6 @@ Release date: TBA
 * On Python versions >= 3.9, ``astroid`` now understands subscripting
   builtin classes such as ``enumerate`` or ``staticmethod``.
 
-* Speed up discovery of modules by initializing importers only when they are required.
-
 * Fixed inference of ``Enums`` when they are imported under an alias.
 
   Closes PyCQA/pylint#5776

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -211,13 +211,20 @@ class ZipFinder(Finder):
 
     def __init__(self, path: Sequence[str]) -> None:
         super().__init__(path)
-        self._zipimporters = _precache_zipimporters(path)
+        for entry_path in path:
+            if entry_path not in sys.path_importer_cache:
+                try:
+                    sys.path_importer_cache[entry_path] = zipimport.zipimporter(
+                        entry_path
+                    )
+                except zipimport.ZipImportError:
+                    continue
 
     def find_module(
         self, modname, module_parts: Sequence[str], processed, submodule_path
     ):
         try:
-            file_type, filename, path = _search_zip(module_parts, self._zipimporters)
+            file_type, filename, path = _search_zip(module_parts)
         except ImportError:
             return None
 
@@ -283,79 +290,53 @@ def _cached_set_diff(left, right):
     return result
 
 
-def _precache_zipimporters(
-    path: Sequence[str] | None = None,
-) -> dict[str, zipimport.zipimporter]:
-    """
-    For each path that has not been already cached
-    in the sys.path_importer_cache, create a new zipimporter
-    instance and add it into the cache.
-    Return a dict associating all paths, stored in the cache, to corresponding
-    zipimporter instances.
-
-    :param path: paths that has to be added into the cache
-    :return: association between paths stored in the cache and zipimporter instances
-    """
-    pic = sys.path_importer_cache
-
-    # When measured, despite having the same complexity (O(n)),
-    # converting to tuples and then caching the conversion to sets
-    # and the set difference is faster than converting to sets
-    # and then only caching the set difference.
-
-    req_paths = tuple(path or sys.path)
-    cached_paths = tuple(pic)
-    new_paths = _cached_set_diff(req_paths, cached_paths)
-    # pylint: disable=no-member
-    for entry_path in new_paths:
-        try:
-            pic[entry_path] = zipimport.zipimporter(entry_path)
-        except zipimport.ZipImportError:
-            continue
-    return {
-        key: value
-        for key, value in pic.items()
-        if isinstance(value, zipimport.zipimporter)
-    }
+# @lru_cache
+def _get_zipimporters():
+    for filepath, importer in sys.path_importer_cache.items():
+        if isinstance(importer, zipimport.zipimporter):
+            yield filepath, importer
 
 
 def _search_zip(
-    modpath: Sequence[str], pic: dict[str, zipimport.zipimporter]
+    modpath: Sequence[str],
 ) -> tuple[Literal[ModuleType.PY_ZIPMODULE], str, str]:
-    for filepath, importer in list(pic.items()):
-        if importer is not None:
+    for filepath, importer in _get_zipimporters():
+        if PY310_PLUS:
+            found = importer.find_spec(modpath[0])
+        else:
+            found = importer.find_module(modpath[0])
+        if found:
             if PY310_PLUS:
-                found = importer.find_spec(modpath[0])
-            else:
-                found = importer.find_module(modpath[0])
-            if found:
-                if PY310_PLUS:
-                    if not importer.find_spec(os.path.sep.join(modpath)):
-                        raise ImportError(
-                            "No module named %s in %s/%s"
-                            % (".".join(modpath[1:]), filepath, modpath)
-                        )
-                elif not importer.find_module(os.path.sep.join(modpath)):
+                if not importer.find_spec(os.path.sep.join(modpath)):
                     raise ImportError(
                         "No module named %s in %s/%s"
                         % (".".join(modpath[1:]), filepath, modpath)
                     )
-                # import code; code.interact(local=locals())
-                return (
-                    ModuleType.PY_ZIPMODULE,
-                    os.path.abspath(filepath) + os.path.sep + os.path.sep.join(modpath),
-                    filepath,
+            elif not importer.find_module(os.path.sep.join(modpath)):
+                raise ImportError(
+                    "No module named %s in %s/%s"
+                    % (".".join(modpath[1:]), filepath, modpath)
                 )
+            # import code; code.interact(local=locals())
+            return (
+                ModuleType.PY_ZIPMODULE,
+                os.path.abspath(filepath) + os.path.sep + os.path.sep.join(modpath),
+                filepath,
+            )
     raise ImportError(f"No module named {'.'.join(modpath)}")
 
 
-def _find_spec_with_path(search_path, modname, module_parts, processed, submodule_path):
-    finders = [finder(search_path) for finder in _SPEC_FINDERS]
-    for finder in finders:
-        spec = finder.find_module(modname, module_parts, processed, submodule_path)
+def _find_spec_with_path(
+    search_path: list[str], modname, module_parts, processed, submodule_path
+):
+    for finder in _SPEC_FINDERS:
+        finder_instance = finder(search_path)
+        spec = finder_instance.find_module(
+            modname, module_parts, processed, submodule_path
+        )
         if spec is None:
             continue
-        return finder, spec
+        return finder_instance, spec
 
     raise ImportError(f"No module named {'.'.join(module_parts)}")
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -13,8 +13,7 @@ import os
 import pathlib
 import sys
 import zipimport
-from collections.abc import Sequence
-from functools import lru_cache
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import NamedTuple
 
@@ -213,6 +212,7 @@ class ZipFinder(Finder):
         super().__init__(path)
         for entry_path in path:
             if entry_path not in sys.path_importer_cache:
+                # pylint: disable=no-member
                 try:
                     sys.path_importer_cache[entry_path] = zipimport.zipimporter(
                         entry_path
@@ -283,15 +283,9 @@ def _is_setuptools_namespace(location: pathlib.Path) -> bool:
         return extend_path or declare_namespace
 
 
-@lru_cache()
-def _cached_set_diff(left, right):
-    result = set(left)
-    result.difference_update(right)
-    return result
-
-
-def _get_zipimporters():
+def _get_zipimporters() -> Iterator[str, zipimport.zipimporter]:
     for filepath, importer in sys.path_importer_cache.items():
+        # pylint: disable-next=no-member
         if isinstance(importer, zipimport.zipimporter):
             yield filepath, importer
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -334,7 +334,6 @@ def _search_zip(
                     "No module named %s in %s/%s"
                     % (".".join(modpath[1:]), filepath, modpath)
                 )
-            # import code; code.interact(local=locals())
             return (
                 ModuleType.PY_ZIPMODULE,
                 os.path.abspath(filepath) + os.path.sep + os.path.sep.join(modpath),

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -290,7 +290,6 @@ def _cached_set_diff(left, right):
     return result
 
 
-# @lru_cache
 def _get_zipimporters():
     for filepath, importer in sys.path_importer_cache.items():
         if isinstance(importer, zipimport.zipimporter):

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -253,6 +253,7 @@ class AstroidManager:
                     modname.split("."), context_file=contextfile
                 )
             except ImportError as e:
+                # pylint: disable-next=redefined-variable-type
                 value = AstroidImportError(
                     "Failed to import module {modname} with error:\n{error}.",
                     modname=modname,
@@ -262,7 +263,7 @@ class AstroidManager:
             self._mod_file_cache[(modname, contextfile)] = value
         if isinstance(value, AstroidBuildingError):
             # we remove the traceback here to save on memory usage (since these exceptions are cached)
-            raise value.with_traceback(None)
+            raise value.with_traceback(None)  # pylint: disable=no-member
         return value
 
     def ast_from_module(self, module: types.ModuleType, modname: str | None = None):


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Due to some refactoring in the `spec.py` module I was able to obtain significant performance boosts for `pylint`.
For the `sentry` primer job I got local speedups of **-15%** run time.

There are two related changes here:
1) Only create instances of `Finders` when they are needed. If we can find a module with the first `finder` in `_SPEC_FINDERS` it us unnecessary to instantiate the others. Since this is a costly process we should do this inside the `for` loop.
2) Iterate over `sys.path_importer_cache` in `_search_zip`. This iteration is very costly (still about 10% of runtime). But by doing it within `_search_zip` we only do it when necessary.

I think there is a good chance this will also speed up `home-assistant` since this performance decreases grew with the number of imported modules on `path`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
