### PR TITLE
Infer the `length` argument of the ``random.sample`` function.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,10 +16,6 @@ Release date: TBA
 
   Refs PyCQA/pylint#2567
 
-* Infer the `length` argument of the ``random.sample`` function.
-
-  Refs PyCQA/pylint#7706
-
 * Prevent returning an empty list for ``ClassDef.slots()`` when the mro list contains one class & it is not ``object``.
 
   Refs PyCQA/pylint#5099
@@ -33,6 +29,9 @@ What's New in astroid 2.12.13?
 ==============================
 Release date: TBA
 
+* Infer the `length` argument of the ``random.sample`` function.
+
+  Refs PyCQA/pylint#7706
 
 
 What's New in astroid 2.12.12?

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#2567
 
+* Infer the `length` argument of the ``random.sample`` function.
+
+  Refs PyCQA/pylint#7706
+
 * Add ``_value2member_map_`` member to the ``enum`` brain.
 
   Refs PyCQA/pylint#3941

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -42,10 +42,10 @@ def infer_random_sample(node, context=None):
     if len(node.args) != 2:
         raise UseInferenceDefault
 
-    length = node.args[1]
-    if not isinstance(length, Const):
+    inferred_length = helpers.safe_infer(node.args[1], context=context)
+    if not isinstance(inferred_length, Const):
         raise UseInferenceDefault
-    if not isinstance(length.value, int):
+    if not isinstance(inferred_length.value, int):
         raise UseInferenceDefault
 
     inferred_sequence = helpers.safe_infer(node.args[0], context=context)
@@ -55,12 +55,12 @@ def infer_random_sample(node, context=None):
     if not isinstance(inferred_sequence, ACCEPTED_ITERABLES_FOR_SAMPLE):
         raise UseInferenceDefault
 
-    if length.value > len(inferred_sequence.elts):
+    if inferred_length.value > len(inferred_sequence.elts):
         # In this case, this will raise a ValueError
         raise UseInferenceDefault
 
     try:
-        elts = random.sample(inferred_sequence.elts, length.value)
+        elts = random.sample(inferred_sequence.elts, inferred_length.value)
     except ValueError as exc:
         raise UseInferenceDefault from exc
 

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -2395,6 +2395,29 @@ class RandomSampleTest(unittest.TestCase):
         elems = sorted(elem.value for elem in inferred.elts)
         self.assertEqual(elems, [1, 2])
 
+    def test_arguments_inferred_successfully(self) -> None:
+        """Test inference of `random.sample` when both arguments are of type `nodes.Call`."""
+        node = astroid.extract_node(
+            """
+        import random
+
+        def sequence():
+            return [1, 2]
+
+        random.sample(sequence(), len([1,2])) #@
+        """
+        )
+        # Check that arguments are of type `nodes.Call`.
+        sequence, length = node.args
+        self.assertIsInstance(sequence, astroid.Call)
+        self.assertIsInstance(length, astroid.Call)
+
+        # Check the inference of `random.sample` call.
+        inferred = next(node.infer())
+        self.assertIsInstance(inferred, astroid.List)
+        elems = sorted(elem.value for elem in inferred.elts)
+        self.assertEqual(elems, [1, 2])
+
     def test_no_crash_on_evaluatedobject(self) -> None:
         node = astroid.extract_node(
             """


### PR DESCRIPTION
<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] Write a good description on what the PR does.

## Description
The bug is where the argument is provided as a `nodes.Call` node instead of a `nodes.Const`. The fix is to infer it first.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX

-->
Refs PyCQA/pylint#7706
