### PR TITLE
Use Python 3.9 for virtualenv-15-windows-test job

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -21,7 +21,8 @@ jobs:
         id: python
         uses: actions/setup-python@v4.3.0
         with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          # virtualenv 15.1.0 cannot be installed on Python 3.10+
+          python-version: 3.9
       - name: Create Python virtual environment with virtualenv==15.1.0
         run: |
           python -m pip install virtualenv==15.1.0


### PR DESCRIPTION

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

virtualenv 15.1.0 cannot be installed on Python 3.10+, so the release test that uses virtualenv 15.1.0 broke when the workflow was changed to use Python 3.10 in #1704.

[Failing run](https://github.com/PyCQA/astroid/actions/runs/3312658937) that I manually triggered earlier this week.

[Example passing run](https://github.com/jacobtylerwalls/astroid/actions/runs/3351386322/jobs/5552801026) on my fork with these changes.

When we eventually drop Python 3.9 as a runtime for pylint, we can remove this test.


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

