### PR TITLE
Refs #1662: Condition `usedforsecurity` support on Py3.9+

### DIFF
--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -34,12 +34,12 @@ def _hashlib_transform():
     algorithms_with_signature = dict.fromkeys(
         ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"], signature
     )
-    blake2b_signature = "data=b'', *, digest_size=64, key=b'', salt=b'', \
+    blake2b_signature = f"data=b'', *, digest_size=64, key=b'', salt=b'', \
             person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, \
-            node_depth=0, inner_size=0, last_node=False, usedforsecurity=True"
-    blake2s_signature = "data=b'', *, digest_size=32, key=b'', salt=b'', \
+            node_depth=0, inner_size=0, last_node=False{maybe_usedforsecurity}"
+    blake2s_signature = f"data=b'', *, digest_size=32, key=b'', salt=b'', \
             person=b'', fanout=1, depth=1, leaf_size=0, node_offset=0, \
-            node_depth=0, inner_size=0, last_node=False, usedforsecurity=True"
+            node_depth=0, inner_size=0, last_node=False{maybe_usedforsecurity}"
     new_algorithms = dict.fromkeys(
         ["sha3_224", "sha3_256", "sha3_384", "sha3_512", "shake_128", "shake_256"],
         signature,

--- a/astroid/brain/brain_hashlib.py
+++ b/astroid/brain/brain_hashlib.py
@@ -4,11 +4,13 @@
 
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import parse
+from astroid.const import PY39_PLUS
 from astroid.manager import AstroidManager
 
 
 def _hashlib_transform():
-    signature = "value='', usedforsecurity=True"
+    maybe_usedforsecurity = ", usedforsecurity=True" if PY39_PLUS else ""
+    signature = f"value=''{maybe_usedforsecurity}"
     template = """
     class %(name)s(object):
       def __init__(self, %(signature)s): pass

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -18,6 +18,7 @@ import pytest
 import astroid
 from astroid import MANAGER, bases, builder, nodes, objects, test_utils, util
 from astroid.bases import Instance
+from astroid.const import PY39_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
     InferenceError,
@@ -75,8 +76,11 @@ class HashlibTest(unittest.TestCase):
         self.assertIn("hexdigest", class_obj)
         self.assertIn("block_size", class_obj)
         self.assertIn("digest_size", class_obj)
-        self.assertEqual(len(class_obj["__init__"].args.args), 3)
-        self.assertEqual(len(class_obj["__init__"].args.defaults), 2)
+        # usedforsecurity was added in Python 3.9, see 8e7174a9
+        self.assertEqual(len(class_obj["__init__"].args.args), 3 if PY39_PLUS else 2)
+        self.assertEqual(
+            len(class_obj["__init__"].args.defaults), 2 if PY39_PLUS else 1
+        )
         self.assertEqual(len(class_obj["update"].args.args), 2)
         self.assertEqual(len(class_obj["digest"].args.args), 1)
         self.assertEqual(len(class_obj["hexdigest"].args.args), 1)


### PR DESCRIPTION
## Description
See https://github.com/PyCQA/astroid/pull/1662#issuecomment-1166271441, the better way to do this is to condition the support for this keyword on Python 3.9+.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Refs #1662
