### PR TITLE
Fix a crash on ``namedtuples`` that use ``typename``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,8 +19,8 @@ Release date: TBA
 
 * Fixed a crash on ``namedtuples`` that use ``typename`` to specify their name.
 
-
   Closes PyCQA/pylint#7429
+
 
 What's New in astroid 2.12.8?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,9 @@ What's New in astroid 2.12.9?
 =============================
 Release date: TBA
 
+* Fixed a crash on ``namedtuples`` that use ``typename`` to specify their name.
 
+  Closes PyCQA/pylint#7429
 
 What's New in astroid 2.12.8?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@ Release date: TBA
 
 * Fixed a crash on ``namedtuples`` that use ``typename`` to specify their name.
 
+
   Closes PyCQA/pylint#7429
 
 What's New in astroid 2.12.8?

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -543,7 +543,7 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
         container = next(node.args[1].infer())
     except (InferenceError, StopIteration) as exc:
         raise UseInferenceDefault from exc
-    # We pass on IndexError as well try to infer 'field_names' from the keywords
+    # We pass on IndexError as we'll try to infer 'field_names' from the keywords
     except IndexError:
         pass
     if not container:

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -538,10 +538,22 @@ def _get_namedtuple_fields(node: nodes.Call) -> str:
     extract a node from them later on.
     """
     names = []
+    container = None
     try:
         container = next(node.args[1].infer())
     except (InferenceError, StopIteration) as exc:
         raise UseInferenceDefault from exc
+    # We pass on IndexError as well try to infer 'field_names' from the keywords
+    except IndexError:
+        pass
+    if not container:
+        for keyword_node in node.keywords:
+            if keyword_node.arg == "field_names":
+                try:
+                    container = next(keyword_node.value.infer())
+                except (InferenceError, StopIteration) as exc:
+                    raise UseInferenceDefault from exc
+                break
     if not isinstance(container, nodes.BaseContainer):
         raise UseInferenceDefault
     for elt in container.elts:

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -434,6 +434,23 @@ class NamedTupleTest(unittest.TestCase):
         inferred = next(node.infer())
         self.assertIs(util.Uninferable, inferred)
 
+    def test_name_as_typename(self) -> None:
+        """Reported in https://github.com/PyCQA/pylint/issues/7429 as a crash."""
+        good_node, good_node_two, bad_node = builder.extract_node(
+            """
+            import collections
+            collections.namedtuple(typename="MyTuple", field_names=["birth_date", "city"])  #@
+            collections.namedtuple("MyTuple", field_names=["birth_date", "city"])  #@
+            collections.namedtuple(["birth_date", "city"], typename="MyTuple")  #@
+        """
+        )
+        good_inferred = next(good_node.infer())
+        assert isinstance(good_inferred, nodes.ClassDef)
+        good_node_two_inferred = next(good_node_two.infer())
+        assert isinstance(good_node_two_inferred, nodes.ClassDef)
+        bad_node_inferred = next(bad_node.infer())
+        assert bad_node_inferred == util.Uninferable
+
 
 class DefaultDictTest(unittest.TestCase):
     def test_1(self) -> None:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Closes https://github.com/PyCQA/pylint/issues/7429

## Type of Changes


<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |



@Pierre-Sassoulas I couldn't get the inference failure path to cover, I think it is covered in another path.

Anyway I think it is good to have there, even if uncovered.