### PR TITLE
Give a created Arguments node a parent

### DIFF
--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -795,7 +795,9 @@ class PropertyModel(ObjectModel):
     """Model for a builtin property"""
 
     def _init_function(self, name):
-        args = nodes.Arguments()
+        function = nodes.FunctionDef(name=name, parent=self._instance)
+
+        args = nodes.Arguments(parent=function)
         args.postinit(
             args=[],
             defaults=[],
@@ -806,8 +808,6 @@ class PropertyModel(ObjectModel):
             posonlyargs_annotations=[],
             kwonlyargs_annotations=[],
         )
-
-        function = nodes.FunctionDef(name=name, parent=self._instance)
 
         function.postinit(args=args, body=[])
         return function


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

This can lead to crashes when asking for the `__repr__` of an `Arguments` node as that assumes it has a `parent` attribute, like it should.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

