### PR TITLE
Use ``WeakKeyDictionary`` in ``decorators.cached``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,10 @@ What's New in astroid 2.12.10?
 ==============================
 Release date: TBA
 
+* ``decorators.cached`` now uses a ``WeakKeyDictionary`` to allow the garbave collector
+  to remove entries when possible.
 
+  Refs #1780
 
 What's New in astroid 2.12.9?
 =============================

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -10,6 +10,7 @@ import functools
 import inspect
 import sys
 import warnings
+import weakref
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -32,8 +33,10 @@ _P = ParamSpec("_P")
 def cached(func, instance, args, kwargs):
     """Simple decorator to cache result of method calls without args."""
     cache = getattr(instance, "__cache", None)
+    # Use a WeakKeyDictionary to allow the garbage collector to remove entries
+    # that only exist in the cache.
     if cache is None:
-        instance.__cache = cache = {}
+        instance.__cache = cache = weakref.WeakKeyDictionary()
     try:
         return cache[func]
     except KeyError:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Refs. https://github.com/PyCQA/astroid/issues/1780

@matusvalo would you be able to this change?

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Details

I use the following script to check for the leakage of `NodeNG` objects.

```python
from io import StringIO

from pylint.lint import Run, pylinter
from pylint.reporters.text import TextReporter
from pympler import muppy, summary

from astroid import nodes


def get_memory_info(
    should_count_nodes: bool = False, should_tracemalloc: bool = False
) -> None:
    prev_nodes = 0

    for round in range(5):
        # Note counting setup
        count_nodes = 0

        # Run program
        Run(
            ["astroid/nodes/node_ng.py"],
            exit=False,
            reporter=TextReporter(StringIO()),
        )
        # Clear cache
        pylinter.MANAGER.clear_cache()

        # Node counting
        if should_count_nodes:
            for o in muppy.get_objects():
                if isinstance(o, nodes.NodeNG):
                    count_nodes += 1

            print()
            print("Nodes INC:", count_nodes - prev_nodes)
            prev_nodes = count_nodes
            print("Nodes NEW:", prev_nodes)



get_memory_info(should_count_nodes=True)
```

On ``main`` this returns:
```console
Nodes INC: 132313
Nodes NEW: 132313

Nodes INC: 93202
Nodes NEW: 225515

Nodes INC: 92207
Nodes NEW: 317722

Nodes INC: 92147
Nodes NEW: 409869

Nodes INC: 92147
Nodes NEW: 502016
```

On this ``PR`` this returns:
```console
Nodes INC: 105458
Nodes NEW: 105458

Nodes INC: 63140
Nodes NEW: 168598

Nodes INC: 58253
Nodes NEW: 226851

Nodes INC: 58193
Nodes NEW: 285044

Nodes INC: 58193
Nodes NEW: 343237
```

We're definitely still leaking, but it seems to be better at least.

I ran the `pylint` test suite and the time was around as I expect and similar to a run against `main` just before it. So I think the caching is also still working.