### PR TITLE
Don't add ``KW_ONLY`` fields to dataclass fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,10 @@ Release date: TBA
 
   Closes #1737
 
+* Don't add dataclass fields annotated with ``KW_ONLY`` to the list of fields.
+
+  Refs PyCQA/pylint#5767
+
 What's New in astroid 2.12.2?
 =============================
 Release date: 2022-07-12

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -19,9 +19,9 @@ import sys
 from collections.abc import Generator
 from typing import Tuple, Union
 
-from astroid import bases, context, inference_tip
+from astroid import bases, context, helpers, inference_tip
 from astroid.builder import parse
-from astroid.const import PY39_PLUS
+from astroid.const import PY39_PLUS, PY310_PLUS
 from astroid.exceptions import (
     AstroidSyntaxError,
     InferenceError,
@@ -409,10 +409,12 @@ def _is_class_var(node: NodeNG) -> bool:
 
 def _is_keyword_only_sentinel(node: NodeNG) -> bool:
     """Return True if node is the KW_ONLY sentinel."""
-    return any(
+    if not PY310_PLUS:
+        return False
+    inferred = helpers.safe_infer(node)
+    return (
         isinstance(inferred, bases.Instance)
         and inferred.qname() == "dataclasses._KW_ONLY_TYPE"
-        for inferred in node.infer()
     )
 
 

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -19,7 +19,7 @@ import sys
 from collections.abc import Generator
 from typing import Tuple, Union
 
-from astroid import context, inference_tip
+from astroid import bases, context, inference_tip
 from astroid.builder import parse
 from astroid.const import PY39_PLUS
 from astroid.exceptions import (
@@ -133,6 +133,9 @@ def _get_dataclass_attributes(node: ClassDef, init: bool = False) -> Generator:
             continue
 
         if _is_class_var(assign_node.annotation):  # type: ignore[arg-type] # annotation is never None
+            continue
+
+        if _is_keyword_only_sentinel(assign_node.annotation):
             continue
 
         if init:
@@ -401,6 +404,15 @@ def _is_class_var(node: NodeNG) -> bool:
         and node.value.name == "ClassVar"
         or isinstance(node.value, Attribute)
         and node.value.attrname == "ClassVar"
+    )
+
+
+def _is_keyword_only_sentinel(node: NodeNG) -> bool:
+    """Return True if node is the KW_ONLY sentinel."""
+    return any(
+        isinstance(inferred, bases.Instance)
+        and inferred.qname() == "dataclasses._KW_ONLY_TYPE"
+        for inferred in node.infer()
     )
 
 

--- a/tests/unittest_brain_dataclasses.py
+++ b/tests/unittest_brain_dataclasses.py
@@ -6,6 +6,7 @@ import pytest
 
 import astroid
 from astroid import bases, nodes
+from astroid.const import PY310_PLUS
 from astroid.exceptions import InferenceError
 from astroid.util import Uninferable
 
@@ -737,8 +738,12 @@ def test_kw_only_sentinel() -> None:
     B.__init__  #@
     """
     )
+    if PY310_PLUS:
+        expected = ["self", "y"]
+    else:
+        expected = ["self", "_", "y"]
     init = next(node_one.infer())
-    assert [a.name for a in init.args.args] == ["self", "y"]
+    assert [a.name for a in init.args.args] == expected
 
     init = next(node_two.infer())
-    assert [a.name for a in init.args.args] == ["self", "y"]
+    assert [a.name for a in init.args.args] == expected


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Refs. https://github.com/PyCQA/pylint/issues/5767

/CC @jacobtylerwalls 

How should we deal with this. 

```python
import dataclasses


@dataclasses.dataclass
class A:
    _: dataclasses.KW_ONLY
    data: str


print(A.__dataclass_fields__)
```

Returns:
```python
❯ python test.py
{'data': Field(name='data',type=<class 'str'>,default=<dataclasses._MISSING_TYPE object at 0x107b04c50>,default_factory=<dataclasses._MISSING_TYPE object at 0x107b04c50>,init=True,repr=True,hash=None,compare=True,metadata=mappingproxy({}),kw_only=True,_field_type=_FIELD)}
```

But on < 3.10 `KW_ONLY` doesn't exist so this will crash. How should we deal with that? We can't infer `KW_ONLY` and thus don't know if it should be added to the fields.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
