### PR TITLE
Add ``__init__`` to the ``ObjectModel`` and return ``BoundMethods``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,9 @@ Release date: TBA
 
   Closes #104, Closes #1611
 
+* ``__new__`` and ``__init__`` have been added to the ``ObjectModel`` and are now
+  inferred as ``BoundMethods``.
+
 * Old style string formatting (using ``%`` operators) is now correctly inferred.
 
   Closes #151

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -140,7 +140,7 @@ class ObjectModel:
     @property
     def attr___init__(self) -> bases.BoundMethod:
         """Calling cls.__init__() normally returns None."""
-        # The *args and **kwargs are necessary not too trigger warnings about missing
+        # The *args and **kwargs are necessary not to trigger warnings about missing
         # or extra parameters for '__init__' methods we don't infer correctly.
         # This BoundMethod is the fallback value for those.
         node: nodes.FunctionDef = builder.extract_node(
@@ -499,7 +499,7 @@ class ClassModel(ObjectModel):
 
     @property
     def attr___class__(self):
-        # pylint: disable=import-outside-toplevel; circular importdd
+        # pylint: disable=import-outside-toplevel; circular import
         from astroid import helpers
 
         return helpers.object_type(self._instance)

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -31,15 +31,17 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import astroid
-from astroid import nodes, util
+from astroid import bases, nodes, util
 from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
 from astroid.nodes import node_classes
 
 objects = util.lazy_import("objects")
+builder = util.lazy_import("builder")
 
 if TYPE_CHECKING:
+    from astroid import builder
     from astroid.objects import Property
 
 IMPL_PREFIX = "attr_"
@@ -119,21 +121,41 @@ class ObjectModel:
         raise AttributeInferenceError(target=self._instance, attribute=name)
 
     @property
-    def attr___new__(self):
-        """Calling cls.__new__(cls) on an object returns an instance of that object.
+    def attr___new__(self) -> bases.BoundMethod:
+        """Calling cls.__new__(type) on an object returns an instance of 'type'."""
+        node: nodes.FunctionDef = builder.extract_node(
+            """def __new__(self, cls): return cls()"""
+        )
+        # We set the parent as being the ClassDef of 'object' as that
+        # triggers correct inference as a call to __new__ in bases.py
+        node.parent: nodes.ClassDef = AstroidManager().builtins_module["object"]
 
-        Instance is either an instance or a class definition of the instance to be
-        created.
-        """
         # TODO: Use isinstance instead of try ... except after _instance has typing
         try:
-            return self._instance._proxied.instantiate_class()
+            bound = self._instance._proxied
         except AttributeError:
-            return self._instance.instantiate_class()
+            bound = self._instance
+        return bases.BoundMethod(proxy=node, bound=bound)
 
     @property
-    def attr___init__(self) -> nodes.Const:
-        return nodes.Const(None)
+    def attr___init__(self) -> bases.BoundMethod:
+        """Calling cls.__init__() normally returns None."""
+        # The *args and **kwargs are necessary not too trigger warnings about missing
+        # or extra parameters for '__init__' methods we don't infer correctly.
+        # This BoundMethod is the fallback value for those.
+        node: nodes.FunctionDef = builder.extract_node(
+            """def __init__(self, *args, **kwargs): return None"""
+        )
+        # We set the parent as being the ClassDef of 'object' as that
+        # is where this method originally comes from
+        node.parent: nodes.ClassDef = AstroidManager().builtins_module["object"]
+
+        # TODO: Use isinstance instead of try ... except after _instance has typing
+        try:
+            bound = self._instance._proxied
+        except AttributeError:
+            bound = self._instance
+        return bases.BoundMethod(proxy=node, bound=bound)
 
 
 class ModuleModel(ObjectModel):
@@ -304,9 +326,6 @@ class FunctionModel(ObjectModel):
 
     @property
     def attr___get__(self):
-        # pylint: disable=import-outside-toplevel; circular import
-        from astroid import bases
-
         func = self._instance
 
         class DescriptorBoundMethod(bases.BoundMethod):
@@ -458,9 +477,6 @@ class ClassModel(ObjectModel):
         if not self._instance.newstyle:
             raise AttributeInferenceError(target=self._instance, attribute="mro")
 
-        # pylint: disable=import-outside-toplevel; circular import
-        from astroid import bases
-
         other_self = self
 
         # Cls.mro is a method and we need to return one in order to have a proper inference.
@@ -483,7 +499,7 @@ class ClassModel(ObjectModel):
 
     @property
     def attr___class__(self):
-        # pylint: disable=import-outside-toplevel; circular import
+        # pylint: disable=import-outside-toplevel; circular importdd
         from astroid import helpers
 
         return helpers.object_type(self._instance)
@@ -495,10 +511,6 @@ class ClassModel(ObjectModel):
         This looks only in the current module for retrieving the subclasses,
         thus it might miss a couple of them.
         """
-        # pylint: disable=import-outside-toplevel; circular import
-        from astroid import bases
-        from astroid.nodes import scoped_nodes
-
         if not self._instance.newstyle:
             raise AttributeInferenceError(
                 target=self._instance, attribute="__subclasses__"
@@ -508,7 +520,7 @@ class ClassModel(ObjectModel):
         root = self._instance.root()
         classes = [
             cls
-            for cls in root.nodes_of_class(scoped_nodes.ClassDef)
+            for cls in root.nodes_of_class(nodes.ClassDef)
             if cls != self._instance and cls.is_subtype_of(qname, context=self.context)
         ]
 
@@ -781,12 +793,8 @@ class DictModel(ObjectModel):
 class PropertyModel(ObjectModel):
     """Model for a builtin property"""
 
-    # pylint: disable=import-outside-toplevel
     def _init_function(self, name):
-        from astroid.nodes.node_classes import Arguments
-        from astroid.nodes.scoped_nodes import FunctionDef
-
-        args = Arguments()
+        args = nodes.Arguments()
         args.postinit(
             args=[],
             defaults=[],
@@ -798,18 +806,16 @@ class PropertyModel(ObjectModel):
             kwonlyargs_annotations=[],
         )
 
-        function = FunctionDef(name=name, parent=self._instance)
+        function = nodes.FunctionDef(name=name, parent=self._instance)
 
         function.postinit(args=args, body=[])
         return function
 
     @property
     def attr_fget(self):
-        from astroid.nodes.scoped_nodes import FunctionDef
-
         func = self._instance
 
-        class PropertyFuncAccessor(FunctionDef):
+        class PropertyFuncAccessor(nodes.FunctionDef):
             def infer_call_result(self, caller=None, context=None):
                 nonlocal func
                 if caller and len(caller.args) != 1:
@@ -827,8 +833,6 @@ class PropertyModel(ObjectModel):
 
     @property
     def attr_fset(self):
-        from astroid.nodes.scoped_nodes import FunctionDef
-
         func = self._instance
 
         def find_setter(func: Property) -> astroid.FunctionDef | None:
@@ -852,7 +856,7 @@ class PropertyModel(ObjectModel):
                 f"Unable to find the setter of property {func.function.name}"
             )
 
-        class PropertyFuncAccessor(FunctionDef):
+        class PropertyFuncAccessor(nodes.FunctionDef):
             def infer_call_result(self, caller=None, context=None):
                 nonlocal func_setter
                 if caller and len(caller.args) != 2:

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -31,7 +31,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import astroid
-from astroid import util
+from astroid import nodes, util
 from astroid.context import InferenceContext, copy_context
 from astroid.exceptions import AttributeInferenceError, InferenceError, NoDefault
 from astroid.manager import AstroidManager
@@ -130,6 +130,10 @@ class ObjectModel:
             return self._instance._proxied.instantiate_class()
         except AttributeError:
             return self._instance.instantiate_class()
+
+    @property
+    def attr___init__(self) -> nodes.Const:
+        return nodes.Const(None)
 
 
 class ModuleModel(ObjectModel):
@@ -409,7 +413,6 @@ class FunctionModel(ObjectModel):
     attr___delattr___ = attr___ne__
     attr___getattribute__ = attr___ne__
     attr___hash__ = attr___ne__
-    attr___init__ = attr___ne__
     attr___dir__ = attr___ne__
     attr___call__ = attr___ne__
     attr___class__ = attr___ne__

--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -253,6 +253,27 @@ class ModuleModelTest(unittest.TestCase):
         xml.__cached__ #@
         xml.__package__ #@
         xml.__dict__ #@
+        xml.__init__ #@
+        xml.__new__ #@
+
+        xml.__subclasshook__ #@
+        xml.__str__ #@
+        xml.__sizeof__ #@
+        xml.__repr__ #@
+        xml.__reduce__ #@
+
+        xml.__setattr__ #@
+        xml.__reduce_ex__ #@
+        xml.__lt__ #@
+        xml.__eq__ #@
+        xml.__gt__ #@
+        xml.__format__ #@
+        xml.__delattr___ #@
+        xml.__getattribute__ #@
+        xml.__hash__ #@
+        xml.__dir__ #@
+        xml.__call__ #@
+        xml.__closure__ #@
         """
         )
         assert isinstance(ast_nodes, list)
