### PR TITLE
Inference context annotations

### DIFF
--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -29,7 +29,7 @@ class CallSite:
     """
 
     def __init__(
-        self, callcontext: CallContext, argument_context_map=None, context=None
+        self, callcontext: CallContext, argument_context_map=None, context: InferenceContext | None = None
     ):
         if argument_context_map is None:
             argument_context_map = {}
@@ -81,7 +81,7 @@ class CallSite:
         """
         return len(self.keyword_arguments) != len(self._unpacked_kwargs)
 
-    def _unpack_keywords(self, keywords, context=None):
+    def _unpack_keywords(self, keywords, context: InferenceContext | None = None):
         values = {}
         context = context or InferenceContext()
         context.extra_context = self.argument_context_map
@@ -125,7 +125,7 @@ class CallSite:
                 values[name] = value
         return values
 
-    def _unpack_args(self, args, context=None):
+    def _unpack_args(self, args, context: InferenceContext | None = None):
         values = []
         context = context or InferenceContext()
         context.extra_context = self.argument_context_map

--- a/astroid/arguments.py
+++ b/astroid/arguments.py
@@ -29,7 +29,10 @@ class CallSite:
     """
 
     def __init__(
-        self, callcontext: CallContext, argument_context_map=None, context: InferenceContext | None = None
+        self,
+        callcontext: CallContext,
+        argument_context_map=None,
+        context: InferenceContext | None = None,
     ):
         if argument_context_map is None:
             argument_context_map = {}

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -71,7 +71,7 @@ POSSIBLE_PROPERTIES = {
 }
 
 
-def _is_property(meth, context=None):
+def _is_property(meth, context: InferenceContext | None = None):
     decoratornames = meth.decoratornames(context=context)
     if PROPERTIES.intersection(decoratornames):
         return True
@@ -209,7 +209,7 @@ class BaseInstance(Proxy):
     def display_type(self) -> str:
         return "Instance of"
 
-    def getattr(self, name, context=None, lookupclass=True):
+    def getattr(self, name, context: InferenceContext | None = None, lookupclass=True):
         try:
             values = self._proxied.instance_attr(name, context)
         except AttributeInferenceError as exc:
@@ -235,7 +235,7 @@ class BaseInstance(Proxy):
                 pass
         return values
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context: InferenceContext | None = None):
         """inferred getattr"""
         if not context:
             context = InferenceContext()
@@ -266,7 +266,7 @@ class BaseInstance(Proxy):
             except AttributeInferenceError as error:
                 raise InferenceError(**vars(error)) from error
 
-    def _wrap_attr(self, attrs, context=None):
+    def _wrap_attr(self, attrs, context: InferenceContext | None = None):
         """wrap bound methods of attrs in a InstanceMethod proxies"""
         for attr in attrs:
             if isinstance(attr, UnboundMethod):
@@ -338,7 +338,7 @@ class Instance(BaseInstance):
     def display_type(self) -> str:
         return "Instance of"
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Infer the truth value for an Instance
 
         The truth value of an instance is determined by these conditions:
@@ -364,7 +364,7 @@ class Instance(BaseInstance):
                 return True
         return result
 
-    def getitem(self, index, context=None):
+    def getitem(self, index, context: InferenceContext | None = None):
         new_context = bind_context_to_node(context, self)
         if not context:
             context = new_context
@@ -402,12 +402,12 @@ class UnboundMethod(Proxy):
     def is_bound(self):
         return False
 
-    def getattr(self, name, context=None):
+    def getattr(self, name, context: InferenceContext | None = None):
         if name in self.special_attributes:
             return [self.special_attributes.lookup(name)]
         return self._proxied.getattr(name, context)
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context: InferenceContext | None = None):
         if name in self.special_attributes:
             return iter((self.special_attributes.lookup(name),))
         return self._proxied.igetattr(name, context)
@@ -462,7 +462,7 @@ class UnboundMethod(Proxy):
                 yield Instance(inferred)
             raise InferenceError
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         return True
 
 
@@ -576,7 +576,7 @@ class BoundMethod(UnboundMethod):
         cls.locals = cls_locals
         return cls
 
-    def infer_call_result(self, caller, context=None):
+    def infer_call_result(self, caller, context: InferenceContext | None = None):
         context = bind_context_to_node(context, self.bound)
         if (
             self.bound.__class__.__name__ == "ClassDef"
@@ -591,7 +591,7 @@ class BoundMethod(UnboundMethod):
 
         return super().infer_call_result(caller, context)
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         return True
 
 
@@ -605,7 +605,7 @@ class Generator(BaseInstance):
 
     special_attributes = lazy_descriptor(objectmodel.GeneratorModel)
 
-    def __init__(self, parent=None, generator_initial_context=None):
+    def __init__(self, parent=None, generator_initial_context: InferenceContext | None = None):
         super().__init__()
         self.parent = parent
         self._call_context = copy_context(generator_initial_context)
@@ -623,7 +623,7 @@ class Generator(BaseInstance):
     def display_type(self) -> str:
         return "Generator"
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         return True
 
     def __repr__(self) -> str:

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -605,7 +605,9 @@ class Generator(BaseInstance):
 
     special_attributes = lazy_descriptor(objectmodel.GeneratorModel)
 
-    def __init__(self, parent=None, generator_initial_context: InferenceContext | None = None):
+    def __init__(
+        self, parent=None, generator_initial_context: InferenceContext | None = None
+    ):
         super().__init__()
         self.parent = parent
         self._call_context = copy_context(generator_initial_context)

--- a/astroid/brain/brain_argparse.py
+++ b/astroid/brain/brain_argparse.py
@@ -2,12 +2,15 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 from astroid import arguments, inference_tip, nodes
+from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.manager import AstroidManager
 
 
-def infer_namespace(node, context=None):
+def infer_namespace(node, context: InferenceContext | None = None):
     callsite = arguments.CallSite.from_call(node, context=context)
     if not callsite.keyword_arguments:
         # Cannot make sense of it.

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -697,8 +697,6 @@ def infer_isinstance(callnode, context: InferenceContext | None = None):
     """Infer isinstance calls
 
     :param nodes.Call callnode: an isinstance call
