### PR TITLE
Fix detecting invalid metaclasses

### DIFF
--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2841,7 +2841,7 @@ class ClassDef(
                 return next(
                     node
                     for node in self._metaclass.infer(context=context)
-                    if isinstance(node, NodeNG)
+                    if node is not util.Uninferable
                 )
             except (InferenceError, StopIteration):
                 return None

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1415,6 +1415,20 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         inferred = next(klass.infer())
         self.assertIsNone(inferred.metaclass())
 
+    @staticmethod
+    def test_with_invalid_metaclass():
+        klass = extract_node(
+            """
+        class InvalidAsMetaclass: ...
+
+        class Invalid(metaclass=InvalidAsMetaclass()):  #@
+            pass
+        """
+        )
+        inferred = next(klass.infer())
+        metaclass = inferred.metaclass()
+        assert isinstance(metaclass, Instance)
+
     def test_nonregr_infer_callresult(self) -> None:
         astroid = builder.parse(
             """


### PR DESCRIPTION
## Description
Noticed two failing pylint tests (`invalid_metaclass` and `dataclass_typecheck`) with astroid main. Bisects to #1678.
The change hasn't been released yet, so there is no need to backport the fix.

/CC: @DanielNoord

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |