### PR TITLE
Fixed the ``__init__`` of ``dataclassess`` with multiple inheritance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ What's New in astroid 2.12.9?
 =============================
 Release date: TBA
 
+* Fixed creation of the ``__init__`` of ``dataclassess`` with multiple inheritance.
+
+  Closes PyCQA/pylint#7427
+
 * Fixed a crash on ``namedtuples`` that use ``typename`` to specify their name.
 
   Closes PyCQA/pylint#7429


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Closes PyCQA/pylint#7427

Refs. https://github.com/PyCQA/astroid/pull/1768 https://github.com/PyCQA/astroid/pull/1764 https://github.com/PyCQA/astroid/pull/1770

This list is getting long...

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


@Pierre-Sassoulas Our tests for `dataclasses` are getting so robust now 🎉 😅 