### PR TITLE
Allow untyped decorators in mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ no_implicit_optional = true
 scripts_are_modules = true
 show_error_codes = true
 warn_redundant_casts = true
+allow_untyped_decorators = true
+strict = true
 
 [[tool.mypy.overrides]]
 # Importlib typeshed stubs do not include the private functions we use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ scripts_are_modules = true
 show_error_codes = true
 warn_redundant_casts = true
 allow_untyped_decorators = true
-strict = true
 
 [[tool.mypy.overrides]]
 # Importlib typeshed stubs do not include the private functions we use


### PR DESCRIPTION
These are the settings I've been using for adding types. Obviously we're far from getting it to pass with strict settings, but strict makes it easier to see what is unannotated.

For me at least, adding types to decorators is totally unfeasible right now, so those should be allowed for the time being.