### PR TITLE
Infer instance from the result of call to __new__

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ What's New in astroid 2.13.0?
 =============================
 Release date: TBA
 
+* Infer resulting instance from call to the ``__new__`` method if class
+__definition provides any.
 
 
 What's New in astroid 2.12.3?

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2307,7 +2307,11 @@ class ClassDef(
             context.callcontext.callee = dunder_call
             yield from dunder_call.infer_call_result(caller, context)
         else:
-            yield self.instantiate_class()
+            dunder_new = next(self.igetattr("__new__", context), None)
+            if dunder_new and dunder_new.body:
+                yield from dunder_new.infer_call_result(caller, context)
+            else:
+                yield self.instantiate_class()
 
     def scope_lookup(self, node, name, offset=0):
         """Lookup where the given name is assigned.

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1518,6 +1518,17 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         self.assertIsInstance(inferred, Instance)
         self.assertEqual(inferred._proxied, node.root()["cls"])
 
+    def test_new_replacement(self) -> None:
+        node = extract_node("""
+            class Response: pass
+            class Chameleon:
+                def __new__(cls, arg):
+                    return Response()
+            Chameleon(42)
+        """, "test_mod")
+        inferred = next(node.infer())
+        assert inferred.pytype() == "test_mod.Response"
+
     def test_two_parents_from_same_module(self) -> None:
         code = """
             from data import nonregr


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
In Python, parentheses over class type implicitly invoke the `__new__` method. The method may override instance of the class. If the case is relatively simple so astroid is able to infer the actual class, give it a try.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Refs: PyCQA/pylint#7258