-    :param InferenceContext context: context for call
-        (currently unused but is a common interface for inference)
     :rtype nodes.Const: Boolean Const value of isinstance call
 
     :raises UseInferenceDefault: If the node cannot be inferred

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -171,7 +171,7 @@ def register_builtin_transform(transform, builtin_name):
     an optional context.
     """
 
-    def _transform_wrapper(node, context=None):
+    def _transform_wrapper(node, context: InferenceContext | None = None):
         result = transform(node, context=context)
         if result:
             if not result.parent:
@@ -336,7 +336,7 @@ def _get_elts(arg, context):
     return items
 
 
-def infer_dict(node, context=None):
+def infer_dict(node, context: InferenceContext | None = None):
     """Try to infer a dict call to a Dict node.
 
     The function treats the following cases:
@@ -379,7 +379,7 @@ def infer_dict(node, context=None):
     return value
 
 
-def infer_super(node, context=None):
+def infer_super(node, context: InferenceContext | None = None):
     """Understand super calls.
 
     There are some restrictions for what can be understood:
@@ -458,7 +458,7 @@ def _infer_getattr_args(node, context):
     return obj, attr.value
 
 
-def infer_getattr(node, context=None):
+def infer_getattr(node, context: InferenceContext | None = None):
     """Understand getattr calls
 
     If one of the arguments is an Uninferable object, then the
@@ -486,7 +486,7 @@ def infer_getattr(node, context=None):
     raise UseInferenceDefault
 
 
-def infer_hasattr(node, context=None):
+def infer_hasattr(node, context: InferenceContext | None = None):
     """Understand hasattr calls
 
     This always guarantees three possible outcomes for calling
@@ -513,7 +513,7 @@ def infer_hasattr(node, context=None):
     return nodes.Const(True)
 
 
-def infer_callable(node, context=None):
+def infer_callable(node, context: InferenceContext | None = None):
     """Understand callable calls
 
     This follows Python's semantics, where an object
