### PR TITLE
Fix crash in `ExplicitNamespacePackageFinder`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,11 +12,9 @@ What's New in astroid 2.12.3?
 =============================
 Release date: TBA
 
-
-* Fixed crash in ``ExplicitNamespacePackageFinder``.
+* Fixed crash in ``ExplicitNamespacePackageFinder`` involving ``_SixMetaPathImporter``.
 
   Closes #1708
-
 
 * Fix unhandled `FutureWarning` from pandas import in cython modules
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,6 @@ Release date: TBA
 
   Closes #1717
 
-
 What's New in astroid 2.12.2?
 =============================
 Release date: 2022-07-12

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.12.3?
 =============================
 Release date: TBA
 
+* Fixed crash in ``ExplicitNamespacePackageFinder``.
+
+  Closes #1708
+
 
 What's New in astroid 2.12.2?
 =============================

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -201,12 +201,7 @@ class ExplicitNamespacePackageFinder(ImportlibFinder):
         if processed:
             modname = ".".join(processed + [modname])
         if util.is_namespace(modname) and modname in sys.modules:
-            try:
-                submodule_path = sys.modules[modname].__path__
-            except AttributeError:
-                submodule_path = sys.modules[
-                    modname
-                ].__spec__.submodule_search_locations
+            submodule_path = sys.modules[modname].__path__
             return ModuleSpec(
                 name=modname,
                 location="",

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -201,7 +201,12 @@ class ExplicitNamespacePackageFinder(ImportlibFinder):
         if processed:
             modname = ".".join(processed + [modname])
         if util.is_namespace(modname) and modname in sys.modules:
-            submodule_path = sys.modules[modname].__path__
+            try:
+                submodule_path = sys.modules[modname].__path__
+            except AttributeError:
+                submodule_path = sys.modules[
+                    modname
+                ].__spec__.submodule_search_locations
             return ModuleSpec(
                 name=modname,
                 location="",

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -72,7 +72,8 @@ def is_namespace(modname: str) -> bool:
         if found_spec and found_spec.submodule_search_locations:
             last_submodule_search_locations = found_spec.submodule_search_locations
 
-    if found_spec is None:
-        return False
-
-    return found_spec.origin is None
+    return (
+        found_spec is not None
+        and found_spec.submodule_search_locations is not None
+        and found_spec.origin is None
+    )

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -7,3 +7,4 @@ PyQt6
 types-python-dateutil
 six
 types-six
+urllib3

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from xml import etree
 from xml.etree import ElementTree
 
+import pytest
 from pytest import CaptureFixture, LogCaptureFixture
 
 import astroid
@@ -24,6 +25,13 @@ from astroid import modutils
 from astroid.interpreter._import import spec
 
 from . import resources
+
+try:
+    import six  # pylint: disable=unused-import
+
+    HAS_SIX = True
+except ImportError:
+    HAS_SIX = False
 
 
 def _get_file_from_object(obj) -> str:
@@ -439,9 +447,10 @@ class ExtensionPackageWhitelistTest(unittest.TestCase):
         )
 
 
+@pytest.mark.skipif(not HAS_SIX, reason="This test requires six.")
 def test_file_info_from_modpath_namespace_package() -> None:
     assert (
-        modutils.file_info_from_modpath(["urllib3.packages.six.moves.http_client"]).type
+        modutils.file_info_from_modpath(["six.moves.http_client"]).type
         is spec.ModuleType.PY_NAMESPACE
     )
 

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -439,5 +439,12 @@ class ExtensionPackageWhitelistTest(unittest.TestCase):
         )
 
 
+def test_file_info_from_modpath_namespace_package() -> None:
+    assert (
+        modutils.file_info_from_modpath(["urllib3.packages.six.moves.http_client"]).type
+        is spec.ModuleType.PY_NAMESPACE
+    )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -448,10 +448,11 @@ class ExtensionPackageWhitelistTest(unittest.TestCase):
 
 
 @pytest.mark.skipif(not HAS_URLLIB3, reason="This test requires urllib3.")
-def test_file_info_from_modpath_namespace_package() -> None:
-    assert (
-        modutils.file_info_from_modpath(["urllib3.packages.six.moves.http_client"]).type
-        is spec.ModuleType.PY_NAMESPACE
+def test_file_info_from_modpath__SixMetaPathImporter() -> None:
+    pytest.raises(
+        ImportError,
+        modutils.file_info_from_modpath,
+        ["urllib3.packages.six.moves.http_client"],
     )
 
 

--- a/tests/unittest_modutils.py
+++ b/tests/unittest_modutils.py
@@ -27,11 +27,11 @@ from astroid.interpreter._import import spec
 from . import resources
 
 try:
-    import six  # pylint: disable=unused-import
+    import urllib3  # pylint: disable=unused-import
 
-    HAS_SIX = True
+    HAS_URLLIB3 = True
 except ImportError:
-    HAS_SIX = False
+    HAS_URLLIB3 = False
 
 
 def _get_file_from_object(obj) -> str:
@@ -447,10 +447,10 @@ class ExtensionPackageWhitelistTest(unittest.TestCase):
         )
 
 
-@pytest.mark.skipif(not HAS_SIX, reason="This test requires six.")
+@pytest.mark.skipif(not HAS_URLLIB3, reason="This test requires urllib3.")
 def test_file_info_from_modpath_namespace_package() -> None:
     assert (
-        modutils.file_info_from_modpath(["six.moves.http_client"]).type
+        modutils.file_info_from_modpath(["urllib3.packages.six.moves.http_client"]).type
         is spec.ModuleType.PY_NAMESPACE
     )
 


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Some weirdness with `_SixMetaPathImporter` demonstrated that `astroid.interpreter._import.util.is_namespace` needs to check the presence of `submodule_search_locations` before reporting something to be a namespace package.

## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
Closes #1708