### PR TITLE
Prevent returning an empty list for ``ClassDef.slots()``

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#2567
 
+* Prevent returning an empty list for ``ClassDef.slots()`` when the mro list contains one class & it is not ``object``.
+
+  Refs PyCQA/pylint#5099
+
 * Add ``_value2member_map_`` member to the ``enum`` brain.
 
   Refs PyCQA/pylint#3941

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2968,7 +2968,7 @@ class ClassDef(
             mro: list[ClassDef],
         ) -> Iterator[node_classes.NodeNG | None]:
             # Not interested in object, since it can't have slots.
-            for cls in mro[:-1]:
+            for cls in [cls for cls in mro if cls.qname() != "builtins.object"]:
                 try:
                     cls_slots = cls._slots()
                 except NotImplementedError:

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2967,8 +2967,10 @@ class ClassDef(
         def grouped_slots(
             mro: list[ClassDef],
         ) -> Iterator[node_classes.NodeNG | None]:
-            # Not interested in object, since it can't have slots.
-            for cls in [cls for cls in mro if cls.qname() != "builtins.object"]:
+            for cls in mro:
+                # Not interested in object, since it can't have slots.
+                if cls.qname() == "builtins.object":
+                    continue
                 try:
                     cls_slots = cls._slots()
                 except NotImplementedError:

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1820,7 +1820,6 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(slots[0], nodes.Const)
         assert slots[0].value == "value"
 
-
     def test_collections_generic_alias_slots(self):
         """Test slots for a class which is a subclass of a generic alias type."""
         node = builder.extract_node(

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1820,6 +1820,27 @@ class TypingBrain(unittest.TestCase):
         assert isinstance(slots[0], nodes.Const)
         assert slots[0].value == "value"
 
+
+    def test_collections_generic_alias_slots(self):
+        """Test slots for a class which is a subclass of a generic alias type."""
+        node = builder.extract_node(
+            """
+        import collections
+        import typing
+        Type = typing.TypeVar('Type')
+        class A(collections.abc.AsyncIterator[Type]):
+            __slots__ = ('_value',)
+            def __init__(self, value: collections.abc.AsyncIterator[Type]):
+                self._value = value
+        """
+        )
+        inferred = next(node.infer())
+        assert isinstance(inferred, nodes.ClassDef)
+        slots = inferred.slots()
+        assert len(slots) == 1
+        assert isinstance(slots[0], nodes.Const)
+        assert slots[0].value == "_value"
+
     def test_has_dunder_args(self) -> None:
         ast_node = builder.extract_node(
             """


### PR DESCRIPTION
Prevent returning an empty list for ``ClassDef.slots()`` when the mro list contains one class & it is not ``object``.

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:


-->
Refs PyCQA/pylint#5099