@@ -283,6 +304,20 @@ class ModuleModelTest(unittest.TestCase):
 
         dict_ = next(ast_nodes[8].infer())
         self.assertIsInstance(dict_, astroid.Dict)
+
+        init_ = next(ast_nodes[9].infer())
+        assert isinstance(init_, nodes.Const)
+        assert init_.value is None
+
+        new_ = next(ast_nodes[10].infer())
+        assert isinstance(new_, nodes.Module)
+        assert new_.name == "xml"
+
+        # The following nodes are just here for theoretical completeness,
+        # and they either return Uninferable or raise InferenceError.
+        for ast_node in ast_nodes[11:28]:
+            with pytest.raises(InferenceError):
+                next(ast_node.infer())
 
 
 class FunctionModelTest(unittest.TestCase):
@@ -394,6 +429,27 @@ class FunctionModelTest(unittest.TestCase):
         func.__globals__ #@
         func.__code__ #@
         func.__closure__ #@
+        func.__init__ #@
+        func.__new__ #@
+
+        func.__subclasshook__ #@
+        func.__str__ #@
+        func.__sizeof__ #@
+        func.__repr__ #@
+        func.__reduce__ #@
+
+        func.__reduce_ex__ #@
+        func.__lt__ #@
+        func.__eq__ #@
+        func.__gt__ #@
+        func.__format__ #@
+        func.__delattr___ #@
+        func.__getattribute__ #@
+        func.__hash__ #@
+        func.__dir__ #@
+        func.__class__ #@
+
+        func.__setattr__ #@
         ''',
             module_name="fake_module",
         )
@@ -426,6 +482,24 @@ class FunctionModelTest(unittest.TestCase):
 
         for ast_node in ast_nodes[7:9]:
             self.assertIs(next(ast_node.infer()), astroid.Uninferable)
+
+        init_ = next(ast_nodes[9].infer())
+        assert isinstance(init_, nodes.Const)
+        assert init_.value is None
+
+        new_ = next(ast_nodes[10].infer())
+        assert isinstance(new_, nodes.FunctionDef)
+        assert new_.name == "func"
+
+        # The following nodes are just here for theoretical completeness,
+        # and they either return Uninferable or raise InferenceError.
+        for ast_node in ast_nodes[11:26]:
+            inferred = next(ast_node.infer())
+            assert inferred is util.Uninferable
+
+        for ast_node in ast_nodes[26:27]:
+            with pytest.raises(InferenceError):
+                inferred = next(ast_node.infer())
 
     def test_empty_return_annotation(self) -> None:
         ast_node = builder.extract_node(

--- a/tests/unittest_objects.py
+++ b/tests/unittest_objects.py
@@ -568,6 +568,26 @@ class SuperTests(unittest.TestCase):
             isinstance(i, (nodes.NodeNG, type(util.Uninferable))) for i in inferred
         )
 
+    def test_super_init_call(self) -> None:
+        """Test that __init__ is still callable."""
+        init_node: nodes.Attribute = builder.extract_node(
+            """
+        class SuperUsingClass:
+            @staticmethod
+            def test():
+                super(object, 1).__new__ #@
+                super(object, 1).__init__ #@
+        class A:
+            pass
+        A().__new__ #@
+        A().__init__ #@
+        """
+        )
+        assert isinstance(next(init_node[0].infer()), bases.BoundMethod)
+        assert isinstance(next(init_node[1].infer()), bases.BoundMethod)
+        assert isinstance(next(init_node[2].infer()), bases.BoundMethod)
+        assert isinstance(next(init_node[3].infer()), bases.BoundMethod)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Steps

- [x] Write a good description on what the PR does.

## Description

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Related Issue

Blocked by https://github.com/PyCQA/astroid/pull/1686
Precedes https://github.com/PyCQA/astroid/pull/1519

@jacobtylerwalls Please only consider the last commit. This is the next step in "completing" our `ObjectModel`. Since all objects have an `__init__` that normally returns `None` we can define ``attr___init__`` on ``ObjectModel``.