### PR TITLE
Prevent first-party imports from being resolved to `site-packages`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@ What's New in astroid 2.12.5?
 =============================
 Release date: TBA
 
+* Prevent first-party imports from being resolved to `site-packages`.
+
+  Refs PyCQA/pylint#7365
 
 
 What's New in astroid 2.12.4?

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -13,6 +13,8 @@ from importlib.util import _find_spec_from_path  # type: ignore[attr-defined]
 
 @lru_cache(maxsize=4096)
 def is_namespace(modname: str) -> bool:
+    from astroid.modutils import EXT_LIB_DIRS  # pylint: disable=import-outside-toplevel
+
     if modname in sys.builtin_module_names:
         return False
 
@@ -70,6 +72,11 @@ def is_namespace(modname: str) -> bool:
 
         # Update last_submodule_search_locations
         if found_spec and found_spec.submodule_search_locations:
+            if any(
+                location in EXT_LIB_DIRS
+                for location in found_spec.submodule_search_locations
+            ):
+                return False
             last_submodule_search_locations = found_spec.submodule_search_locations
 
     return (

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -15,7 +15,12 @@ from astroid.const import IS_PYPY
 
 @lru_cache(maxsize=4096)
 def is_namespace(modname: str) -> bool:
-    from astroid.modutils import EXT_LIB_DIRS  # pylint: disable=import-outside-toplevel
+    from astroid.modutils import (  # pylint: disable=import-outside-toplevel
+        EXT_LIB_DIRS,
+        STD_LIB_DIRS,
+    )
+
+    STD_AND_EXT_LIB_DIRS = STD_LIB_DIRS.union(EXT_LIB_DIRS)
 
     if modname in sys.builtin_module_names:
         return False
@@ -75,7 +80,7 @@ def is_namespace(modname: str) -> bool:
         # Update last_submodule_search_locations
         if found_spec and found_spec.submodule_search_locations:
             if any(
-                location in EXT_LIB_DIRS
+                any(location.startswith(lib_dir) for lib_dir in STD_AND_EXT_LIB_DIRS)
                 for location in found_spec.submodule_search_locations
             ):
                 return False

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -77,8 +77,10 @@ def is_namespace(modname: str) -> bool:
                 last_submodule_search_locations.append(str(assumed_location))
             continue
 
-        # Update last_submodule_search_locations
+        # Update last_submodule_search_locations for next iteration
         if found_spec and found_spec.submodule_search_locations:
+            # But immediately return False if we can detect we are in stdlib
+            # or external lib (e.g site-packages)
             if any(
                 any(location.startswith(lib_dir) for lib_dir in STD_AND_EXT_LIB_DIRS)
                 for location in found_spec.submodule_search_locations

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -129,11 +129,13 @@ class AstroidManagerTest(
 
     def test_module_is_not_namespace(self) -> None:
         def debug_result():
+            import sysconfig
             from importlib.util import _find_spec_from_path
 
             tested = list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1]
             spec = _find_spec_from_path(tested)
             return (
+                f"SYCONFIG PATHS: {sysconfig.get_paths()}\n"
                 f"EXT_LIB_DIRS: {EXT_LIB_DIRS}\n"
                 f"TESTED: {tested}\n"
                 f"SPEC VARS: {vars(spec)}"

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -128,6 +128,7 @@ class AstroidManagerTest(
     def test_module_is_not_namespace(self) -> None:
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
+        self.assertFalse(util.is_namespace("site-packages"))
 
     def test_module_unexpectedly_missing_spec(self) -> None:
         astroid_module = sys.modules["astroid"]

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -131,7 +131,7 @@ class AstroidManagerTest(
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
         self.assertFalse(
-            util.is_namespace(list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[0])
+            util.is_namespace(list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1])
         )
         self.assertFalse(util.is_namespace("importlib._bootstrap"))
 

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -128,24 +128,10 @@ class AstroidManagerTest(
         )
 
     def test_module_is_not_namespace(self) -> None:
-        def debug_result():
-            import sysconfig
-            from importlib.util import _find_spec_from_path
-
-            tested = list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1]
-            spec = _find_spec_from_path(tested)
-            return (
-                f"SYCONFIG PATHS: {sysconfig.get_paths()}\n"
-                f"EXT_LIB_DIRS: {EXT_LIB_DIRS}\n"
-                f"TESTED: {tested}\n"
-                f"SPEC VARS: {vars(spec)}"
-            )
-
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
         self.assertFalse(
             util.is_namespace(list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1]),
-            debug_result(),
         )
         self.assertFalse(util.is_namespace("importlib._bootstrap"))
 

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -128,10 +128,22 @@ class AstroidManagerTest(
         )
 
     def test_module_is_not_namespace(self) -> None:
+        def debug_result():
+            from importlib.util import _find_spec_from_path
+
+            tested = list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1]
+            spec = _find_spec_from_path(tested)
+            return (
+                f"EXT_LIB_DIRS: {EXT_LIB_DIRS}\n"
+                f"TESTED: {tested}\n"
+                f"SPEC VARS: {vars(spec)}"
+            )
+
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
         self.assertFalse(
-            util.is_namespace(list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1])
+            util.is_namespace(list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[-1]),
+            debug_result(),
         )
         self.assertFalse(util.is_namespace("importlib._bootstrap"))
 

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -15,7 +15,7 @@ from astroid import manager, test_utils
 from astroid.const import IS_JYTHON
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import util
-from astroid.modutils import is_standard_module
+from astroid.modutils import EXT_LIB_DIRS, is_standard_module
 from astroid.nodes import Const
 from astroid.nodes.scoped_nodes import ClassDef
 
@@ -128,7 +128,9 @@ class AstroidManagerTest(
     def test_module_is_not_namespace(self) -> None:
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
-        self.assertFalse(util.is_namespace("site-packages"))
+        self.assertFalse(
+            util.is_namespace(list(EXT_LIB_DIRS)[0].rsplit("/", maxsplit=1)[0])
+        )
 
     def test_module_unexpectedly_missing_spec(self) -> None:
         astroid_module = sys.modules["astroid"]


### PR DESCRIPTION

## Description
Regression in 5067f08.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
Closes PyCQA/pylint#7365