### PR TITLE
Fix a crash when `None` participates in a `**` expression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ What's New in astroid 2.12.1?
 =============================
 Release date: TBA
 
+* Fix a crash when ``None`` (or a value inferred as ``None``) participates in a
+  ``**`` expression.
 
 
 What's New in astroid 2.12.0?

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -121,6 +121,8 @@ def const_infer_binary_op(self, opnode, operator, other, context, _):
         if (
             operator == "**"
             and isinstance(self, nodes.Const)
+            and isinstance(self.value, (int, float))
+            and isinstance(other.value, (int, float))
             and (self.value > 1e5 or other.value > 1e5)
         ):
             yield not_implemented

--- a/tests/unittest_protocols.py
+++ b/tests/unittest_protocols.py
@@ -275,6 +275,10 @@ class ProtocolTests(unittest.TestCase):
         parsed = extract_node("15 ** 20220609")
         assert parsed.inferred() == [Uninferable]
 
+        # Test a pathological case (more realistic: None as naive inference result)
+        parsed = extract_node("None ** 2")
+        assert parsed.inferred() == [Uninferable]
+
 
 @pytest.mark.skipif(not PY38_PLUS, reason="needs assignment expressions")
 def test_named_expr_inference() -> None:


### PR DESCRIPTION


## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Fixes regression in #1610

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
See primer failure in https://github.com/PyCQA/pylint/runs/7265941894?check_suite_focus=true
