### PR TITLE
Fix a crash inferring invalid string formatting with `%`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#7265
 
+* Fix a crash inferring invalid old-style string formatting with `%`.
+
+  Closes #1737
+
 What's New in astroid 2.12.2?
 =============================
 Release date: 2022-07-12

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -648,7 +648,7 @@ def _infer_old_style_string_formatting(
 
     try:
         return (nodes.const_factory(instance.value % values),)
-    except (TypeError, KeyError):
+    except (TypeError, KeyError, ValueError):
         return (util.Uninferable,)
 
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6955,6 +6955,7 @@ class TestOldStyleStringFormatting:
             "My name is %s, I'm %s" % ((fname,)*2)
             """,
             """20 % 0""",
+            """("%" + str(20)) % 0""",
         ],
     )
     def test_old_style_string_formatting_uninferable(self, format_string: str) -> None:


### PR DESCRIPTION
## Description
Fix a crash inferring invalid string formatting with `%`.

## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #1737

