### PR TITLE
Revert "Type ``_infer`` of Attribute, AssignAttr, Global and Subscript (#1657)"

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -30,11 +30,7 @@ from astroid.manager import AstroidManager
 from astroid.nodes import _base_nodes
 from astroid.nodes.const import OP_PRECEDENCE
 from astroid.nodes.node_ng import NodeNG
-from astroid.typing import (
-    InferenceErrorInfo,
-    InferenceResult,
-    SuccessfulInferenceResult,
-)
+from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -70,7 +66,7 @@ AssignedStmtsCall = Callable[
 ]
 InferLHS = Callable[
     [_NodesT, Optional[InferenceContext]],
-    typing.Generator[InferenceResult, None, Optional[InferenceErrorInfo]],
+    typing.Generator[InferenceResult, None, None],
 ]
 InferBinaryOperation = Callable[
     [_NodesT, Optional[InferenceContext]],
@@ -969,8 +965,6 @@ class AssignAttr(_base_nodes.ParentAssignNode):
 
     _astroid_fields = ("expr",)
     _other_fields = ("attrname",)
-
-    infer_lhs: ClassVar[InferLHS[AssignAttr]]
 
     @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
@@ -3842,8 +3836,6 @@ class Subscript(NodeNG):
 
     _astroid_fields = ("value", "slice")
     _other_fields = ("ctx",)
-
-    infer_lhs: ClassVar[InferLHS[Subscript]]
 
     def __init__(
         self,


### PR DESCRIPTION
## Description
This reverts commit 90362ad816c0e3ac586519edb5bc9d9cd7b384cb.
The commit caused a pylint crash with Home Assistant. Will need to investigate it.

Crash: https://github.com/cdce8p/ha-core/runs/7053862874?check_suite_focus=true#step:8:93