### PR TITLE
Fix crash with inference of type-annotated Enum classes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ Release date: TBA
 
   Refs PyCQA/pylint#7265
 
+* Fix crash with inference of type-annotated Enum classes where the member has no value.
+
 * Fix a crash inferring invalid old-style string formatting with `%`.
 
   Closes #1737

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -379,7 +379,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 continue
 
             inferred_return_value = None
-            if isinstance(stmt, (nodes.AnnAssign, nodes.Assign)) and stmt.value:
+            if stmt.value is not None:
                 if isinstance(stmt.value, nodes.Const):
                     if isinstance(stmt.value.value, str):
                         inferred_return_value = repr(stmt.value.value)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -379,7 +379,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 continue
 
             inferred_return_value = None
-            if isinstance(stmt, (nodes.AnnAssign, nodes.Assign)):
+            if isinstance(stmt, (nodes.AnnAssign, nodes.Assign)) and stmt.value:
                 if isinstance(stmt.value, nodes.Const):
                     if isinstance(stmt.value.value, str):
                         inferred_return_value = repr(stmt.value.value)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -379,7 +379,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 continue
 
             inferred_return_value = None
-            if isinstance(stmt, (nodes.AnnAssign, nodes.Assign)):
+            if isinstance(stmt, nodes.Assign) or isinstance(stmt, nodes.AnnAssign) and stmt.value:
                 if isinstance(stmt.value, nodes.Const):
                     if isinstance(stmt.value.value, str):
                         inferred_return_value = repr(stmt.value.value)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -379,7 +379,11 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 continue
 
             inferred_return_value = None
-            if isinstance(stmt, nodes.Assign) or isinstance(stmt, nodes.AnnAssign) and stmt.value:
+            if (
+                isinstance(stmt, nodes.Assign)
+                or isinstance(stmt, nodes.AnnAssign)
+                and stmt.value
+            ):
                 if isinstance(stmt.value, nodes.Const):
                     if isinstance(stmt.value.value, str):
                         inferred_return_value = repr(stmt.value.value)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -380,7 +380,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
 
             inferred_return_value = None
             if isinstance(stmt, (nodes.AnnAssign, nodes.Assign)):
-                if stmt.value and isinstance(stmt.value, nodes.Const):
+                if isinstance(stmt.value, nodes.Const):
                     if isinstance(stmt.value.value, str):
                         inferred_return_value = repr(stmt.value.value)
                     else:

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -379,12 +379,8 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
                 continue
 
             inferred_return_value = None
-            if (
-                isinstance(stmt, nodes.Assign)
-                or isinstance(stmt, nodes.AnnAssign)
-                and stmt.value
-            ):
-                if isinstance(stmt.value, nodes.Const):
+            if isinstance(stmt, (nodes.AnnAssign, nodes.Assign)):
+                if stmt.value and isinstance(stmt.value, nodes.Const):
                     if isinstance(stmt.value.value, str):
                         inferred_return_value = repr(stmt.value.value)
                     else:

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2525,7 +2525,7 @@ def test_enums_type_annotation_no_value(annotation) -> None:
         """
     from enum import Enum
     class Veg(Enum):
-        TOMATO: {annotation} 
+        TOMATO: {annotation}
 
     Veg.TOMATO.value
     """

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -2515,6 +2515,25 @@ def test_enums_type_annotation_str_member() -> None:
     assert inferred_member_value.value == "sweet"
 
 
+@pytest.mark.parametrize("annotation", ["bool", "dict", "int", "str"])
+def test_enums_type_annotation_no_value(annotation) -> None:
+    """A type-annotated member of an Enum class which has no value where:
+    - `member.value.value` is `None`
+    is not inferred
+    """
+    node = builder.extract_node(
+        """
+    from enum import Enum
+    class Veg(Enum):
+        TOMATO: {annotation} 
+
+    Veg.TOMATO.value
+    """
+    )
+    inferred_member_value = node.inferred()[0]
+    assert inferred_member_value.value is None
+
+
 @pytest.mark.parametrize("annotation, value", [("int", 42), ("bytes", b"")])
 def test_enums_type_annotation_non_str_member(annotation, value) -> None:
     """A type-annotated member of an Enum class where:


### PR DESCRIPTION
Fix crash with inference of type-annotated Enum classes where the member has no value.

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
