### PR TITLE
Remove str instance in model of BaseException.attrs

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -672,10 +672,7 @@ class InstanceModel(ObjectModel):
 class ExceptionInstanceModel(InstanceModel):
     @property
     def attr_args(self):
-        message = node_classes.Const("")
-        args = node_classes.Tuple(parent=self._instance)
-        args.postinit((message,))
-        return args
+        return node_classes.Tuple(parent=self._instance)
 
     @property
     def attr___traceback__(self):


### PR DESCRIPTION
Do not require first exception argument to be a string. The word "usually" does not imply an obligation.
https://docs.python.org/3/library/exceptions.html#BaseException.args

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Refs: PyCQA/pylint#7233
