### PR TITLE
Use relative paths in `create_contributor_list.py`

### DIFF
--- a/script/create_contributor_list.py
+++ b/script/create_contributor_list.py
@@ -6,9 +6,14 @@ from pathlib import Path
 
 from contributors_txt import create_contributors_txt
 
-ASTROID_BASE_DIRECTORY = Path(__file__).parent.parent
-ALIASES_FILE = ASTROID_BASE_DIRECTORY / "script/.contributors_aliases.json"
-DEFAULT_CONTRIBUTOR_PATH = ASTROID_BASE_DIRECTORY / "CONTRIBUTORS.txt"
+CWD = Path(".").absolute()
+ASTROID_BASE_DIRECTORY = Path(__file__).parent.parent.absolute()
+ALIASES_FILE = (
+    ASTROID_BASE_DIRECTORY / "script/.contributors_aliases.json"
+).relative_to(CWD)
+DEFAULT_CONTRIBUTOR_PATH = (ASTROID_BASE_DIRECTORY / "CONTRIBUTORS.txt").relative_to(
+    CWD
+)
 
 
 def main():


### PR DESCRIPTION
## Description
On MacOS `Path(__file__).parent.parent` seems to be resolved to an absolute path. This causes the `contibutors-txt` script to insert a duplicate header as the path for `.contributors_aliases.json` doesn't match anymore.

https://github.com/PyCQA/astroid/blob/1a074cf66fc4fdb6714fac7afb14f9e7457cd704/CONTRIBUTORS.txt#L1-L5

Refs
* https://github.com/PyCQA/pylint/issues/7362
* https://github.com/PyCQA/pylint/pull/7656