### PR TITLE
Fix `getattr` inference with empty annotation assignments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,11 @@ Release date: TBA
 
   Refs PyCQA/pylint#7592
 
+* Fix inferring attributes with empty annotation assignments if parent
+  class contains valid assignment.
+
+  Refs PyCQA/pylint#7631
+
 
 What's New in astroid 2.12.11?
 ==============================

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -46,6 +46,7 @@ from astroid.nodes import Arguments, Const, NodeNG, _base_nodes, node_classes
 from astroid.nodes.scoped_nodes.mixin import ComprehensionScope, LocalsDictNodeNG
 from astroid.nodes.scoped_nodes.utils import builtin_lookup
 from astroid.nodes.utils import Position
+from astroid.typing import InferenceResult
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -2525,7 +2526,12 @@ class ClassDef(
             pass
         return bases.Instance(self)
 
-    def getattr(self, name, context=None, class_context=True):
+    def getattr(
+        self,
+        name: str,
+        context: InferenceContext | None = None,
+        class_context: bool = True,
+    ) -> list[NodeNG]:
         """Get an attribute from this class, using Python's attribute semantic.
 
         This method doesn't look in the :attr:`instance_attrs` dictionary
@@ -2541,13 +2547,10 @@ class ClassDef(
         metaclass will be done.
 
         :param name: The attribute to look for.
-        :type name: str
 
         :param class_context: Whether the attribute can be accessed statically.
-        :type class_context: bool
 
         :returns: The attribute.
-        :rtype: list(NodeNG)
 
         :raises AttributeInferenceError: If the attribute cannot be inferred.
         """
@@ -2570,17 +2573,16 @@ class ClassDef(
         if class_context:
             values += self._metaclass_lookup_attribute(name, context)
 
-        if not values:
-            raise AttributeInferenceError(target=self, attribute=name, context=context)
-
-        # Look for AnnAssigns, which are not attributes in the purest sense.
-        for value in values:
+        # Remove AnnAssigns without value, which are not attributes in the purest sense.
+        for value in values.copy():
             if isinstance(value, node_classes.AssignName):
                 stmt = value.statement(future=True)
                 if isinstance(stmt, node_classes.AnnAssign) and stmt.value is None:
-                    raise AttributeInferenceError(
-                        target=self, attribute=name, context=context
-                    )
+                    values.pop(values.index(value))
+
+        if not values:
+            raise AttributeInferenceError(target=self, attribute=name, context=context)
+
         return values
 
     def _metaclass_lookup_attribute(self, name, context):
@@ -2622,14 +2624,17 @@ class ClassDef(
             else:
                 yield bases.BoundMethod(attr, self)
 
-    def igetattr(self, name, context=None, class_context=True):
+    def igetattr(
+        self,
+        name: str,
+        context: InferenceContext | None = None,
+        class_context: bool = True,
+    ) -> Iterator[InferenceResult]:
         """Infer the possible values of the given variable.
 
         :param name: The name of the variable to infer.
-        :type name: str
 
         :returns: The inferred possible values.
-        :rtype: iterable(NodeNG or Uninferable)
         """
         # set lookup name since this is necessary to infer on import nodes for
         # instance

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1268,6 +1268,22 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         self.assertIsInstance(attr1, nodes.AssignName)
         self.assertEqual(attr1.name, "attr")
 
+    @staticmethod
+    def test_getattr_with_enpty_annassign() -> None:
+        code = """
+            class Parent:
+                attr: int = 2
+
+            class Child(Parent):  #@
+                attr: int
+        """
+        child = extract_node(code)
+        attr = child.getattr("attr")
+        assert len(attr) == 1
+        assert isinstance(attr[0], nodes.AssignName)
+        assert attr[0].name == "attr"
+        assert attr[0].lineno == 3
+
     def test_function_with_decorator_lineno(self) -> None:
         data = """
             @f(a=2,


### PR DESCRIPTION
## Description
Don't exit with `AttributeInferenceError` for annotation assignments if parent class contains valid assignment.

```py
class Parent:
    attr: int = 2

class Child(Parent):
    attr: int
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
Refs https://github.com/PyCQA/pylint/issues/7631