### PR TITLE
Improve packaging [PEP 517 + 621]

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-extend-ignore = E203,E266,E501,C901,F401
-max-complexity = 20
-select = B,C,E,F,W,T4,B9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,12 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install requirements
         run: |
-          python -m pip install -U pip twine wheel
-          python -m pip install -U "setuptools>=56.0.0"
+          # Remove dist, build, and astroid.egg-info
+          # when building locally for testing!
+          python -m pip install twine build
       - name: Build distributions
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Upload to PyPI
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: copyright-notice
         args: ["--notice=script/copyright.txt", "--enforce-all", "--autofix"]
-        exclude: tests/testdata
+        exclude: tests/testdata|setup.py
         types: [python]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.34.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: copyright-notice
         args: ["--notice=script/copyright.txt", "--enforce-all", "--autofix"]
-        exclude: tests/testdata|setup.py
+        exclude: tests/testdata
         types: [python]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.34.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,1 @@
-prune .github
-prune doc
-prune tests
-exclude .*
-exclude ChangeLog
-exclude pylintrc
-exclude README.rst
-exclude requirements_*.txt
-exclude tox.ini
+include README.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools~=62.6", "wheel~=0.37.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name        = "astroid"
+license     = {text = "LGPL-2.1-or-later"}
+description = "An abstract syntax tree for Python with inference support."
+readme      = "README.rst"
+authors     = [
+    {name = "Python Code Quality Authority", email = "code-quality@python.org"}
+]
+keywords    = ["static code analysis", "python", "abstract syntax tree"]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+]
+requires-python = ">=3.7.2"
+dependencies = [
+    "lazy_object_proxy>=1.4.0",
+    "wrapt>=1.11,<2",
+    "typed-ast>=1.4.0,<2.0;implementation_name=='cpython' and python_version<'3.8'",
+    "typing-extensions>=3.10;python_version<'3.10'",
+]
+dynamic = ["version"]
+
+[project.urls]
+"Docs"           = "https://pylint.pycqa.org/projects/astroid/en/latest/"
+"Source Code"    = "https://github.com/PyCQA/astroid"
+"Bug tracker"    = "https://github.com/PyCQA/astroid/issues"
+"Discord server" = "https://discord.gg/Egy6P8AMB5"
+
+[tool.setuptools]
+license-files = ["LICENSE", "CONTRIBUTORS.txt"]  # Keep in sync with setup.cfg
+
+[tool.setuptools.packages.find]
+include = ["astroid*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "astroid.__pkginfo__.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,51 +1,12 @@
+# Setuptools v62.6 doesn't support editable installs with just 'pyproject.toml' (PEP 660).
+# Keep this file until it does!
+
 [metadata]
-name = astroid
-description = An abstract syntax tree for Python with inference support.
-version = attr: astroid.__pkginfo__.__version__
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-url = https://github.com/PyCQA/astroid
-author = Python Code Quality Authority
-author_email = code-quality@python.org
-license = LGPL-2.1-or-later
+# wheel doesn't yet read license_files from pyproject.toml - tools.setuptools
+# Keep it here until it does!
 license_files =
     LICENSE
     CONTRIBUTORS.txt
-classifiers =
-    Development Status :: 6 - Mature
-    Environment :: Console
-    Intended Audience :: Developers
-    License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)
-    Operating System :: OS Independent
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: PyPy
-    Topic :: Software Development :: Libraries :: Python Modules
-    Topic :: Software Development :: Quality Assurance
-    Topic :: Software Development :: Testing
-keywords = static code analysis,python,abstract syntax tree
-project_urls =
-    Bug tracker = https://github.com/PyCQA/astroid/issues
-    Discord server = https://discord.gg/Egy6P8AMB5
-
-[options]
-packages = find:
-install_requires =
-    lazy_object_proxy>=1.4.0
-    wrapt>=1.11,<2
-    typed-ast>=1.4.0,<2.0;implementation_name=="cpython" and python_version<"3.8"
-    typing-extensions>=3.10;python_version<"3.10"
-python_requires = >=3.7.2
-
-[options.packages.find]
-include =
-    astroid*
 
 [aliases]
 test = pytest
@@ -62,6 +23,11 @@ known_third_party = sphinx, pytest, six, nose, numpy, attr
 known_first_party = astroid
 include_trailing_comma = True
 skip_glob = tests/testdata
+
+[flake8]
+# Required for flake8-typing-imports (v1.12.0)
+# The plugin doesn't yet read the value from pyproject.toml
+min_python_version = 3.7.2
 
 [mypy]
 scripts_are_modules = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ include_trailing_comma = True
 skip_glob = tests/testdata
 
 [flake8]
+extend-ignore = E203,E266,E501,C901,F401
+max-complexity = 20
+select = B,C,E,F,W,T4,B9
 # Required for flake8-typing-imports (v1.12.0)
 # The plugin doesn't yet read the value from pyproject.toml
 min_python_version = 3.7.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+# Keep file until dependabot issue is resolved
+# https://github.com/dependabot/dependabot-core/issues/4483
+
+from setuptools import setup
+
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-# Keep until dependabot issue is resolved
-# https://github.com/dependabot/dependabot-core/issues/4483
-
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Keep until dependabot issue is resolved
+# https://github.com/dependabot/dependabot-core/issues/4483
+
 from setuptools import setup
 
 setup()


### PR DESCRIPTION
## Description
Similar to https://github.com/PyCQA/pylint/pull/7076

* Use isolated build environments [PEP 517](https://peps.python.org/pep-0517/) with `python -m build` instead of deprecated `python setup.py sdist bdist_wheel`
* Move project metadata from `setup.cfg` to `pyproject.toml` [PEP 621](https://peps.python.org/pep-0621/)
* Cleanup `MANIFEST.in` -> entries haven't been used.
* Add `README.rst` to `MANIFEST.in`. Required to be able to build the `wheel` from `sdist` and still include the readme text in the project metadata.

**Metadata diff**
```diff
-Author: Python Code Quality Authority
-Author-email: code-quality@python.org
+Author-email: Python Code Quality Authority <code-quality@python.org>
...
-Home-page: https://github.com/PyCQA/astroid
+Project-URL: Source Code, https://github.com/PyCQA/astroid
...
+Project-URL: Docs, https://pylint.pycqa.org/projects/astroid/en/latest/
...
-Platform: UNKNOWN
```

**Notes**
* `README.rst` should be included in `sdist` to build `wheel` successfully. Without `MANIFEST.in`, `README.rst` would be added automatically. Let's add it manually, just in case something else is added to `MANIFEST.in` later.
* `Platform` isn't used currently / anymore
* `Home-page` was defined with `url`. I've moved it to `project.urls` and renamed it to `Source Code`.
* Added `project.url` for `Docs`