### PR TITLE
Handle empty ``modname`` in ``ast_from_module_name``

### DIFF
--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -155,6 +155,8 @@ class AstroidManager:
         use_cache: bool = True,
     ) -> nodes.Module:
         """Given a module name, return the astroid object."""
+        if modname is None:
+            raise AstroidBuildingError("No module name given.")
         # Sometimes we don't want to use the cache. For example, when we're
         # importing a module with the same name as the file that is importing
         # we want to fallback on the import system to make sure we get the correct

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -356,6 +356,10 @@ class AstroidManagerTest(
         stdlib_math = next(module.body[1].value.args[0].infer())
         assert self.manager.astroid_cache["math"] != stdlib_math
 
+    def test_raises_exception_for_empty_modname(self) -> None:
+        with pytest.raises(AstroidBuildingError):
+            self.manager.ast_from_module_name(None)
+
 
 class BorgAstroidManagerTC(unittest.TestCase):
     def test_borg(self) -> None:


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Based on the typing we support this, but currently this would crash with an `AttributeError` in one of the called functions. This handles this a little bit nicer, even though we never actually call this like this.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |