### PR TITLE
Fix a crash involving `Uninferable` args to `namedtuple`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,9 @@ What's New in astroid 2.12.6?
 =============================
 Release date: TBA
 
+* Fix a crash involving ``Uninferable`` arguments to ``namedtuple()``.
 
+  Closes PyCQA/pylint#7375
 
 
 What's New in astroid 2.12.5?

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -538,7 +538,13 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
     extract a node from them later on.
     """
     names = []
-    for elt in next(node.args[1].infer()).elts:
+    try:
+        container = next(node.args[1].infer())
+    except (InferenceError, StopIteration) as exc:
+        raise UseInferenceDefault from exc
+    if container is astroid.Uninferable:
+        raise UseInferenceDefault
+    for elt in container.elts:
         if isinstance(elt, nodes.Const):
             names.append(elt.as_string())
             continue

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -542,7 +542,7 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
         container = next(node.args[1].infer())
     except (InferenceError, StopIteration) as exc:
         raise UseInferenceDefault from exc
-    if container is astroid.Uninferable:
+    if not isinstance(container, nodes.BaseContainer):
         raise UseInferenceDefault
     for elt in container.elts:
         if isinstance(elt, nodes.Const):

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1650,7 +1650,7 @@ class TypingBrain(unittest.TestCase):
         call = nodes.Call(1)
         fs = FrozenSet()
         fs.elts = astroid.Uninferable
-        call.args = [nodes.Const('uninferable'), fs]
+        call.args = [nodes.Const("uninferable"), fs]
         with pytest.raises(UseInferenceDefault):
             _get_namedtuple_fields(call)
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -18,6 +18,7 @@ import pytest
 import astroid
 from astroid import MANAGER, bases, builder, nodes, objects, test_utils, util
 from astroid.bases import Instance
+from astroid.brain.brain_namedtuple_enum import _get_namedtuple_fields
 from astroid.const import PY39_PLUS
 from astroid.exceptions import (
     AttributeInferenceError,
@@ -26,6 +27,7 @@ from astroid.exceptions import (
 )
 from astroid.nodes.node_classes import Const
 from astroid.nodes.scoped_nodes import ClassDef
+from astroid.objects import FrozenSet
 
 try:
     import multiprocessing  # pylint: disable=unused-import
@@ -1643,6 +1645,14 @@ class TypingBrain(unittest.TestCase):
         """
         )
         next(node.infer())
+
+    def test_namedtuple_uninferable_member(self) -> None:
+        call = nodes.Call(1)
+        fs = FrozenSet()
+        fs.elts = astroid.Uninferable
+        call.args = [nodes.Const('uninferable'), fs]
+        with pytest.raises(UseInferenceDefault):
+            _get_namedtuple_fields(call)
 
     def test_typing_types(self) -> None:
         ast_nodes = builder.extract_node(


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
Previously, the namedtuple brain assumed that the second argument to `namedtuple()` would be a container, but it could be `Uninferable`. In the bug report, it was a [dict comprehension relying on a function argument](https://github.com/microsoft/nni/blob/5874c27fcdc68c185901181e32382dfa50215b11/nni/runtime/env_vars.py#L30).

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
Closes PyCQA/pylint#7375

Regression in 9531e037bba6dcd1edd0e4626883e54ce6e3b6da.