### PR TITLE
Fix a crash involving properties within `if` blocks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ What's New in astroid 2.12.1?
 =============================
 Release date: TBA
 
+* Fix a crash involving properties within ``if`` blocks.
 
 
 What's New in astroid 2.12.0?

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -1153,7 +1153,7 @@ def infer_functiondef(
         isinstance(val, objects.Property) for val in parent_frame.locals[self.name]
     )
     # We also don't want to pass parent if the definition is within a Try node
-    if isinstance(self.parent, (nodes.TryExcept, nodes.TryFinally)):
+    if isinstance(self.parent, (nodes.TryExcept, nodes.TryFinally, nodes.If)):
         property_already_in_parent_locals = True
 
     prop_func = objects.Property(

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2459,6 +2459,26 @@ def test_property_in_body_of_try() -> None:
     next(node.value.infer())
 
 
+def test_property_in_body_of_if() -> None:
+    node: nodes.Return = builder._extract_single_node(
+        """
+    def myfunc():
+        if True:
+
+            @property
+            def myfunc():
+                return None
+
+        @myfunc.setter
+        def myfunc():
+            pass
+
+        return myfunc() #@
+    """
+    )
+    next(node.value.infer())
+
+
 def test_issue940_enums_as_a_real_world_usecase() -> None:
     node = builder.extract_node(
         """


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Extend fix from #1690 to `if` blocks. Revealed in pylint stdlib primer, see https://github.com/PyCQA/pylint/runs/7265941894?check_suite_focus=true
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

