### PR TITLE
Improve is_namespace() check for modules where `__spec__` is None

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#5151
 
+* Improve detection of namespace packages for the modules with ``__spec__`` set to None.
+
+  Closes PyCQA/pylint#7488.
+
 
 What's New in astroid 2.12.11?
 ==============================

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -52,8 +52,11 @@ def is_namespace(modname: str) -> bool:
                 # Check first fragment of modname, e.g. "astroid", not "astroid.interpreter"
                 # because of cffi's behavior
                 # See: https://github.com/PyCQA/astroid/issues/1776
+                mod = sys.modules[processed_components[0]]
                 return (
-                    sys.modules[processed_components[0]].__spec__ is None
+                    mod.__spec__ is None
+                    and getattr(mod, "__file__", None) is None
+                    and hasattr(mod, "__path__")
                     and not IS_PYPY
                 )
             except KeyError:

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -144,6 +144,15 @@ class AstroidManagerTest(
         finally:
             astroid_module.__spec__ = original_spec
 
+    def test_module_unexpectedly_spec_is_none(self) -> None:
+        astroid_module = sys.modules["astroid"]
+        original_spec = astroid_module.__spec__
+        astroid_module.__spec__ = None
+        try:
+            self.assertFalse(util.is_namespace("astroid"))
+        finally:
+            astroid_module.__spec__ = original_spec
+
     def test_implicit_namespace_package(self) -> None:
         data_dir = os.path.dirname(resources.find("data/namespace_pep_420"))
         contribute = os.path.join(data_dir, "contribute_to_namespace")


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

See https://stackoverflow.com/a/42962529.

Let's take the following contents as an example:
```python
import celery.result

```

From #1777, astroid started to use `processed_components` for namespace check. In the above case, the `modname` is `celery.result`, it first checks for `celery` and then `celery.result`. Before that PR, it'd always check for `celery.result`.

~~But if you have imported it as `celery.result`,
`sys.modules["celery"].__spec__` is going to be `None`, and hence the function will return True, but below where we try to load get `submodule_path`/`__path__` for `celery.result` will fail as it is not a package. Also celery is not a namespace package.~~

[`celery` is recreating module to make it lazily load](https://github.com/celery/celery/blob/34533ab44d2a6492004bc3df44dc04ad5c6611e7/celery/__init__.py#L150), which does not have `__spec__` set. Reading through [Python's docs](https://docs.python.org/3/reference/import.html#spec__), it seems that `__spec__` can be set to None, so it seems like it's not a thing that we can depend upon for namespace checks.

---

The `celery.result` gets imported for me when `pylint-pytest` plugin tries to load fixtures, but this could happen anytime if any plugin imports packages. In that case, `importlib.util._find_spec_from_path("celery")` will raise ValueError since it's already in `sys.modules` and does not have a spec.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

Fixes https://github.com/PyCQA/pylint/issues/7488.