### PR TITLE
Move changelog entry for dataclasses regression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,11 @@ What's New in astroid 2.12.12?
 ==============================
 Release date: TBA
 
+* Fixed a regression in the creation of the ``__init__`` of dataclasses with
+  multiple inheritance.
+
+  Closes PyCQA/pylint#7434
+
 * Add the ``length`` parameter to ``hash.digest`` & ``hash.hexdigest`` in the ``hashlib`` brain.
 
   Refs PyCQA/pylint#4039
@@ -42,10 +47,6 @@ Release date: 2022-10-10
 
   Closes PyCQA/pylint#7488.
 
-* Fixed a regression in the creation of the ``__init__`` of dataclasses with
-  multiple inheritance.
-
-  Closes PyCQA/pylint#7434
 
 What's New in astroid 2.12.10?
 ==============================


### PR DESCRIPTION
## Description
Move changelog entry for #1812 from `2.12.11` to `2.12.12`. Unfortunately the PR wasn't marked with `Needs backport` before and thus the commit https://github.com/PyCQA/astroid/commit/1ffe4001633488c8c0cf1160d98793bbe3f79da9 wasn't included in the release.

I've added the label and updated the milestone on #1812 now.

/CC: @DanielNoord