### PR TITLE
Prevent a crash when inferring calls to `str.format` with invalid args

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,11 @@ Release date: TBA
 
   Refs PyCQA/pylint#5099
 
+* Prevent a crash when inferring calls to ``str.format`` with inferred arguments
+  that would be invalid.
+
+  Closes #1856
+
 * Infer the `length` argument of the ``random.sample`` function.
 
   Refs PyCQA/pylint#7706

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -954,8 +954,10 @@ def _infer_str_format_call(
 
     try:
         formatted_string = format_template.format(*pos_values, **keyword_values)
-    except (IndexError, KeyError):
-        # If there is an IndexError there are too few arguments to interpolate
+    except (IndexError, KeyError, TypeError, ValueError):
+        # IndexError: there are too few arguments to interpolate
+        # TypeError: Unsupported format string
+        # ValueError: Unknown format code
         return iter([util.Uninferable])
 
     return iter([nodes.const_factory(formatted_string)])

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -103,6 +103,12 @@ class TestStringNodes:
             """
             "My name is {fname}, I'm {age}".format(fsname = "Daniel", age = 12)
             """,
+            """
+            "My unicode character is {:c}".format(None)
+            """,
+            """
+            "My hex format is {:4x}".format('1')
+            """,
         ],
     )
     def test_string_format_uninferable(self, format_string: str) -> None:


### PR DESCRIPTION

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

`str.format` can also emit `ValueError` or `TypeError`, so we need to catch them here.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Related Issue
Closes #1856
