### PR TITLE
Prevent creating `Instance` that proxies another `Instance` when inferring `__new__(cls)`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -109,6 +109,11 @@ Release date: TBA
 
   Closes PyCQA/pylint#7092
 
+* Prevent creating ``Instance`` objects that proxy other ``Instance``s when there is
+  ambiguity (or user error) in calling ``__new__(cls)``.
+
+  Refs PyCQA/pylint#7109
+
 
 What's New in astroid 2.11.6?
 =============================

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import collections
 import collections.abc
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from astroid import decorators, nodes
+from astroid import decorators
 from astroid.const import PY310_PLUS
 from astroid.context import (
     CallContext,
@@ -32,6 +32,9 @@ from astroid.util import Uninferable, lazy_descriptor, lazy_import
 objectmodel = lazy_import("interpreter.objectmodel")
 helpers = lazy_import("helpers")
 manager = lazy_import("manager")
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 # TODO: check if needs special treatment
@@ -290,11 +293,6 @@ class Instance(BaseInstance):
     # pylint: disable=unnecessary-lambda
     special_attributes = lazy_descriptor(lambda: objectmodel.InstanceModel())
 
-    def __init__(self, proxied: nodes.ClassDef) -> None:
-        if not isinstance(proxied, nodes.ClassDef):
-            raise TypeError
-        super().__init__(proxied)
-
     def __repr__(self):
         return "<Instance of {}.{} at 0x{}>".format(
             self._proxied.root().name, self._proxied.name, id(self)
@@ -417,6 +415,9 @@ class UnboundMethod(Proxy):
     ) -> collections.abc.Generator[
         nodes.Const | Instance | type[Uninferable], None, None
     ]:
+        # pylint: disable-next=import-outside-toplevel; circular import
+        from astroid import nodes
+
         if not caller.args:
             return
         # Attempt to create a constant

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -436,7 +436,14 @@ class UnboundMethod(Proxy):
         node_context = context.extra_context.get(caller.args[0])
         infer = caller.args[0].infer(context=node_context)
 
-        yield from (Instance(x) if x is not Uninferable else x for x in infer)  # type: ignore[misc,arg-type]
+        for inferred in infer:
+            if isinstance(inferred, type(Uninferable)):  # isinstance helps mypy
+                yield inferred
+            if isinstance(inferred, Instance):
+                raise InferenceError
+            if isinstance(inferred, (nodes.ClassDef, nodes.Lambda, Proxy)):
+                yield Instance(inferred)
+            raise InferenceError
 
     def bool_value(self, context=None):
         return True

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -433,9 +433,7 @@ class UnboundMethod(Proxy):
                 return
 
         node_context = context.extra_context.get(caller.args[0])
-        infer = caller.args[0].infer(context=node_context)
-
-        for inferred in infer:
+        for inferred in caller.args[0].infer(context=node_context):
             if inferred is Uninferable:
                 yield inferred
             if isinstance(inferred, nodes.ClassDef):

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -437,11 +437,9 @@ class UnboundMethod(Proxy):
         infer = caller.args[0].infer(context=node_context)
 
         for inferred in infer:
-            if isinstance(inferred, type(Uninferable)):  # isinstance helps mypy
+            if inferred is Uninferable:
                 yield inferred
-            if isinstance(inferred, Instance):
-                raise InferenceError
-            if isinstance(inferred, (nodes.ClassDef, nodes.Lambda, Proxy)):
+            if isinstance(inferred, nodes.ClassDef):
                 yield Instance(inferred)
             raise InferenceError
 

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -293,6 +293,9 @@ class Instance(BaseInstance):
     # pylint: disable=unnecessary-lambda
     special_attributes = lazy_descriptor(lambda: objectmodel.InstanceModel())
 
+    def __init__(self, proxied: nodes.ClassDef) -> None:
+        super().__init__(proxied)
+
     def __repr__(self):
         return "<Instance of {}.{} at 0x{}>".format(
             self._proxied.root().name, self._proxied.name, id(self)

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -3799,6 +3799,15 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         with pytest.raises(InferenceError):
             next(ast_node4.infer())
 
+        ast_node5 = extract_node(
+            """
+        class A:  pass
+        A.__new__(A())  #@
+        """
+        )
+        with pytest.raises(InferenceError):
+            next(ast_node5.infer())
+
     @pytest.mark.xfail(reason="Does not support function metaclasses")
     def test_function_metaclasses(self):
         # These are not supported right now, although


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
See discussion at https://github.com/PyCQA/pylint/issues/7109#issuecomment-1172909800. When astroid thinks `__new__(cls)` is being called with an instance either due to user error or because of inference ambiguity (e.g. the library code in the OP used an `isinstance` guard that astroid doesn't cope with), we now raise `InferenceError` instead of creating a bogus Instance-proxied-to-Instance. Callers then transform this to `Uninferable` as appropriate. (See #782 for a precedent.)

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
Refs PyCQA/pylint#7109