### PR TITLE
Stop detecting modules compiled by `cffi` as namespace packages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,10 @@ What's New in astroid 2.12.10?
 ==============================
 Release date: TBA
 
+* Fixed a crash when introspecting modules compiled by `cffi`.
+
+  Closes #1776
+  Closes PyCQA/pylint#7399
 
 
 What's New in astroid 2.12.9?

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -49,7 +49,13 @@ def is_namespace(modname: str) -> bool:
                 # .pth files will be on sys.modules
                 # __spec__ is set inconsistently on PyPy so we can't really on the heuristic here
                 # See: https://foss.heptapod.net/pypy/pypy/-/issues/3736
-                return sys.modules[modname].__spec__ is None and not IS_PYPY
+                # Check first fragment of modname, e.g. "astroid", not "astroid.interpreter"
+                # because of cffi's behavior
+                # See: https://github.com/PyCQA/astroid/issues/1776
+                return (
+                    sys.modules[processed_components[0]].__spec__ is None
+                    and not IS_PYPY
+                )
             except KeyError:
                 return False
             except AttributeError:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

The `is_namespace()` changes in 2.12 broke introspection of modules compiled by `cffi`, which as quoted in the issue, patch `sys.modules`. The only reason we are looking at `sys.modules` is to support the edge case of old `pkg_resources`-style namespace packages. The principle of false negatives are better than letting things crash suggests that we should just loosen the check to top level modnames ("pylint" rather than "pylint.lint"), because that allows the `cffi` modules to not crash without failing the `pkg_resources` tests. (Another way of saying: I'm not aware of any false negatives we're causing with `pkg_resources`-style packages, since the tests pass, but I can't rule it out.)

No tests--did not want to introduce a test dependency on `cffi`.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue

Closes #1776
Closes PyCQA/pylint#7399


@dalcinl, does this resolve your issue?