### PR TITLE
Create a ``CacheManager`` class to manage storing and clearing caches

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,9 @@ What's New in astroid 2.12.10?
 ==============================
 Release date: TBA
 
+* ``decorators.cached`` now gets its cache cleared by calling ``AstroidManager.clear_cache``.
 
+  Refs #1780
 
 What's New in astroid 2.12.9?
 =============================

--- a/astroid/_cache.py
+++ b/astroid/_cache.py
@@ -1,6 +1,7 @@
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
+
 from __future__ import annotations
 
 from typing import Any

--- a/astroid/_cache.py
+++ b/astroid/_cache.py
@@ -1,3 +1,6 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 from __future__ import annotations
 
 from typing import Any

--- a/astroid/_cache.py
+++ b/astroid/_cache.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class CacheManager:
+    """Manager of caches, to be used as a singleton."""
+
+    def __init__(self) -> None:
+        self.dict_caches: list[dict[Any, Any]] = []
+
+    def clear_all_caches(self) -> None:
+        """Clear all caches."""
+        for dict_cache in self.dict_caches:
+            dict_cache.clear()
+
+    def add_dict_cache(self, cache: dict[Any, Any]) -> None:
+        """Add a dictionary cache to the manager."""
+        self.dict_caches.append(cache)
+
+
+CACHE_MANAGER = CacheManager()

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -15,7 +15,7 @@ from typing import TypeVar
 
 import wrapt
 
-from astroid import util
+from astroid import _cache, util
 from astroid.context import InferenceContext
 from astroid.exceptions import InferenceError
 
@@ -34,6 +34,7 @@ def cached(func, instance, args, kwargs):
     cache = getattr(instance, "__cache", None)
     if cache is None:
         instance.__cache = cache = {}
+        _cache.CACHE_MANAGER.add_dict_cache(cache)
     try:
         return cache[func]
     except KeyError:

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -16,6 +16,7 @@ import zipimport
 from importlib.util import find_spec, module_from_spec
 from typing import TYPE_CHECKING, ClassVar
 
+from astroid._cache import CACHE_MANAGER
 from astroid.const import BRAIN_MODULES_DIRECTORY
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import spec, util
@@ -390,6 +391,8 @@ class AstroidManager:
         self.astroid_cache.clear()
         # NB: not a new TransformVisitor()
         AstroidManager.brain["_transform"].transforms = collections.defaultdict(list)
+
+        CACHE_MANAGER.clear_all_caches()
 
         for lru_cache in (
             LookupMixIn.lookup,


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Refs. https://github.com/PyCQA/astroid/issues/1780

Another attempt after #1781. Results are the same 🎉 

@matusvalo would you be able to test this change?
@jacobtylerwalls Does this seem like a reasonable design to you?

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Details

I use the following script to check for the leakage of `NodeNG` objects.

```python
from io import StringIO

from pylint.lint import Run, pylinter
from pylint.reporters.text import TextReporter
from pympler import muppy, summary

from astroid import nodes


def get_memory_info(
    should_count_nodes: bool = False, should_tracemalloc: bool = False
) -> None:
    prev_nodes = 0

    for round in range(5):
        # Node counting setup
        count_nodes = 0

        # Run program
        Run(
            ["astroid/nodes/node_ng.py"],
            exit=False,
            reporter=TextReporter(StringIO()),
        )
        # Clear cache
        pylinter.MANAGER.clear_cache()

        # Node counting
        if should_count_nodes:
            for o in muppy.get_objects():
                if isinstance(o, nodes.NodeNG):
                    count_nodes += 1

            print()
            print("Nodes INC:", count_nodes - prev_nodes)
            prev_nodes = count_nodes
            print("Nodes NEW:", prev_nodes)



get_memory_info(should_count_nodes=True)
```

On ``main`` this returns:
```console
Nodes INC: 132313
Nodes NEW: 132313

Nodes INC: 93202
Nodes NEW: 225515

Nodes INC: 92207
Nodes NEW: 317722

Nodes INC: 92147
Nodes NEW: 409869

Nodes INC: 92147
Nodes NEW: 502016
```

On this ``PR`` this returns:
```console
Nodes INC: 105458
Nodes NEW: 105458

Nodes INC: 63140
Nodes NEW: 168598

Nodes INC: 58253
Nodes NEW: 226851

Nodes INC: 58193
Nodes NEW: 285044

Nodes INC: 58193
Nodes NEW: 343237
```

We're definitely still leaking, but it seems to be better at least.

I ran the `pylint` test suite and the time was around as I expect and similar to a run against `main` just before it. So I think the caching is also still working.