@@ -571,7 +571,7 @@ def infer_property(
     return prop_func
 
 
-def infer_bool(node, context=None):
+def infer_bool(node, context: InferenceContext | None = None):
     """Understand bool calls."""
     if len(node.args) > 1:
         # Invalid bool call.
@@ -594,7 +594,7 @@ def infer_bool(node, context=None):
     return nodes.Const(bool_value)
 
 
-def infer_type(node, context=None):
+def infer_type(node, context: InferenceContext | None = None):
     """Understand the one-argument form of *type*."""
     if len(node.args) != 1:
         raise UseInferenceDefault
@@ -602,7 +602,7 @@ def infer_type(node, context=None):
     return helpers.object_type(node.args[0], context)
 
 
-def infer_slice(node, context=None):
+def infer_slice(node, context: InferenceContext | None = None):
     """Understand `slice` calls."""
     args = node.args
     if not 0 < len(args) <= 3:
@@ -629,7 +629,7 @@ def infer_slice(node, context=None):
     return slice_node
 
 
-def _infer_object__new__decorator(node, context=None):
+def _infer_object__new__decorator(node, context: InferenceContext | None = None):
     # Instantiate class immediately
     # since that's what @object.__new__ does
     return iter((node.instantiate_class(),))
@@ -650,7 +650,7 @@ def _infer_object__new__decorator_check(node):
     return False
 
 
-def infer_issubclass(callnode, context=None):
+def infer_issubclass(callnode, context: InferenceContext | None = None):
     """Infer issubclass() calls
 
     :param nodes.Call callnode: an `issubclass` call
@@ -693,7 +693,7 @@ def infer_issubclass(callnode, context=None):
     return nodes.Const(issubclass_bool)
 
 
-def infer_isinstance(callnode, context=None):
+def infer_isinstance(callnode, context: InferenceContext | None = None):
     """Infer isinstance calls
 
     :param nodes.Call callnode: an isinstance call
@@ -732,7 +732,7 @@ def infer_isinstance(callnode, context=None):
     return nodes.Const(isinstance_bool)
 
 
-def _class_or_tuple_to_container(node, context=None):
+def _class_or_tuple_to_container(node, context: InferenceContext | None = None):
     # Move inferences results into container
     # to simplify later logic
     # raises InferenceError if any of the inferences fall through
@@ -757,7 +757,7 @@ def _class_or_tuple_to_container(node, context=None):
     return class_container
 
 
-def infer_len(node, context=None):
+def infer_len(node, context: InferenceContext | None = None):
     """Infer length calls
 
     :param nodes.Call node: len call to infer
@@ -780,7 +780,7 @@ def infer_len(node, context=None):
         raise UseInferenceDefault(str(exc)) from exc
 
 
-def infer_str(node, context=None):
+def infer_str(node, context: InferenceContext | None = None):
     """Infer str() calls
 
     :param nodes.Call node: str() call to infer
@@ -796,7 +796,7 @@ def infer_str(node, context=None):
         raise UseInferenceDefault(str(exc)) from exc
 
 
-def infer_int(node, context=None):
+def infer_int(node, context: InferenceContext | None = None):
     """Infer int() calls
 
     :param nodes.Call node: int() call to infer
@@ -828,7 +828,7 @@ def infer_int(node, context=None):
     return nodes.Const(0)
 
 
-def infer_dict_fromkeys(node, context=None):
+def infer_dict_fromkeys(node, context: InferenceContext | None = None):
     """Infer dict.fromkeys
 
     :param nodes.Call node: dict.fromkeys() call to infer

--- a/astroid/brain/brain_collections.py
+++ b/astroid/brain/brain_collections.py
@@ -2,9 +2,12 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
 from astroid.const import PY39_PLUS
+from astroid.context import InferenceContext
 from astroid.exceptions import AttributeInferenceError
 from astroid.manager import AstroidManager
 from astroid.nodes.scoped_nodes import ClassDef
@@ -106,7 +109,7 @@ def __class_getitem__(cls, item):
 """
 
 
-def easy_class_getitem_inference(node, context=None):
+def easy_class_getitem_inference(node, context: InferenceContext | None = None):
     # Here __class_getitem__ exists but is quite a mess to infer thus
     # put an easy inference tip
     func_to_add = extract_node(CLASS_GET_ITEM_TEMPLATE)

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -44,7 +44,7 @@ class LruWrappedModel(objectmodel.FunctionModel):
         )
 
         class CacheInfoBoundMethod(BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context: InferenceContext | None = None):
                 yield helpers.safe_infer(cache_info)
 
         return CacheInfoBoundMethod(proxy=self._instance, bound=self._instance)
@@ -55,7 +55,7 @@ class LruWrappedModel(objectmodel.FunctionModel):
         return BoundMethod(proxy=node, bound=self._instance.parent.scope())
 
 
-def _transform_lru_cache(node, context=None) -> None:
+def _transform_lru_cache(node, context: InferenceContext | None = None) -> None:
     # TODO: this is not ideal, since the node should be immutable,
     # but due to https://github.com/PyCQA/astroid/issues/354,
     # there's not much we can do now.

--- a/astroid/brain/brain_functools.py
+++ b/astroid/brain/brain_functools.py
@@ -44,7 +44,9 @@ class LruWrappedModel(objectmodel.FunctionModel):
         )
 
         class CacheInfoBoundMethod(BoundMethod):
-            def infer_call_result(self, caller, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller, context: InferenceContext | None = None
+            ):
                 yield helpers.safe_infer(cache_info)
 
         return CacheInfoBoundMethod(proxy=self._instance, bound=self._instance)

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -464,7 +464,7 @@ def infer_enum_class(node: nodes.ClassDef) -> nodes.ClassDef:
     return node
 
 
-def infer_typing_namedtuple_class(class_node, context=None):
+def infer_typing_namedtuple_class(class_node, context: InferenceContext | None = None):
     """Infer a subclass of typing.NamedTuple"""
     # Check if it has the corresponding bases
     annassigns_fields = [
@@ -497,7 +497,7 @@ def infer_typing_namedtuple_class(class_node, context=None):
     return iter((generated_class_node,))
 
 
-def infer_typing_namedtuple_function(node, context=None):
+def infer_typing_namedtuple_function(node, context: InferenceContext | None = None):
     """
     Starting with python3.9, NamedTuple is a function of the typing module.
     The class NamedTuple is build dynamically through a call to `type` during

--- a/astroid/brain/brain_numpy_ndarray.py
+++ b/astroid/brain/brain_numpy_ndarray.py
@@ -3,14 +3,17 @@
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 """Astroid hooks for numpy ndarray class."""
+from __future__ import annotations
+
 from astroid.brain.brain_numpy_utils import numpy_supports_type_hints
 from astroid.builder import extract_node
+from astroid.context import InferenceContext
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
 from astroid.nodes.node_classes import Attribute
 
 
-def infer_numpy_ndarray(node, context=None):
+def infer_numpy_ndarray(node, context: InferenceContext | None = None):
     ndarray = """
     class ndarray(object):
         def __init__(self, shape, dtype=float, buffer=None, offset=0,

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from astroid.builder import extract_node
+from astroid.context import InferenceContext
 from astroid.nodes.node_classes import Attribute, Import, Name, NodeNG
 
 # Class subscript is available in numpy starting with version 1.20.0
@@ -34,7 +35,7 @@ def _get_numpy_version() -> tuple[str, str, str]:
         return ("0", "0", "0")
 
 
-def infer_numpy_member(src, node, context=None):
+def infer_numpy_member(src, node, context: InferenceContext | None = None):
     node = extract_node(src)
     return node.infer(context=context)
 

--- a/astroid/brain/brain_random.py
+++ b/astroid/brain/brain_random.py
@@ -2,9 +2,12 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import random
 
 from astroid import helpers
+from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.inference_tip import inference_tip
 from astroid.manager import AstroidManager
@@ -38,7 +41,7 @@ def _clone_node_with_lineno(node, parent, lineno):
     return new_node
 
 
-def infer_random_sample(node, context=None):
+def infer_random_sample(node, context: InferenceContext | None = None):
     if len(node.args) != 2:
         raise UseInferenceDefault
 

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -20,8 +20,11 @@ Doing this type[int] is allowed whereas str[int] is not.
 Thanks to Lukasz Langa for fruitful discussion.
 """
 
+from __future__ import annotations
+
 from astroid import extract_node, inference_tip, nodes
 from astroid.const import PY39_PLUS
+from astroid.context import InferenceContext
 from astroid.exceptions import UseInferenceDefault
 from astroid.manager import AstroidManager
 
@@ -40,7 +43,7 @@ def _looks_like_type_subscript(node):
     return False
 
 
-def infer_type_sub(node, context=None):
+def infer_type_sub(node, context: InferenceContext | None = None):
     """
     Infer a type[...] subscript
 

--- a/astroid/brain/brain_type.py
+++ b/astroid/brain/brain_type.py
@@ -48,8 +48,6 @@ def infer_type_sub(node, context: InferenceContext | None = None):
 
     :param node: node to infer
     :type node: astroid.nodes.node_classes.NodeNG
-    :param context: inference context
-    :type context: astroid.context.InferenceContext
     :return: the inferred node
     :rtype: nodes.NodeNG
     """

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -278,7 +278,7 @@ def infer_typing_alias(
     try:
         res = next(node.args[0].infer(context=ctx))
     except StopIteration as e:
-        raise InferenceError(node=node.args[0], context=context) from e
+        raise InferenceError(node=node.args[0], context=ctx) from e
 
     assign_name = node.parent.targets[0]
 
@@ -359,7 +359,7 @@ def infer_special_alias(
     try:
         res = next(node.args[0].infer(context=ctx))
     except StopIteration as e:
-        raise InferenceError(node=node.args[0], context=context) from e
+        raise InferenceError(node=node.args[0], context=ctx) from e
 
     assign_name = node.parent.targets[0]
     class_def = ClassDef(

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -42,7 +42,7 @@ class InferenceContext:
 
     max_inferred = 100
 
-    def __init__(self, path=None, nodes_inferred=None):
+    def __init__(self, path: set[tuple[NodeNG, str | None]] | None=None, nodes_inferred: list[int] | None=None):
         if nodes_inferred is None:
             self._nodes_inferred = [0]
         else:
@@ -72,7 +72,7 @@ class InferenceContext:
 
         e.g. the bound node of object.__new__(cls) is the object node
         """
-        self.extra_context = {}
+        self.extra_context: dict[NodeNG, InferenceContext] = {}
         """
         :type: dict(NodeNG, Context)
 
@@ -81,7 +81,7 @@ class InferenceContext:
         """
 
     @property
-    def nodes_inferred(self):
+    def nodes_inferred(self) -> int:
         """
         Number of nodes inferred in this context and all its clones/descendents
 
@@ -91,7 +91,7 @@ class InferenceContext:
         return self._nodes_inferred[0]
 
     @nodes_inferred.setter
-    def nodes_inferred(self, value):
+    def nodes_inferred(self, value: int) -> None:
         self._nodes_inferred[0] = value
 
     @property
@@ -104,7 +104,7 @@ class InferenceContext:
         """
         return _INFERENCE_CACHE
 
-    def push(self, node):
+    def push(self, node) -> bool:
         """Push node into inference path
 
         :return: True if node is already in context path else False
@@ -174,7 +174,7 @@ def copy_context(context: InferenceContext | None) -> InferenceContext:
     return InferenceContext()
 
 
-def bind_context_to_node(context, node):
+def bind_context_to_node(context: InferenceContext | None, node) -> InferenceContext:
     """Give a context a boundnode
     to retrieve the correct function name or attribute value
     with from further inference.

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import pprint
-from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
+from typing import Any, TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     from astroid.nodes.node_classes import Keyword, NodeNG
@@ -76,7 +76,7 @@ class InferenceContext:
 
         e.g. the bound node of object.__new__(cls) is the object node
         """
-        self.extra_context: dict[NodeNG, InferenceContext] = {}
+        self.extra_context: dict[Any, InferenceContext] = {}
         """
         :type: dict(NodeNG, Context)
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -186,9 +186,6 @@ def bind_context_to_node(context: InferenceContext | None, node) -> InferenceCon
     Do not use an existing context since the boundnode could then
     be incorrectly propagated higher up in the call stack.
 
-    :param context: Context to use
-    :type context: Optional(context)
-
     :param node: Node to do name lookups from
     :type node NodeNG:
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -67,14 +67,18 @@ class InferenceContext:
         """
         self.callcontext: CallContext | None = None
         """The call arguments and keywords for the given context."""
-        self.boundnode: NodeNG | None = None
+        self.boundnode = None
         """
+        :type: optional[NodeNG]
+
         The bound node of the given context
 
         e.g. the bound node of object.__new__(cls) is the object node
         """
         self.extra_context: dict[Any, InferenceContext] = {}
         """
+        :type: dict(NodeNG, Context)
+
         Context that needs to be passed down through call stacks
         for call arguments
         """

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -44,7 +44,7 @@ class InferenceContext:
 
     def __init__(
         self,
-        path: set[tuple[NodeNG, str | None]] | None = None,
+        path: set[tuple[Any, str | None]] | None = None,
         nodes_inferred: list[int] | None = None,
     ):
         if nodes_inferred is None:

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -51,10 +51,9 @@ class InferenceContext:
             self._nodes_inferred = [0]
         else:
             self._nodes_inferred = nodes_inferred
+
         self.path = path or set()
         """
-        :type: set(tuple(NodeNG, optional(str)))
-
         Path of visited nodes and their lookupname
 
         Currently this key is ``(node, context.lookupname)``
@@ -68,18 +67,14 @@ class InferenceContext:
         """
         self.callcontext: CallContext | None = None
         """The call arguments and keywords for the given context."""
-        self.boundnode = None
+        self.boundnode: NodeNG | None = None
         """
-        :type: optional[NodeNG]
-
         The bound node of the given context
 
         e.g. the bound node of object.__new__(cls) is the object node
         """
         self.extra_context: dict[Any, InferenceContext] = {}
         """
-        :type: dict(NodeNG, Context)
-
         Context that needs to be passed down through call stacks
         for call arguments
         """
@@ -111,8 +106,7 @@ class InferenceContext:
     def push(self, node) -> bool:
         """Push node into inference path
 
-        :return: True if node is already in context path else False
-        :rtype: bool
+        :return: Whether node is already in context path.
 
         Allows one to see if the given node has already
         been looked at for this inference context"""

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -42,7 +42,11 @@ class InferenceContext:
 
     max_inferred = 100
 
-    def __init__(self, path: set[tuple[NodeNG, str | None]] | None=None, nodes_inferred: list[int] | None=None):
+    def __init__(
+        self,
+        path: set[tuple[NodeNG, str | None]] | None = None,
+        nodes_inferred: list[int] | None = None,
+    ):
         if nodes_inferred is None:
             self._nodes_inferred = [0]
         else:

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import pprint
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     from astroid.nodes.node_classes import Keyword, NodeNG
@@ -44,7 +44,7 @@ class InferenceContext:
 
     def __init__(
         self,
-        path: set[tuple[Any, str | None]] | None = None,
+        path=None,
         nodes_inferred: list[int] | None = None,
     ):
         if nodes_inferred is None:
@@ -77,7 +77,7 @@ class InferenceContext:
 
         e.g. the bound node of object.__new__(cls) is the object node
         """
-        self.extra_context: dict[Any, InferenceContext] = {}
+        self.extra_context = {}
         """
         :type: dict(NodeNG, Context)
 

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -54,6 +54,8 @@ class InferenceContext:
 
         self.path = path or set()
         """
+        :type: set(tuple(NodeNG, optional(str)))
+
         Path of visited nodes and their lookupname
 
         Currently this key is ``(node, context.lookupname)``

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -119,7 +119,7 @@ class InferenceContext:
         self.path.add((node, name))
         return False
 
-    def clone(self):
+    def clone(self) -> InferenceContext:
         """Clone inference path
 
         For example, each side of a binary operation (BinOp)

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -97,7 +97,7 @@ def path_wrapper(func):
     """
 
     @functools.wraps(func)
-    def wrapped(node, context=None, _func=func, **kwargs):
+    def wrapped(node, context: InferenceContext | None = None, _func=func, **kwargs):
         """wrapper function handling context"""
         if context is None:
             context = InferenceContext()

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -94,7 +94,7 @@ def object_type(
     return list(types)[0]
 
 
-def _object_type_is_subclass(obj_type, class_or_seq, context=None):
+def _object_type_is_subclass(obj_type, class_or_seq, context: InferenceContext | None = None):
     if not isinstance(class_or_seq, (tuple, list)):
         class_seq = (class_or_seq,)
     else:
@@ -121,7 +121,7 @@ def _object_type_is_subclass(obj_type, class_or_seq, context=None):
     return False
 
 
-def object_isinstance(node, class_or_seq, context=None):
+def object_isinstance(node, class_or_seq, context: InferenceContext | None = None):
     """Check if a node 'isinstance' any node in class_or_seq
 
     :param node: A given node
@@ -136,7 +136,7 @@ def object_isinstance(node, class_or_seq, context=None):
     return _object_type_is_subclass(obj_type, class_or_seq, context=context)
 
 
-def object_issubclass(node, class_or_seq, context=None):
+def object_issubclass(node, class_or_seq, context: InferenceContext | None = None):
     """Check if a type is a subclass of any node in class_or_seq
 
     :param node: A given node
@@ -174,7 +174,7 @@ def safe_infer(
         return value
 
 
-def has_known_bases(klass, context=None):
+def has_known_bases(klass, context: InferenceContext | None = None):
     """Return true if all base classes of a class could be inferred."""
     try:
         return klass._all_bases_known
@@ -240,7 +240,7 @@ def class_instance_as_index(node):
     return None
 
 
-def object_len(node, context=None):
+def object_len(node, context: InferenceContext | None = None):
     """Infer length of given node object
 
     :param Union[nodes.ClassDef, nodes.Instance] node:

--- a/astroid/helpers.py
+++ b/astroid/helpers.py
@@ -94,7 +94,9 @@ def object_type(
     return list(types)[0]
 
 
-def _object_type_is_subclass(obj_type, class_or_seq, context: InferenceContext | None = None):
+def _object_type_is_subclass(
+    obj_type, class_or_seq, context: InferenceContext | None = None
+):
     if not isinstance(class_or_seq, (tuple, list)):
         class_seq = (class_or_seq,)
     else:

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -87,7 +87,7 @@ nodes.Const._infer = infer_end  # type: ignore[assignment]
 nodes.Slice._infer = infer_end  # type: ignore[assignment]
 
 
-def _infer_sequence_helper(node, context=None):
+def _infer_sequence_helper(node, context: InferenceContext | None = None):
     """Infer all values based on _BaseContainer.elts"""
     values = []
 

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -340,7 +340,7 @@ class FunctionModel(ObjectModel):
                 # is different.
                 return 0
 
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context: InferenceContext | None = None):
                 if len(caller.args) > 2 or len(caller.args) < 1:
                     raise InferenceError(
                         "Invalid arguments for descriptor binding",
@@ -486,7 +486,7 @@ class ClassModel(ObjectModel):
         # Cls.mro is a method and we need to return one in order to have a proper inference.
         # The method we're returning is capable of inferring the underlying MRO though.
         class MroBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context: InferenceContext | None = None):
                 yield other_self.attr___mro__
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -532,7 +532,7 @@ class ClassModel(ObjectModel):
         obj.postinit(classes)
 
         class SubclassesBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context: InferenceContext | None = None):
                 yield obj
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -794,7 +794,7 @@ class DictModel(ObjectModel):
         """Generate a bound method that can infer the given *obj*."""
 
         class DictMethodBoundMethod(astroid.BoundMethod):
-            def infer_call_result(self, caller, context=None):
+            def infer_call_result(self, caller, context: InferenceContext | None = None):
                 yield obj
 
         meth = next(self._instance._proxied.igetattr(name), None)
@@ -859,7 +859,7 @@ class PropertyModel(ObjectModel):
         func = self._instance
 
         class PropertyFuncAccessor(nodes.FunctionDef):
-            def infer_call_result(self, caller=None, context=None):
+            def infer_call_result(self, caller=None, context: InferenceContext | None = None):
                 nonlocal func
                 if caller and len(caller.args) != 1:
                     raise InferenceError(
@@ -900,7 +900,7 @@ class PropertyModel(ObjectModel):
             )
 
         class PropertyFuncAccessor(nodes.FunctionDef):
-            def infer_call_result(self, caller=None, context=None):
+            def infer_call_result(self, caller=None, context: InferenceContext | None = None):
                 nonlocal func_setter
                 if caller and len(caller.args) != 2:
                     raise InferenceError(

--- a/astroid/interpreter/objectmodel.py
+++ b/astroid/interpreter/objectmodel.py
@@ -340,7 +340,9 @@ class FunctionModel(ObjectModel):
                 # is different.
                 return 0
 
-            def infer_call_result(self, caller, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller, context: InferenceContext | None = None
+            ):
                 if len(caller.args) > 2 or len(caller.args) < 1:
                     raise InferenceError(
                         "Invalid arguments for descriptor binding",
@@ -486,7 +488,9 @@ class ClassModel(ObjectModel):
         # Cls.mro is a method and we need to return one in order to have a proper inference.
         # The method we're returning is capable of inferring the underlying MRO though.
         class MroBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller, context: InferenceContext | None = None
+            ):
                 yield other_self.attr___mro__
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -532,7 +536,9 @@ class ClassModel(ObjectModel):
         obj.postinit(classes)
 
         class SubclassesBoundMethod(bases.BoundMethod):
-            def infer_call_result(self, caller, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller, context: InferenceContext | None = None
+            ):
                 yield obj
 
         implicit_metaclass = self._instance.implicit_metaclass()
@@ -794,7 +800,9 @@ class DictModel(ObjectModel):
         """Generate a bound method that can infer the given *obj*."""
 
         class DictMethodBoundMethod(astroid.BoundMethod):
-            def infer_call_result(self, caller, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller, context: InferenceContext | None = None
+            ):
                 yield obj
 
         meth = next(self._instance._proxied.igetattr(name), None)
@@ -859,7 +867,9 @@ class PropertyModel(ObjectModel):
         func = self._instance
 
         class PropertyFuncAccessor(nodes.FunctionDef):
-            def infer_call_result(self, caller=None, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller=None, context: InferenceContext | None = None
+            ):
                 nonlocal func
                 if caller and len(caller.args) != 1:
                     raise InferenceError(
@@ -900,7 +910,9 @@ class PropertyModel(ObjectModel):
             )
 
         class PropertyFuncAccessor(nodes.FunctionDef):
-            def infer_call_result(self, caller=None, context: InferenceContext | None = None):
+            def infer_call_result(
+                self, caller=None, context: InferenceContext | None = None
+            ):
                 nonlocal func_setter
                 if caller and len(caller.args) != 2:
                     raise InferenceError(

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -82,7 +82,7 @@ InferUnaryOp = Callable[[_NodesT, str], ConstFactoryResult]
 
 
 @decorators.raise_if_nothing_inferred
-def unpack_infer(stmt, context=None):
+def unpack_infer(stmt, context: InferenceContext | None = None):
     """recursively generate nodes inferred by the given statement.
     If the inferred value is a list or a tuple, recurse on the elements
     """
@@ -182,7 +182,7 @@ def are_exclusive(stmt1, stmt2, exceptions: list[str] | None = None) -> bool:
 _SLICE_SENTINEL = object()
 
 
-def _slice_value(index, context=None):
+def _slice_value(index, context: InferenceContext | None = None):
     """Get the value of the given slice index."""
 
     if isinstance(index, Const):
@@ -209,7 +209,7 @@ def _slice_value(index, context=None):
     return _SLICE_SENTINEL
 
 
-def _infer_slice(node, context=None):
+def _infer_slice(node, context: InferenceContext | None = None):
     lower = _slice_value(node.lower, context)
     upper = _slice_value(node.upper, context)
     step = _slice_value(node.step, context)
@@ -224,7 +224,7 @@ def _infer_slice(node, context=None):
     )
 
 
-def _container_getitem(instance, elts, index, context=None):
+def _container_getitem(instance, elts, index, context: InferenceContext | None = None):
     """Get a slice or an item, using the given *index*, for the given sequence."""
     try:
         if isinstance(index, Slice):
@@ -327,7 +327,7 @@ class BaseContainer(_base_nodes.ParentAssignNode, Instance, metaclass=abc.ABCMet
         """
         return self.elts
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -1447,7 +1447,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         InferBinaryOperation[AugAssign, util.BadBinaryOperationMessage]
     ]
 
-    def type_errors(self, context=None):
+    def type_errors(self, context: InferenceContext | None = None):
         """Get a list of type errors which can occur during inference.
 
         Each TypeError is represented by a :class:`BadBinaryOperationMessage` ,
@@ -1546,7 +1546,7 @@ class BinOp(NodeNG):
     # This is set by inference.py
     _infer_binop: ClassVar[InferBinaryOperation[BinOp, util.BadBinaryOperationMessage]]
 
-    def type_errors(self, context=None):
+    def type_errors(self, context: InferenceContext | None = None):
         """Get a list of type errors which can occur during inference.
 
         Each TypeError is represented by a :class:`BadBinaryOperationMessage`,
@@ -2016,7 +2016,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
             raise AttributeError
         return super().__getattr__(name)
 
-    def getitem(self, index, context=None):
+    def getitem(self, index, context: InferenceContext | None = None):
         """Get an item from this node if subscriptable.
 
         :param index: The node to use as a subscript index.
@@ -2085,7 +2085,7 @@ class Const(_base_nodes.NoChildrenNode, Instance):
         """
         return self._proxied.qname()
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -2467,7 +2467,7 @@ class Dict(NodeNG, Instance):
 
         raise AstroidIndexError(index)
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -3502,7 +3502,7 @@ class List(BaseContainer):
         """
         return "builtins.list"
 
-    def getitem(self, index, context=None):
+    def getitem(self, index, context: InferenceContext | None = None):
         """Get an item from this node.
 
         :param index: The node to use as a subscript index.
@@ -3830,7 +3830,7 @@ class Slice(NodeNG):
         """
         return "builtins.slice"
 
-    def igetattr(self, attrname, context=None):
+    def igetattr(self, attrname, context: InferenceContext | None = None):
         """Infer the possible values of the given attribute on the slice.
 
         :param attrname: The name of the attribute to infer.
@@ -3848,7 +3848,7 @@ class Slice(NodeNG):
         else:
             yield from self.getattr(attrname, context=context)
 
-    def getattr(self, attrname, context=None):
+    def getattr(self, attrname, context: InferenceContext | None = None):
         return self._proxied.getattr(attrname, context)
 
     def get_children(self):
@@ -4267,7 +4267,7 @@ class Tuple(BaseContainer):
         """
         return "builtins.tuple"
 
-    def getitem(self, index, context=None):
+    def getitem(self, index, context: InferenceContext | None = None):
         """Get an item from this node.
 
         :param index: The node to use as a subscript index.
@@ -4340,7 +4340,7 @@ class UnaryOp(NodeNG):
         InferBinaryOperation[UnaryOp, util.BadUnaryOperationMessage]
     ]
 
-    def type_errors(self, context=None):
+    def type_errors(self, context: InferenceContext | None = None):
         """Get a list of type errors which can occur during inference.
 
         Each TypeError is represented by a :class:`BadBinaryOperationMessage`,
@@ -4934,7 +4934,7 @@ class Unknown(_base_nodes.AssignTypeNode):
     def qname(self) -> Literal["Unknown"]:
         return "Unknown"
 
-    def _infer(self, context=None, **kwargs):
+    def _infer(self, context: InferenceContext | None = None, **kwargs):
         """Inference on an Unknown node immediately terminates."""
         yield util.Uninferable
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -782,7 +782,7 @@ class NodeNG:
         _repr_tree(self, result, set())
         return "".join(result)
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         The boolean value of a node can have three

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -393,7 +393,7 @@ class Module(LocalsDictNodeNG):
         """
         return "Module"
 
-    def getattr(self, name, context=None, ignore_locals=False):
+    def getattr(self, name, context: InferenceContext | None = None, ignore_locals=False):
         if not name:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 
@@ -416,7 +416,7 @@ class Module(LocalsDictNodeNG):
             return result
         raise AttributeInferenceError(target=self, attribute=name, context=context)
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context: InferenceContext | None = None):
         """Infer the possible values of the given variable.
 
         :param name: The name of the variable to infer.
@@ -641,7 +641,7 @@ class Module(LocalsDictNodeNG):
         """
         return [name for name in self.keys() if not name.startswith("_")]
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -733,7 +733,7 @@ class GeneratorExp(ComprehensionScope):
         else:
             self.generators = generators
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -831,7 +831,7 @@ class DictComp(ComprehensionScope):
         else:
             self.generators = generators
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -916,7 +916,7 @@ class SetComp(ComprehensionScope):
         else:
             self.generators = generators
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -984,7 +984,7 @@ class ListComp(ComprehensionScope):
         else:
             self.generators = generators
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -1174,7 +1174,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
             names.append(self.args.kwarg)
         return names
 
-    def infer_call_result(self, caller, context=None):
+    def infer_call_result(self, caller, context: InferenceContext | None = None):
         """Infer what the function returns when called.
 
         :param caller: Unused
@@ -1213,7 +1213,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
             frame = self
         return frame._scope_lookup(node, name, offset)
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -1565,7 +1565,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         """
         return self.fromlineno, self.tolineno
 
-    def igetattr(self, name, context=None):
+    def igetattr(self, name, context: InferenceContext | None = None):
         """Inferred getattr, which returns an iterator of inferred statements."""
         try:
             return bases._infer_stmts(self.getattr(name, context), context, frame=self)
@@ -1587,7 +1587,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         )
 
     @decorators_mod.cached
-    def decoratornames(self, context=None):
+    def decoratornames(self, context: InferenceContext | None = None):
         """Get the qualified names of each of the decorators on this function.
 
         :param context:
@@ -1660,7 +1660,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         """
         return bool(next(self._get_yield_nodes_skip_lambdas(), False))
 
-    def infer_yield_result(self, context=None):
+    def infer_yield_result(self, context: InferenceContext | None = None):
         """Infer what the function yields when called
 
         :returns: What the function yields
@@ -1677,7 +1677,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
             elif yield_.scope() == self:
                 yield from yield_.value.infer(context=context)
 
-    def infer_call_result(self, caller=None, context=None):
+    def infer_call_result(self, caller=None, context: InferenceContext | None = None):
         """Infer what the function returns when called.
 
         :returns: What the function returns.
@@ -1741,7 +1741,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
                 except InferenceError:
                     yield util.Uninferable
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.
@@ -2118,7 +2118,7 @@ class ClassDef(
         if doc_node:
             self._doc = doc_node.value
 
-    def _newstyle_impl(self, context=None):
+    def _newstyle_impl(self, context: InferenceContext | None = None):
         if context is None:
             context = InferenceContext()
         if self._newstyle is not None:
@@ -2206,7 +2206,7 @@ class ClassDef(
         """
         return True
 
-    def is_subtype_of(self, type_name, context=None):
+    def is_subtype_of(self, type_name, context: InferenceContext | None = None):
         """Whether this class is a subtype of the given type.
 
         :param type_name: The name of the type of check against.
@@ -2269,7 +2269,7 @@ class ClassDef(
         result.parent = caller.parent
         return result
 
-    def infer_call_result(self, caller, context=None):
+    def infer_call_result(self, caller, context: InferenceContext | None = None):
         """infer what a class is returning when called"""
         if self.is_subtype_of("builtins.type", context) and len(caller.args) == 3:
             result = self._infer_type_call(caller, context)
@@ -2404,7 +2404,7 @@ class ClassDef(
                 except InferenceError:
                     continue
 
-    def local_attr_ancestors(self, name, context=None):
+    def local_attr_ancestors(self, name, context: InferenceContext | None = None):
         """Iterate over the parents that define the given name.
 
         :param name: The name to find definitions for.
@@ -2425,7 +2425,7 @@ class ClassDef(
             if name in astroid:
                 yield astroid
 
-    def instance_attr_ancestors(self, name, context=None):
+    def instance_attr_ancestors(self, name, context: InferenceContext | None = None):
         """Iterate over the parents that define the given name as an attribute.
 
         :param name: The name to find definitions for.
@@ -2450,7 +2450,7 @@ class ClassDef(
         """
         return node in self.bases
 
-    def local_attr(self, name, context=None):
+    def local_attr(self, name, context: InferenceContext | None = None):
         """Get the list of assign nodes associated to the given name.
 
         Assignments are looked for in both this class and in parents.
@@ -2473,7 +2473,7 @@ class ClassDef(
             return result
         raise AttributeInferenceError(target=self, attribute=name, context=context)
 
-    def instance_attr(self, name, context=None):
+    def instance_attr(self, name, context: InferenceContext | None = None):
         """Get the list of nodes associated to the given attribute name.
 
         Assignments are looked for in both this class and in parents.
@@ -2680,7 +2680,7 @@ class ClassDef(
                     str(error), target=self, attribute=name, context=context
                 ) from error
 
-    def has_dynamic_getattr(self, context=None):
+    def has_dynamic_getattr(self, context: InferenceContext | None = None):
         """Check if the class has a custom __getattr__ or __getattribute__.
 
         If any such method is found and it is not from
@@ -2707,7 +2707,7 @@ class ClassDef(
                 pass
         return False
 
-    def getitem(self, index, context=None):
+    def getitem(self, index, context: InferenceContext | None = None):
         """Return the inference of a subscript.
 
         This is basically looking up the method in the metaclass and calling it.
@@ -2980,7 +2980,7 @@ class ClassDef(
 
         return sorted(set(slots), key=lambda item: item.value)
 
-    def _inferred_bases(self, context=None):
+    def _inferred_bases(self, context: InferenceContext | None = None):
         # Similar with .ancestors, but the difference is when one base is inferred,
         # only the first object is wanted. That's because
         # we aren't interested in superclasses, as in the following
@@ -3019,7 +3019,7 @@ class ClassDef(
             else:
                 yield from baseobj.bases
 
-    def _compute_mro(self, context=None):
+    def _compute_mro(self, context: InferenceContext | None = None):
         inferred_bases = list(self._inferred_bases(context=context))
         bases_mro = []
         for base in inferred_bases:
@@ -3043,7 +3043,7 @@ class ClassDef(
         clean_typing_generic_mro(unmerged_mro)
         return _c3_merge(unmerged_mro, self, context)
 
-    def mro(self, context=None) -> list[ClassDef]:
+    def mro(self, context: InferenceContext | None = None) -> list[ClassDef]:
         """Get the method resolution order, using C3 linearization.
 
         :returns: The list of ancestors, sorted by the mro.
@@ -3053,7 +3053,7 @@ class ClassDef(
         """
         return self._compute_mro(context=context)
 
-    def bool_value(self, context=None):
+    def bool_value(self, context: InferenceContext | None = None):
         """Determine the boolean value of this node.
 
         :returns: The boolean value of this node.

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -393,7 +393,9 @@ class Module(LocalsDictNodeNG):
         """
         return "Module"
 
-    def getattr(self, name, context: InferenceContext | None = None, ignore_locals=False):
+    def getattr(
+        self, name, context: InferenceContext | None = None, ignore_locals=False
+    ):
         if not name:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 

--- a/astroid/objects.py
+++ b/astroid/objects.py
@@ -47,7 +47,7 @@ class FrozenSet(node_classes.BaseContainer):
     def pytype(self) -> Literal["builtins.frozenset"]:
         return "builtins.frozenset"
 
-    def _infer(self, context=None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
         yield self
 
     @cached_property
@@ -80,7 +80,7 @@ class Super(node_classes.NodeNG):
         self._scope = scope
         super().__init__()
 
-    def _infer(self, context=None, **kwargs: Any):
+    def _infer(self, context: InferenceContext | None = None, **kwargs: Any):
         yield self
 
     def super_mro(self):
@@ -220,7 +220,7 @@ class Super(node_classes.NodeNG):
         if not found:
             raise AttributeInferenceError(target=self, attribute=name, context=context)
 
-    def getattr(self, name, context=None):
+    def getattr(self, name, context: InferenceContext | None = None):
         return list(self.igetattr(name, context=context))
 
 
@@ -298,7 +298,7 @@ class PartialFunction(scoped_nodes.FunctionDef):
 
         self.filled_positionals = len(self.filled_args)
 
-    def infer_call_result(self, caller=None, context=None):
+    def infer_call_result(self, caller=None, context: InferenceContext | None = None):
         if context:
             current_passed_keywords = {
                 keyword for (keyword, _) in context.callcontext.keywords
@@ -340,7 +340,7 @@ class Property(scoped_nodes.FunctionDef):
     def pytype(self) -> Literal["builtins.property"]:
         return "builtins.property"
 
-    def infer_call_result(self, caller=None, context=None):
+    def infer_call_result(self, caller=None, context: InferenceContext | None = None):
         raise InferenceError("Properties are not callable")
 
     def _infer(

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 black==22.10.0
-pylint==2.15.5
+pylint==2.15.6
 isort==5.10.1
 flake8==5.0.4
 flake8-typing-imports==1.14.0


### PR DESCRIPTION
## Description

Add type annotations pertaining to inference contexts.

1. The file `context.py` is mostly typed.
2. Most if not all inference context args are annotated.
3. Two minor code errors exposed by the type checker are fixed.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Related Issue

This fixes a code error. I don't know if it was associated with any known bug.