### PR TITLE
Fix uncaught ValueError on inference of __getitem__ with slice(..., ..., 0)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,9 @@ Release date: TBA
 
   Refs PyCQA/pylint#7706
 
+* Catch ``ValueError`` when indexing some builtin containers and sequences during inference.
+
+  Closes #1843
 
 What's New in astroid 2.12.12?
 ==============================

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -27,6 +27,7 @@ from astroid.exceptions import (
     AstroidError,
     AstroidIndexError,
     AstroidTypeError,
+    AstroidValueError,
     AttributeInferenceError,
     InferenceError,
     NameInferenceError,
@@ -441,6 +442,7 @@ def infer_subscript(
             except (
                 AstroidTypeError,
                 AstroidIndexError,
+                AstroidValueError,
                 AttributeInferenceError,
                 AttributeError,
             ) as exc:

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -22,6 +22,7 @@ from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidIndexError,
     AstroidTypeError,
+    AstroidValueError,
     InferenceError,
     NoDefault,
     ParentMissingError,
@@ -234,6 +235,13 @@ def _container_getitem(instance, elts, index, context=None):
             return new_cls
         if isinstance(index, Const):
             return elts[index.value]
+    except ValueError as exc:
+        raise AstroidValueError(
+            message="Slice {index!r} cannot index container",
+            node=instance,
+            index=index,
+            context=context,
+        ) from exc
     except IndexError as exc:
         raise AstroidIndexError(
             message="Index {index!s} out of range",
@@ -2030,6 +2038,10 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         try:
             if isinstance(self.value, (str, bytes)):
                 return Const(self.value[index_value])
+        except ValueError as exc:
+            raise AstroidValueError(
+                f"Could not index {self.value!r} with {index_value!r}"
+            ) from exc
         except IndexError as exc:
             raise AstroidIndexError(
                 message="Index {index!r} out of range",

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -5316,6 +5316,16 @@ def test_slice_inference_in_for_loops_not_working() -> None:
         assert inferred == util.Uninferable
 
 
+def test_slice_zero_step_does_not_raise_ValueError() -> None:
+    node = extract_node("x = [][::0]; x")
+    assert next(node.infer()) == util.Uninferable
+
+
+def test_slice_zero_step_on_str_does_not_raise_ValueError() -> None:
+    node = extract_node('x = ""[::0]; x')
+    assert next(node.infer()) == util.Uninferable
+
+
 def test_unpacking_starred_and_dicts_in_assignment() -> None:
     node = extract_node(
         """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

See #1843 for a reproducer.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->

Closes #1843 