### PR TITLE
Add typing to ``const_factory``

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -51,9 +51,7 @@ def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
 
 
-_ContainerNodesT = TypeVar(
-    "_ContainerNodesT", bound=Union["List", "Set", "Tuple", "Dict"]
-)
+_ContainerNodesT = TypeVar("_ContainerNodesT", "List", "Set", "Tuple", "Dict")
 _NodesT = TypeVar("_NodesT", bound=NodeNG)
 
 AssignedStmtsPossibleNode = Union["List", "Tuple", "AssignName", "AssignAttr", None]
@@ -5371,7 +5369,7 @@ def _two_step_initialization(
 ) -> _ContainerNodesT:
     instance = cls()
     instance.postinit(value)
-    return instance  # type: ignore[return-value]
+    return instance
 
 
 def _dict_initialization(cls: type[Dict], value: list[Any]) -> Dict:

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -5374,10 +5374,6 @@ def _two_step_initialization(
     return instance  # type: ignore[return-value]
 
 
-def _dict_initialization(cls: type[Dict], value: list[Any]) -> Dict:
-    return _two_step_initialization(cls, value)
-
-
 def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
     """Return an astroid node for a python value."""
     assert not isinstance(value, NodeNG)
@@ -5395,8 +5391,6 @@ def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
     # each element to an AST. This is fixed in 2.0
     # and this approach is a temporary hack.
     initializer_cls = CONST_CLS[value.__class__]
-    if issubclass(initializer_cls, (List, Set, Tuple)):
+    if issubclass(initializer_cls, (Dict, List, Set, Tuple)):
         return _two_step_initialization(initializer_cls, [])  # type: ignore[return-value, type-var]
-    if issubclass(initializer_cls, Dict):
-        return _dict_initialization(initializer_cls, [])
     return Const(value)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -5392,12 +5392,9 @@ def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
     # or a mapping, in order to avoid transforming
     # each element to an AST. This is fixed in 2.0
     # and this approach is a temporary hack.
-    if isinstance(value, list):
-        return _two_step_initialization(List, [])
-    if isinstance(value, set):
-        return _two_step_initialization(Set, [])
-    if isinstance(value, tuple):
-        return _two_step_initialization(Tuple, [])
-    if isinstance(value, (list, set, tuple, dict)):
-        return _dict_initialization(Dict, [])
+    initializer_cls = CONST_CLS[value.__class__]
+    if issubclass(initializer_cls, (List, Set, Tuple)):
+        return _two_step_initialization(initializer_cls, [])
+    if issubclass(initializer_cls, Dict):
+        return _dict_initialization(initializer_cls, [])
     return Const(value)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -51,9 +51,6 @@ def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
 
 
-_ContainerNodesT = TypeVar(
-    "_ContainerNodesT", bound=Union["List", "Set", "Tuple", "Dict"]
-)
 _NodesT = TypeVar("_NodesT", bound=NodeNG)
 
 AssignedStmtsPossibleNode = Union["List", "Tuple", "AssignName", "AssignAttr", None]
@@ -5366,14 +5363,6 @@ CONST_CLS: dict[type, type[NodeNG]] = {
 }
 
 
-def _two_step_initialization(
-    cls: type[_ContainerNodesT], value: list[Any]
-) -> _ContainerNodesT:
-    instance = cls()
-    instance.postinit(value)
-    return instance  # type: ignore[return-value]
-
-
 def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
     """Return an astroid node for a python value."""
     assert not isinstance(value, NodeNG)
@@ -5392,5 +5381,7 @@ def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
     # and this approach is a temporary hack.
     initializer_cls = CONST_CLS[value.__class__]
     if issubclass(initializer_cls, (Dict, List, Set, Tuple)):
-        return _two_step_initialization(initializer_cls, [])  # type: ignore[return-value, type-var]
+        instance = initializer_cls()
+        instance.postinit([])
+        return instance
     return Const(value)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -51,6 +51,9 @@ def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
 
 
+_ContainerNodesT = TypeVar(
+    "_ContainerNodesT", bound=Union["List", "Set", "Tuple", "Dict"]
+)
 _NodesT = TypeVar("_NodesT", bound=NodeNG)
 
 AssignedStmtsPossibleNode = Union["List", "Tuple", "AssignName", "AssignAttr", None]
@@ -5344,7 +5347,9 @@ class MatchOr(Pattern):
 
 # constants ##############################################################
 
-CONST_CLS = {
+# The _proxied attribute of all container types (List, Tuple, etc.)
+# are set during bootstrapping by _astroid_bootstrapping().
+CONST_CLS: dict[type, type[NodeNG]] = {
     list: List,
     tuple: Tuple,
     dict: Dict,
@@ -5352,63 +5357,49 @@ CONST_CLS = {
     type(None): Const,
     type(NotImplemented): Const,
     type(...): Const,
+    bool: Const,
+    int: Const,
+    float: Const,
+    complex: Const,
+    str: Const,
+    bytes: Const,
 }
 
 
-def _update_const_classes():
-    """update constant classes, so the keys of CONST_CLS can be reused"""
-    klasses = (bool, int, float, complex, str, bytes)
-    for kls in klasses:
-        CONST_CLS[kls] = Const
-
-
-_update_const_classes()
-
-
-def _two_step_initialization(cls, value):
+def _two_step_initialization(
+    cls: type[_ContainerNodesT], value: list[Any]
+) -> _ContainerNodesT:
     instance = cls()
     instance.postinit(value)
-    return instance
+    return instance  # type: ignore[return-value]
 
 
-def _dict_initialization(cls, value):
-    if isinstance(value, dict):
-        value = tuple(value.items())
+def _dict_initialization(cls: type[Dict], value: list[Any]) -> Dict:
     return _two_step_initialization(cls, value)
 
 
-_CONST_CLS_CONSTRUCTORS = {
-    List: _two_step_initialization,
-    Tuple: _two_step_initialization,
-    Dict: _dict_initialization,
-    Set: _two_step_initialization,
-    Const: lambda cls, value: cls(value),
-}
-
-
-def const_factory(value):
-    """return an astroid node for a python value"""
-    # XXX we should probably be stricter here and only consider stuff in
-    # CONST_CLS or do better treatment: in case where value is not in CONST_CLS,
-    # we should rather recall the builder on this value than returning an empty
-    # node (another option being that const_factory shouldn't be called with something
-    # not in CONST_CLS)
+def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
+    """Return an astroid node for a python value."""
     assert not isinstance(value, NodeNG)
 
-    # Hack for ignoring elements of a sequence
-    # or a mapping, in order to avoid transforming
-    # each element to an AST. This is fixed in 2.0
-    # and this approach is a temporary hack.
-    if isinstance(value, (list, set, tuple, dict)):
-        elts = []
-    else:
-        elts = value
-
-    try:
-        initializer_cls = CONST_CLS[value.__class__]
-        initializer = _CONST_CLS_CONSTRUCTORS[initializer_cls]
-        return initializer(initializer_cls, elts)
-    except (KeyError, AttributeError):
+    # This only handles instances of the CONST types. Any
+    # subclasses get inferred as EmptyNode.
+    # TODO: See if we should revisit these with the normal builder.
+    if value.__class__ not in CONST_CLS:
         node = EmptyNode()
         node.object = value
         return node
+
+    # TODO: We pass an empty list as elements for a sequence
+    # or a mapping, in order to avoid transforming
+    # each element to an AST. This is fixed in 2.0
+    # and this approach is a temporary hack.
+    if isinstance(value, list):
+        return _two_step_initialization(List, [])
+    if isinstance(value, set):
+        return _two_step_initialization(Set, [])
+    if isinstance(value, tuple):
+        return _two_step_initialization(Tuple, [])
+    if isinstance(value, (list, set, tuple, dict)):
+        return _dict_initialization(Dict, [])
+    return Const(value)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -51,7 +51,9 @@ def _is_const(value):
     return isinstance(value, tuple(CONST_CLS))
 
 
-_ContainerNodesT = TypeVar("_ContainerNodesT", "List", "Set", "Tuple", "Dict")
+_ContainerNodesT = TypeVar(
+    "_ContainerNodesT", bound=Union["List", "Set", "Tuple", "Dict"]
+)
 _NodesT = TypeVar("_NodesT", bound=NodeNG)
 
 AssignedStmtsPossibleNode = Union["List", "Tuple", "AssignName", "AssignAttr", None]
@@ -5369,7 +5371,7 @@ def _two_step_initialization(
 ) -> _ContainerNodesT:
     instance = cls()
     instance.postinit(value)
-    return instance
+    return instance  # type: ignore[return-value]
 
 
 def _dict_initialization(cls: type[Dict], value: list[Any]) -> Dict:
@@ -5394,7 +5396,7 @@ def const_factory(value: Any) -> List | Set | Tuple | Dict | Const | EmptyNode:
     # and this approach is a temporary hack.
     initializer_cls = CONST_CLS[value.__class__]
     if issubclass(initializer_cls, (List, Set, Tuple)):
-        return _two_step_initialization(initializer_cls, [])
+        return _two_step_initialization(initializer_cls, [])  # type: ignore[return-value, type-var]
     if issubclass(initializer_cls, Dict):
         return _dict_initialization(initializer_cls, [])
     return Const(value)

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -478,7 +478,7 @@ class InspectBuilder:
 
 # astroid bootstrapping ######################################################
 
-_CONST_PROXY = {}
+_CONST_PROXY: dict[type, nodes.ClassDef] = {}
 
 
 def _set_proxied(const):
@@ -505,6 +505,7 @@ def _astroid_bootstrapping():
             proxy.parent = astroid_builtin
         else:
             proxy = astroid_builtin.getattr(cls.__name__)[0]
+            assert isinstance(proxy, nodes.ClassDef)
         if cls in (dict, list, set, tuple):
             node_cls._proxied = proxy
         else:


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

This looks like a big chance, but I tested and there is no change in functionality. It's just all a bit more explicit.

I have thought about `overloading` it so `value: str -> Const`, but that's not actually true as `str` also covers all subclasses of `str`. That's not what this function does.

I have also tested if we should just create a node if `value` is a subclass of `str` (or any other `CONST_CLS` but then `sys.version_info` gets inferred as `Tuple`, while it is an instance of `sys.version_info`. Which itself is a subclass of `tuple`.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue