### PR TITLE
Correct typing of ``relative_to_absolute_name``

### DIFF
--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -92,7 +92,7 @@ class ImportFromMixin(FilterStmtsMixin):
         # using the same name as the package, which may end in an infinite loop
         # on relative imports
         # XXX: no more needed ?
-        mymodule: nodes.Module = self.root()
+        mymodule = self.root()
         level = getattr(self, "level", None)  # Import as no level
         if modname is None:
             modname = self.modname

--- a/astroid/mixins.py
+++ b/astroid/mixins.py
@@ -86,13 +86,13 @@ class ImportFromMixin(FilterStmtsMixin):
     def _infer_name(self, frame, name):
         return name
 
-    def do_import_module(self, modname=None):
+    def do_import_module(self, modname: str | None = None) -> nodes.Module:
         """return the ast for a module whose name is <modname> imported by <self>"""
         # handle special case where we are on a package node importing a module
         # using the same name as the package, which may end in an infinite loop
         # on relative imports
         # XXX: no more needed ?
-        mymodule = self.root()
+        mymodule: nodes.Module = self.root()
         level = getattr(self, "level", None)  # Import as no level
         if modname is None:
             modname = self.modname

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -527,7 +527,9 @@ class Module(LocalsDictNodeNG):
                 raise
         return AstroidManager().ast_from_module_name(modname)
 
-    def relative_to_absolute_name(self, modname: str, level: int) -> str:
+    def relative_to_absolute_name(
+        self, modname: str | None, level: int | None
+    ) -> str | None:
         """Get the absolute module name for a relative import.
 
         The relative import can be implicit or explicit.


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

Working on https://github.com/PyCQA/pylint/pull/6982 showed that this typing was incorrect.

It originated from https://github.com/PyCQA/astroid/pull/1211 which was passed on the typing in the docstring. However, this method can also be called with `None` values, as the `do_import_module` method shows.


## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue