### PR TITLE
Fix namespace package detection for frozen stdlib modules on PyPy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ What's New in astroid 2.12.5?
 =============================
 Release date: TBA
 
+* Fix ``astroid.interpreter._import.util.is_namespace()`` incorrectly
+  returning ``True`` for frozen stdlib modules on PyPy.
+
+  Closes #1755
 
 
 What's New in astroid 2.12.4?

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -10,6 +10,8 @@ from functools import lru_cache
 from importlib._bootstrap_external import _NamespacePath
 from importlib.util import _find_spec_from_path  # type: ignore[attr-defined]
 
+from astroid.const import IS_PYPY
+
 
 @lru_cache(maxsize=4096)
 def is_namespace(modname: str) -> bool:
@@ -38,7 +40,7 @@ def is_namespace(modname: str) -> bool:
                 return False
             try:
                 # .pth files will be on sys.modules
-                return sys.modules[modname].__spec__ is None
+                return sys.modules[modname].__spec__ is None and not IS_PYPY
             except KeyError:
                 return False
             except AttributeError:

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -10,9 +10,11 @@ import unittest
 from collections.abc import Iterator
 from contextlib import contextmanager
 
+import pytest
+
 import astroid
 from astroid import manager, test_utils
-from astroid.const import IS_JYTHON
+from astroid.const import IS_JYTHON, IS_PYPY
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import util
 from astroid.modutils import is_standard_module
@@ -156,6 +158,10 @@ class AstroidManagerTest(
             for _ in range(2):
                 sys.path.pop(0)
 
+    @pytest.mark.skipIf(
+        IS_PYPY,
+        reason="PyPy provides no way to tell apart frozen stdlib from old-style namespace packages",
+    )
     def test_namespace_package_pth_support(self) -> None:
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
         site.addpackage(resources.RESOURCE_PATH, pth, [])
@@ -170,6 +176,10 @@ class AstroidManagerTest(
         finally:
             sys.modules.pop("foogle")
 
+    @pytest.mark.skipIf(
+        IS_PYPY,
+        reason="PyPy provides no way to tell apart frozen stdlib from old-style namespace packages",
+    )
     def test_nested_namespace_import(self) -> None:
         pth = "foogle_fax-0.12.5-py2.7-nspkg.pth"
         site.addpackage(resources.RESOURCE_PATH, pth, [])

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -158,7 +158,7 @@ class AstroidManagerTest(
             for _ in range(2):
                 sys.path.pop(0)
 
-    @pytest.mark.skipIf(
+    @pytest.mark.skipif(
         IS_PYPY,
         reason="PyPy provides no way to tell apart frozen stdlib from old-style namespace packages",
     )
@@ -176,7 +176,7 @@ class AstroidManagerTest(
         finally:
             sys.modules.pop("foogle")
 
-    @pytest.mark.skipIf(
+    @pytest.mark.skipif(
         IS_PYPY,
         reason="PyPy provides no way to tell apart frozen stdlib from old-style namespace packages",
     )

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -128,6 +128,7 @@ class AstroidManagerTest(
     def test_module_is_not_namespace(self) -> None:
         self.assertFalse(util.is_namespace("tests.testdata.python3.data.all"))
         self.assertFalse(util.is_namespace("__main__"))
+        self.assertFalse(util.is_namespace("importlib._bootstrap"))
 
     def test_module_unexpectedly_missing_spec(self) -> None:
         astroid_module = sys.modules["astroid"]


### PR DESCRIPTION

## Description
PyPy doesn't bother to set `__spec__` on some frozen stdlib modules like `importlib._bootstrap`. We were using the lack of `__spec__` as a heuristic for old-style namespace packages with `pkg_resources`. That assumption breaks given PyPy's behavior.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Fixes #1755
