### PR TITLE
Prevent a crash when a module's ``__path__`` is missing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,7 +29,9 @@ Release date: TBA
 
   Refs PyCQA/pylint#4039
 
+* Prevent a crash when a module's ``__path__`` attribute is unexpectedly missing.
 
+  Refs PyCQA/pylint#7592
 
 
 What's New in astroid 2.12.11?

--- a/astroid/interpreter/_import/util.py
+++ b/astroid/interpreter/_import/util.py
@@ -42,6 +42,8 @@ def is_namespace(modname: str) -> bool:
             found_spec = _find_spec_from_path(
                 working_modname, path=last_submodule_search_locations
             )
+        except AttributeError:
+            return False
         except ValueError:
             if modname == "__main__":
                 return False

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -9,6 +9,7 @@ import time
 import unittest
 from collections.abc import Iterator
 from contextlib import contextmanager
+from unittest import mock
 
 import pytest
 
@@ -143,6 +144,14 @@ class AstroidManagerTest(
             self.assertFalse(util.is_namespace("astroid"))
         finally:
             astroid_module.__spec__ = original_spec
+
+    @mock.patch(
+        "astroid.interpreter._import.util._find_spec_from_path",
+        side_effect=AttributeError,
+    )
+    def test_module_unexpectedly_missing_path(self, mocked) -> None:
+        """https://github.com/PyCQA/pylint/issues/7592"""
+        self.assertFalse(util.is_namespace("astroid"))
 
     def test_module_unexpectedly_spec_is_none(self) -> None:
         astroid_module = sys.modules["astroid"]


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description
We have several reports of modules missing a `__path__` attribute. I couldn't determine how to reproduce it realistically, so I just mocked it in a test.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Closes PyCQA/pylint#7592
