### PR TITLE
Incompatible variable type fixed

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -930,7 +930,7 @@ def _infer_str_format_call(
     """Return a Const node based on the template and passed arguments."""
     call = arguments.CallSite.from_call(node, context=context)
     if isinstance(node.func.expr, nodes.Name):
-        value: nodes.Const = helpers.safe_infer(node.func.expr)
+        value = helpers.safe_infer(node.func.expr)
     else:
         value = node.func.expr
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Pyre warning

**"filename"**: "astroid/brain/brain_builtin_inference.py"
**"warning_type"**: "Incompatible variable type [9]",
**"warning_message"**: " value is declared to have type `nodes.node_classes.Const` but is used as type `typing.Union[None, typing.Type[util.Uninferable], astroid.bases.Proxy, nodes.node_ng.NodeNG]`.",
**"warning_line"**: 933
**"fix"**: remove nodes.Const
