### PR TITLE
Migrate configs for isort, mypy, and pytest into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,41 @@ include = ["astroid*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "astroid.__pkginfo__.__version__"}
+
+[tool.aliases]
+test = "pytest"
+
+[tool.pytest.ini_options]
+addopts = '-m "not acceptance"'
+python_files = ["*test_*.py"]
+testpaths = ["tests"]
+
+[tool.isort]
+include_trailing_comma = true
+known_first_party = ["astroid"]
+known_third_party = ["attr", "nose", "numpy", "pytest", "six", "sphinx"]
+line_length = 88
+multi_line_output = 3
+skip_glob = ["tests/testdata"]
+
+[tool.mypy]
+enable_error_code = "ignore-without-code"
+no_implicit_optional = true
+scripts_are_modules = true
+show_error_codes = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# Importlib typeshed stubs do not include the private functions we use
+module = [
+    "_io.*",
+    "gi.*",
+    "importlib.*",
+    "lazy_object_proxy.*",
+    "nose.*",
+    "numpy.*",
+    "pytest",
+    "setuptools",
+    "wrapt.*",
+]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,22 +8,6 @@ license_files =
     LICENSE
     CONTRIBUTORS.txt
 
-[aliases]
-test = pytest
-
-[tool:pytest]
-testpaths = tests
-python_files = *test_*.py
-addopts = -m "not acceptance"
-
-[isort]
-multi_line_output = 3
-line_length = 88
-known_third_party = sphinx, pytest, six, nose, numpy, attr
-known_first_party = astroid
-include_trailing_comma = True
-skip_glob = tests/testdata
-
 [flake8]
 extend-ignore =
     C901, # Function complexity checker
@@ -33,44 +17,9 @@ extend-ignore =
     E501, # Line too long
     B950, # Line too long
     B901 # Combine yield and return statements in one function
-max-line-length=88
+max-line-length = 88
 max-complexity = 20
 select = B,C,E,F,W,T4,B9
 # Required for flake8-typing-imports (v1.12.0)
 # The plugin doesn't yet read the value from pyproject.toml
 min_python_version = 3.7.2
-
-[mypy]
-scripts_are_modules = True
-no_implicit_optional = True
-warn_redundant_casts = True
-show_error_codes = True
-enable_error_code = ignore-without-code
-
-[mypy-setuptools]
-ignore_missing_imports = True
-
-[mypy-pytest]
-ignore_missing_imports = True
-
-[mypy-nose.*]
-ignore_missing_imports = True
-
-[mypy-numpy.*]
-ignore_missing_imports = True
-
-[mypy-_io.*]
-ignore_missing_imports = True
-
-[mypy-wrapt.*]
-ignore_missing_imports = True
-
-[mypy-lazy_object_proxy.*]
-ignore_missing_imports = True
-
-[mypy-gi.*]
-ignore_missing_imports = True
-
-[mypy-importlib.*]
-# Importlib typeshed stubs do not include the private functions we use
-ignore_missing_imports = True


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description of what the PR does.

## Description
Migrate the configs into `pyproject.toml` using [`ini2toml`](https://pypi.org/project/ini2toml) to do the file conversion and running [`validate-pyproject`](https://github.com/abravalheri/validate-pyproject) to validate the results.  Skip any configuration that is not yet PEP 621 compatible.
```
git checkout -b more-pyproject.toml
ini2toml setup.cfg
code pyproject.toml setup.cfg  # Cherry-pick those changes which are PEP 621 compatible.
validate-pyproject pyproject.toml
```
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
