### PR TITLE
Fix a crash when inferring old-style string formatting (`%`) using tuples

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ What's New in astroid 2.12.1?
 =============================
 Release date: TBA
 
+* Fix a crash when inferring old-style string formatting (``%``) using tuples.
 
 
 What's New in astroid 2.12.0?

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -626,6 +626,8 @@ def _infer_old_style_string_formatting(
     """
     values = None
     if isinstance(other, nodes.Tuple):
+        if util.Uninferable in other.elts:
+            return (util.Uninferable,)
         inferred_positional = [helpers.safe_infer(i, context) for i in other.elts]
         if all(isinstance(i, nodes.Const) for i in inferred_positional):
             values = tuple(i.value for i in inferred_positional)

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6945,6 +6945,9 @@ class TestOldStyleStringFormatting:
             age = 12
             "My name is %0s, I'm %(age)s" % (fname, age)
             """,
+            """
+            "My name is %s, I'm %s" % ((fname,)*2)
+            """,
         ],
     )
     def test_old_style_string_formatting_uninferable(self, format_string: str) -> None:


### PR DESCRIPTION

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Fix a crash when something in a tuple is already Uninferable by the time we try to infer the result of a `%` (old-style) string formatting call that uses it.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Regression in #1617 
See pylint primer failure: https://github.com/PyCQA/pylint/runs/7265941894?check_suite_focus=true
