### PR TITLE
Remove str instance in model of BaseException.attrs

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -672,10 +672,7 @@ class InstanceModel(ObjectModel):
 class ExceptionInstanceModel(InstanceModel):
     @property
     def attr_args(self):
-        message = node_classes.Const("")
-        args = node_classes.Tuple(parent=self._instance)
-        args.postinit((message,))
-        return args
+        return node_classes.Tuple(parent=self._instance)
 
     @property
     def attr___traceback__(self):

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -671,8 +671,8 @@ class InstanceModel(ObjectModel):
 
 class ExceptionInstanceModel(InstanceModel):
     @property
-    def attr_args(self):
-        return node_classes.Tuple(parent=self._instance)
+    def attr_args(self) -> nodes.Tuple:
+        return nodes.Tuple(parent=self._instance)
 
     @property
     def attr___traceback__(self):

--- a/tests/unittest_object_model.py
+++ b/tests/unittest_object_model.py
@@ -748,6 +748,21 @@ class DictObjectModelTest(unittest.TestCase):
         self.assertIsInstance(items, objects.DictItems)
 
 
+class TestExceptionInstanceModel:
+    """Tests for ExceptionInstanceModel."""
+
+    def test_str_argument_not_required(self) -> None:
+        """Test that the first argument to an exception does not need to be a str."""
+        ast_node = builder.extract_node(
+            """
+        BaseException() #@
+        """
+        )
+        args: nodes.Tuple = next(ast_node.infer()).getattr("args")[0]
+        # BaseException doesn't have any required args, not even a string
+        assert not args.elts
+
+
 class LruCacheModelTest(unittest.TestCase):
     def test_lru_cache(self) -> None:
         ast_nodes = builder.extract_node(


### PR DESCRIPTION
Supersedes #1722 as I didn't have commit rights on the branch.

Original post:

Do not require first exception argument to be a string. The word "usually" does not imply an obligation.
https://docs.python.org/3/library/exceptions.html#BaseException.args

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Refs: PyCQA/pylint#7233
