### PR TITLE
Add typing to ``_function_type`` and ``_build_proxy_class``

### DIFF
--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -21,13 +21,15 @@ from astroid.nodes import scoped_nodes
 from astroid.typing import InferenceResult
 
 
-def _build_proxy_class(cls_name, builtins):
+def _build_proxy_class(cls_name: str, builtins: nodes.Module) -> nodes.ClassDef:
     proxy = raw_building.build_class(cls_name)
     proxy.parent = builtins
     return proxy
 
 
-def _function_type(function, builtins):
+def _function_type(
+    function: nodes.Lambda | bases.UnboundMethod, builtins: nodes.Module
+) -> nodes.ClassDef:
     if isinstance(function, scoped_nodes.Lambda):
         if function.root().name == "builtins":
             cls_name = "builtin_function_or_method"
@@ -35,7 +37,7 @@ def _function_type(function, builtins):
             cls_name = "function"
     elif isinstance(function, bases.BoundMethod):
         cls_name = "method"
-    elif isinstance(function, bases.UnboundMethod):
+    else:
         cls_name = "function"
     return _build_proxy_class(cls_name, builtins)
 

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -86,7 +86,7 @@ class AstroidManager:
         return self._transform.unregister_transform
 
     @property
-    def builtins_module(self):
+    def builtins_module(self) -> nodes.Module:
         return self.astroid_cache["builtins"]
 
     def visit_transforms(self, node):

--- a/astroid/typing.py
+++ b/astroid/typing.py
@@ -32,7 +32,7 @@ InferFn = Callable[..., Any]
 class AstroidManagerBrain(TypedDict):
     """Dictionary to store relevant information for a AstroidManager class."""
 
-    astroid_cache: dict
+    astroid_cache: dict[str, nodes.Module]
     _mod_file_cache: dict
     _failed_import_hooks: list
     always_load_extensions: bool


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

This is all necessary for the further typing of `protocols.py`, which is next in line now that `inference.py` has been finished.
However, we need `helpes.object_type` to be typed for that, which will require some additional PRs.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue