### PR TITLE
Type ``_infer`` of binary operation nodes

### DIFF
--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -599,7 +599,7 @@ def infer_unaryop(
     return InferenceErrorInfo(node=self, context=context)
 
 
-nodes.UnaryOp._infer_unaryop = _infer_unaryop  # type: ignore[assignment]
+nodes.UnaryOp._infer_unaryop = _infer_unaryop
 nodes.UnaryOp._infer = infer_unaryop  # type: ignore[assignment]
 
 
@@ -877,7 +877,7 @@ def infer_binop(
     )
 
 
-nodes.BinOp._infer_binop = _infer_binop  # type: ignore[assignment]
+nodes.BinOp._infer_binop = _infer_binop
 nodes.BinOp._infer = infer_binop  # type: ignore[assignment]
 
 COMPARE_OPS: dict[str, Callable[[Any, Any], bool]] = {
@@ -1016,7 +1016,7 @@ def infer_augassign(
     )
 
 
-nodes.AugAssign._infer_augassign = _infer_augassign  # type: ignore[assignment]
+nodes.AugAssign._infer_augassign = _infer_augassign
 nodes.AugAssign._infer = infer_augassign  # type: ignore[assignment]
 
 # End of binary operation inference.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -70,7 +70,7 @@ InferLHS = Callable[
 ]
 InferBinaryOperation = Callable[
     [_NodesT, Optional[InferenceContext]],
-    Generator[Union[InferenceResult, _BadOpMessageT], None, None],
+    typing.Generator[Union[InferenceResult, _BadOpMessageT], None, None],
 ]
 
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1395,9 +1395,6 @@ class BinOp(NodeNG):
     _astroid_fields = ("left", "right")
     _other_fields = ("op",)
 
-    # This is set by inference.py
-    _infer_binop: ClassVar[InferBinaryOperation[BinOp, util.BadBinaryOperationMessage]]
-
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
@@ -1450,6 +1447,9 @@ class BinOp(NodeNG):
         """
         self.left = left
         self.right = right
+
+    # This is set by inference.py
+    _infer_binop: ClassVar[InferBinaryOperation[BinOp, util.BadBinaryOperationMessage]]
 
     def type_errors(self, context=None):
         """Get a list of type errors which can occur during inference.
@@ -4181,11 +4181,6 @@ class UnaryOp(NodeNG):
     _astroid_fields = ("operand",)
     _other_fields = ("op",)
 
-    # This is set by inference.py
-    _infer_unaryop: ClassVar[
-        InferBinaryOperation[UnaryOp, util.BadUnaryOperationMessage]
-    ]
-
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
@@ -4232,6 +4227,11 @@ class UnaryOp(NodeNG):
         :param operand: What the unary operator is applied to.
         """
         self.operand = operand
+
+    # This is set by inference.py
+    _infer_unaryop: ClassVar[
+        InferBinaryOperation[UnaryOp, util.BadUnaryOperationMessage]
+    ]
 
     def type_errors(self, context=None):
         """Get a list of type errors which can occur during inference.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1343,7 +1343,9 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     """
 
     # This is set by inference.py
-    def _infer_augassign(self, context=None):
+    def _infer_augassign(
+        self, context: InferenceContext | None = None
+    ) -> Generator[InferenceResult | util.BadBinaryOperationMessage, None, None]:
         raise NotImplementedError
 
     def type_errors(self, context=None):
@@ -1443,7 +1445,9 @@ class BinOp(NodeNG):
         self.right = right
 
     # This is set by inference.py
-    def _infer_binop(self, context=None):
+    def _infer_binop(
+        self, context: InferenceContext | None = None
+    ) -> Generator[InferenceResult | util.BadBinaryOperationMessage, None, None]:
         raise NotImplementedError
 
     def type_errors(self, context=None):
@@ -4224,7 +4228,9 @@ class UnaryOp(NodeNG):
         self.operand = operand
 
     # This is set by inference.py
-    def _infer_unaryop(self, context=None):
+    def _infer_unaryop(
+        self, context: InferenceContext | None = None
+    ) -> Generator[InferenceResult | util.BadUnaryOperationMessage, None, None]:
         raise NotImplementedError
 
     def type_errors(self, context=None):


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

Sorry for the size of the PR. Wanted to catch all `_infer's` that use `_filter_operation_errors` and `nodes.Compare` was in between them.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue