### PR TITLE
Prevent applying boolean ops to `NotImplemented`

### DIFF
--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -78,12 +78,15 @@ _UNARY_OPERATORS: dict[str, Callable[[Any], Any]] = {
 
 
 def _infer_unary_op(obj: Any, op: str) -> ConstFactoryResult:
-    """Perform unary operation on object.
+    """Perform unary operation on `object`, unless it is `NotImplemented`.
 
     Can raise TypeError if operation is unsupported.
     """
-    func = _UNARY_OPERATORS[op]
-    value = func(obj)
+    if obj is NotImplemented:
+        value = obj
+    else:
+        func = _UNARY_OPERATORS[op]
+        value = func(obj)
     return nodes.const_factory(value)
 
 

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -78,7 +78,7 @@ _UNARY_OPERATORS: dict[str, Callable[[Any], Any]] = {
 
 
 def _infer_unary_op(obj: Any, op: str) -> ConstFactoryResult:
-    """Perform unary operation on `object`, unless it is `NotImplemented`.
+    """Perform unary operation on `obj`, unless it is `NotImplemented`.
 
     Can raise TypeError if operation is unsupported.
     """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1117,6 +1117,12 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         first = next(ast_node.infer())
         self.assertEqual(first, util.Uninferable)
 
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    def test_binary_op_not_used_in_boolean_context(self) -> None:
+        ast_node = extract_node("not NotImplemented")
+        first = next(ast_node.infer())
+        self.assertIsInstance(first, nodes.Const)
+
     def test_binary_op_list_mul(self) -> None:
         for code in ("a = [[]] * 2", "a = 2 * [[]]"):
             ast = builder.string_build(code, __name__, __file__)


### PR DESCRIPTION
## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Prevents this DeprecationWarning:

```DeprecationWarning: NotImplemented should not be used in a boolean context```

Reproducer:
``` python -Werror -m pylint ipaddress```
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

