### PR TITLE
Fix false positive with inference of `http` module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,10 @@ Release date: TBA
 
   Closes #1737
 
+* Fix false positive with inference of `http` module when iterating `HTTPStatus`.
+
+  Refs PyCQA/pylint#7307
+
 What's New in astroid 2.12.2?
 =============================
 Release date: 2022-07-12

--- a/ChangeLog
+++ b/ChangeLog
@@ -28,7 +28,7 @@ Release date: TBA
 
   Closes #1737
 
-* Fix false positive with inference of `http` module when iterating `HTTPStatus`.
+* Fix false positive with inference of ``http`` module when iterating ``HTTPStatus``.
 
   Refs PyCQA/pylint#7307
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,7 @@ Release date: TBA
 * Fix false positive with inference of ``http`` module when iterating ``HTTPStatus``.
 
   Refs PyCQA/pylint#7307
+
 * Bumped minimum requirement of ``wrapt`` to 1.14 on Python 3.11.
 
 * Don't add dataclass fields annotated with ``KW_ONLY`` to the list of fields.

--- a/astroid/brain/brain_http.py
+++ b/astroid/brain/brain_http.py
@@ -13,10 +13,11 @@ from astroid.manager import AstroidManager
 def _http_transform():
     code = textwrap.dedent(
         """
+    from enum import IntEnum
     from collections import namedtuple
     _HTTPStatus = namedtuple('_HTTPStatus', 'value phrase description')
 
-    class HTTPStatus:
+    class HTTPStatus(IntEnum):
 
         @property
         def phrase(self):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -3143,7 +3143,7 @@ def test_http_status_brain() -> None:
     )
     inferred = next(node.infer())
     # Cannot infer the exact value but the field is there.
-    assert inferred is util.Uninferable
+    assert inferred.value == ""
 
     node = astroid.extract_node(
         """
@@ -3153,6 +3153,19 @@ def test_http_status_brain() -> None:
     )
     inferred = next(node.infer())
     assert isinstance(inferred, astroid.Const)
+
+
+def test_http_status_brain_iterable() -> None:
+    """Astroid inference of `http.HTTPStatus` is an iterable subclass of `enum.IntEnum`"""
+    node = astroid.extract_node(
+        """
+    import http
+    http.HTTPStatus
+    """
+    )
+    inferred = next(node.infer())
+    assert "enum.IntEnum" in [ancestor.qname() for ancestor in inferred.ancestors()]
+    assert inferred.getattr("__iter__")
 
 
 def test_oserror_model() -> None:


### PR DESCRIPTION
Fix false positive with inference of `http` module when iterating `HTTPStatus`.

The [Python source code for HTTPStatus](https://github.com/python/cpython/blob/main/Lib/http/__init__.py) inherits from IntEnum which is iterable.

Closes PyCQA/pylint#7307

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
