### PR TITLE
Mandatory fields

### DIFF
--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1670,47 +1670,17 @@ class Compare(NodeNG):
     [('<=', <Name.b l.1 at 0x7f23b2e9e2b0>), ('<=', <Name.c l.1 at 0x7f23b2e9e390>)]
     """
 
+    left: NodeNG
+    """The value at the left being applied to a comparison operator."""
+
+    ops: list[tuple[str, NodeNG]]
+    """The remainder of the operators and their relevant right hand value."""
+
     _astroid_fields = ("left", "ops")
-
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.left: NodeNG | None = None
-        """The value at the left being applied to a comparison operator."""
-
-        self.ops: list[tuple[str, NodeNG]] = []
-        """The remainder of the operators and their relevant right hand value."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
 
     def postinit(
         self,
-        left: NodeNG | None = None,
+        left: NodeNG,
         ops: list[tuple[str, NodeNG]] | None = None,
     ) -> None:
         """Do some setup after initialisation.
@@ -1722,8 +1692,7 @@ class Compare(NodeNG):
             and their relevant right hand value.
         """
         self.left = left
-        if ops is not None:
-            self.ops = ops
+        self.ops = ops or []
 
     def get_children(self):
         """Get the child nodes below this node.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2907,9 +2907,6 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     orelse: list[NodeNG]
     """The contents of the ``else`` block."""
 
-    is_orelse: bool
-    """Whether the if-statement is the orelse-block of another if statement."""
-
     _astroid_fields = ("test", "body", "orelse")
     _multi_line_block_fields = ("body", "orelse")
 
@@ -2930,7 +2927,11 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         self.test = test
         self.body = body or []
         self.orelse = orelse or []
-        self.is_orelse = isinstance(self.parent, If) and self in self.parent.orelse
+
+    @cached_property
+    def is_orelse(self) -> bool:
+        """Whether the if-statement is the orelse-block of another if statement."""
+        return isinstance(self.parent, If) and self in self.parent.orelse
 
     @cached_property
     def blockstart_tolineno(self):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2865,6 +2865,15 @@ class ImportFrom(_base_nodes.ImportNode):
 class Attribute(NodeNG):
     """Class representing an :class:`ast.Attribute` node."""
 
+    expr: NodeNG
+    """The name that this node represents.
+
+    :type: Name or None
+    """
+
+    attrname: str | None
+    """The name of the attribute."""
+
     _astroid_fields = ("expr",)
     _other_fields = ("attrname",)
 
@@ -2894,14 +2903,7 @@ class Attribute(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.expr: NodeNG | None = None
-        """The name that this node represents.
-
-        :type: Name or None
-        """
-
-        self.attrname: str | None = attrname
-        """The name of the attribute."""
+        self.attrname = attrname
 
         super().__init__(
             lineno=lineno,
@@ -2911,7 +2913,7 @@ class Attribute(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, expr: NodeNG | None = None) -> None:
+    def postinit(self, expr: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param expr: The name that this node represents.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2706,62 +2706,32 @@ class For(
     _other_other_fields = ("type_annotation",)
     _multi_line_block_fields = ("body", "orelse")
 
+    target: NodeNG
+    """What the loop assigns to."""
+
+    iter: NodeNG
+    """What the loop iterates over."""
+
+    body: list[NodeNG]
+    """The contents of the body of the loop."""
+
+    orelse: list[NodeNG]
+    """The contents of the ``else`` block of the loop."""
+
+    type_annotation: NodeNG | None
+    """If present, this will contain the type annotation passed by a type comment"""
+
     optional_assign = True
     """Whether this node optionally assigns a variable.
 
     This is always ``True`` for :class:`For` nodes.
     """
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.target: NodeNG | None = None
-        """What the loop assigns to."""
-
-        self.iter: NodeNG | None = None
-        """What the loop iterates over."""
-
-        self.body: list[NodeNG] = []
-        """The contents of the body of the loop."""
-
-        self.orelse: list[NodeNG] = []
-        """The contents of the ``else`` block of the loop."""
-
-        self.type_annotation: NodeNG | None = None  # can be None
-        """If present, this will contain the type annotation passed by a type comment"""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
-
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
     def postinit(
         self,
-        target: NodeNG | None = None,
-        iter: NodeNG | None = None,
+        target: NodeNG,
+        iter: NodeNG,
         body: list[NodeNG] | None = None,
         orelse: list[NodeNG] | None = None,
         type_annotation: NodeNG | None = None,
@@ -2778,10 +2748,8 @@ class For(
         """
         self.target = target
         self.iter = iter
-        if body is not None:
-            self.body = body
-        if orelse is not None:
-            self.orelse = orelse
+        self.body = body or []
+        self.orelse = orelse or []
         self.type_annotation = type_annotation
 
     assigned_stmts: ClassVar[AssignedStmtsCall[For]]
@@ -2790,11 +2758,8 @@ class For(
     """
 
     @cached_property
-    def blockstart_tolineno(self):
-        """The line on which the beginning of this block ends.
-
-        :type: int
-        """
+    def blockstart_tolineno(self) -> int:
+        """The line on which the beginning of this block ends."""
         return self.iter.tolineno
 
     def get_children(self):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1131,43 +1131,13 @@ class Assert(_base_nodes.Statement):
 
     _astroid_fields = ("test", "fail")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    test: NodeNG
+    """The test that passes or fails the assertion."""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
+    fail: NodeNG | None
+    """The message shown when the assertion fails."""
 
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.test: NodeNG | None = None
-        """The test that passes or fails the assertion."""
-
-        self.fail: NodeNG | None = None  # can be None
-        """The message shown when the assertion fails."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
-
-    def postinit(self, test: NodeNG | None = None, fail: NodeNG | None = None) -> None:
+    def postinit(self, test: NodeNG, fail: NodeNG | None = None) -> None:
         """Do some setup after initialisation.
 
         :param test: The test that passes or fails the assertion.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4188,13 +4188,19 @@ class UnaryOp(NodeNG):
     <UnaryOp l.1 at 0x7f23b2e4e198>
     """
 
+    op: str
+    """The operator."""
+
+    operand: NodeNG
+    """What the unary operator is applied to."""
+
     _astroid_fields = ("operand",)
     _other_fields = ("op",)
 
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: str | None = None,
+        op: str,
         lineno: int | None = None,
         col_offset: int | None = None,
         parent: NodeNG | None = None,
@@ -4217,11 +4223,8 @@ class UnaryOp(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.op: str | None = op
-        """The operator."""
 
-        self.operand: NodeNG | None = None
-        """What the unary operator is applied to."""
+        self.op = op
 
         super().__init__(
             lineno=lineno,
@@ -4231,7 +4234,7 @@ class UnaryOp(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, operand: NodeNG | None = None) -> None:
+    def postinit(self, operand: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param operand: What the unary operator is applied to.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2082,46 +2082,11 @@ class Delete(_base_nodes.AssignTypeNode, _base_nodes.Statement):
 
     _astroid_fields = ("targets",)
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.targets: list[NodeNG] = []
-        """What is being deleted."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    targets: list[NodeNG]
+    """What is being deleted."""
 
     def postinit(self, targets: list[NodeNG] | None = None) -> None:
-        """Do some setup after initialisation.
-
-        :param targets: What is being deleted.
-        """
-        if targets is not None:
-            self.targets = targets
+        self.targets = targets or []
 
     def get_children(self):
         yield from self.targets

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3628,57 +3628,19 @@ class TryFinally(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     _astroid_fields = ("body", "finalbody")
     _multi_line_block_fields = ("body", "finalbody")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    body: list[NodeNG | TryExcept]
+    """The try-except that the finally is attached to."""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.body: list[NodeNG | TryExcept] = []
-        """The try-except that the finally is attached to."""
-
-        self.finalbody: list[NodeNG] = []
-        """The contents of the ``finally`` block."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    finalbody: list[NodeNG]
+    """The contents of the ``finally`` block."""
 
     def postinit(
         self,
         body: list[NodeNG | TryExcept] | None = None,
         finalbody: list[NodeNG] | None = None,
     ) -> None:
-        """Do some setup after initialisation.
-
-        :param body: The try-except that the finally is attached to.
-
-        :param finalbody: The contents of the ``finally`` block.
-        """
-        if body is not None:
-            self.body = body
-        if finalbody is not None:
-            self.finalbody = finalbody
+        self.body = body or []
+        self.finalbody = finalbody or []
 
     def block_range(self, lineno):
         """Get a range from the given line number to where this node ends.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1055,6 +1055,12 @@ class AssignAttr(_base_nodes.ParentAssignNode):
     'self.attribute'
     """
 
+    expr: NodeNG
+    """What has the attribute that is being assigned to."""
+
+    attrname: str
+    """The name of the attribute being assigned to."""
+
     _astroid_fields = ("expr",)
     _other_fields = ("attrname",)
 
@@ -1063,7 +1069,7 @@ class AssignAttr(_base_nodes.ParentAssignNode):
     @decorators.deprecate_default_argument_values(attrname="str")
     def __init__(
         self,
-        attrname: str | None = None,
+        attrname: str,
         lineno: int | None = None,
         col_offset: int | None = None,
         parent: NodeNG | None = None,
@@ -1086,11 +1092,7 @@ class AssignAttr(_base_nodes.ParentAssignNode):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.expr: NodeNG | None = None
-        """What has the attribute that is being assigned to."""
-
-        self.attrname: str | None = attrname
-        """The name of the attribute being assigned to."""
+        self.attrname = attrname
 
         super().__init__(
             lineno=lineno,
@@ -1100,7 +1102,7 @@ class AssignAttr(_base_nodes.ParentAssignNode):
             parent=parent,
         )
 
-    def postinit(self, expr: NodeNG | None = None) -> None:
+    def postinit(self, expr: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param expr: What has the attribute that is being assigned to.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3773,6 +3773,9 @@ class Starred(_base_nodes.ParentAssignNode):
     <Starred l.1 at 0x7f23b2e41978>
     """
 
+    value: NodeNG
+    """What is being unpacked."""
+
     _astroid_fields = ("value",)
     _other_fields = ("ctx",)
 
@@ -3801,9 +3804,6 @@ class Starred(_base_nodes.ParentAssignNode):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: NodeNG | None = None
-        """What is being unpacked."""
-
         self.ctx: Context | None = ctx
         """Whether the starred item is assigned to or loaded from."""
 
@@ -3815,7 +3815,7 @@ class Starred(_base_nodes.ParentAssignNode):
             parent=parent,
         )
 
-    def postinit(self, value: NodeNG | None = None) -> None:
+    def postinit(self, value: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param value: What is being unpacked.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4251,44 +4251,11 @@ class NamedExpr(_base_nodes.AssignTypeNode):
 
     Since NamedExpr are not always called they do not always assign."""
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    target: NodeNG
+    """The assignment target"""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.target: NodeNG
-        """The assignment target
-
-        :type: Name
-        """
-
-        self.value: NodeNG
-        """The value that gets assigned in the expression"""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    value: NodeNG
+    """The value that gets assigned in the expression"""
 
     def postinit(self, target: NodeNG, value: NodeNG) -> None:
         self.target = target

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2332,52 +2332,30 @@ class ExceptHandler(
     _astroid_fields = ("type", "name", "body")
     _multi_line_block_fields = ("body",)
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    type: NodeNG | None
+    """The types that the block handles."""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
+    name: AssignName | None
+    """The name that the caught exception is assigned to."""
 
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.type: NodeNG | None = None  # can be None
-        """The types that the block handles.
-
-        :type: Tuple or NodeNG or None
-        """
-
-        self.name: AssignName | None = None  # can be None
-        """The name that the caught exception is assigned to."""
-
-        self.body: list[NodeNG] = []
-        """The contents of the block."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    body: list[NodeNG]
+    """The contents of the block."""
 
     assigned_stmts: ClassVar[AssignedStmtsCall[ExceptHandler]]
     """Returns the assigned statement (non inferred) according to the assignment type.
     See astroid/protocols.py for actual implementation.
     """
+
+    # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
+    def postinit(
+        self,
+        type: NodeNG | None = None,
+        name: AssignName | None = None,
+        body: list[NodeNG] | None = None,
+    ) -> None:
+        self.type = type
+        self.name = name
+        self.body = body or []
 
     def get_children(self):
         if self.type is not None:
@@ -2387,27 +2365,6 @@ class ExceptHandler(
             yield self.name
 
         yield from self.body
-
-    # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
-    def postinit(
-        self,
-        type: NodeNG | None = None,
-        name: AssignName | None = None,
-        body: list[NodeNG] | None = None,
-    ) -> None:
-        """Do some setup after initialisation.
-
-        :param type: The types that the block handles.
-        :type type: Tuple or NodeNG or None
-
-        :param name: The name that the caught exception is assigned to.
-
-        :param body:The contents of the block.
-        """
-        self.type = type
-        self.name = name
-        if body is not None:
-            self.body = body
 
     @cached_property
     def blockstart_tolineno(self):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4315,51 +4315,21 @@ class While(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     <While l.2 at 0x7f23b2e4e390>
     """
 
+    test: NodeNG
+    """The condition that the loop tests."""
+
+    body: list[NodeNG]
+    """The contents of the loop."""
+
+    orelse: list[NodeNG]
+    """The contents of the ``else`` block."""
+
     _astroid_fields = ("test", "body", "orelse")
     _multi_line_block_fields = ("body", "orelse")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.test: NodeNG | None = None
-        """The condition that the loop tests."""
-
-        self.body: list[NodeNG] = []
-        """The contents of the loop."""
-
-        self.orelse: list[NodeNG] = []
-        """The contents of the ``else`` block."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
-
     def postinit(
         self,
-        test: NodeNG | None = None,
+        test: NodeNG,
         body: list[NodeNG] | None = None,
         orelse: list[NodeNG] | None = None,
     ) -> None:
@@ -4372,10 +4342,8 @@ class While(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         :param orelse: The contents of the ``else`` block.
         """
         self.test = test
-        if body is not None:
-            self.body = body
-        if orelse is not None:
-            self.orelse = orelse
+        self.body = body or []
+        self.orelse = orelse or []
 
     @cached_property
     def blockstart_tolineno(self):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1972,41 +1972,8 @@ class Decorators(NodeNG):
 
     _astroid_fields = ("nodes",)
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.nodes: list[NodeNG]
-        """The decorators that this node contains.
-
-        :type: list(Name or Call) or None
-        """
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    nodes: list[NodeNG]
+    """The decorators that this node contains."""
 
     def postinit(self, nodes: list[NodeNG]) -> None:
         """Do some setup after initialisation.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3761,6 +3761,15 @@ class Subscript(NodeNG):
 
     infer_lhs: ClassVar[InferLHS[Subscript]]
 
+    value: NodeNG
+    """What is being indexed."""
+
+    slice: NodeNG
+    """The slice being used to lookup."""
+
+    ctx: Context | None
+    """Whether the subscripted item is assigned to or loaded from."""
+
     def __init__(
         self,
         ctx: Context | None = None,
@@ -3786,14 +3795,7 @@ class Subscript(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.value: NodeNG | None = None
-        """What is being indexed."""
-
-        self.slice: NodeNG | None = None
-        """The slice being used to lookup."""
-
-        self.ctx: Context | None = ctx
-        """Whether the subscripted item is assigned to or loaded from."""
+        self.ctx = ctx
 
         super().__init__(
             lineno=lineno,
@@ -3804,9 +3806,7 @@ class Subscript(NodeNG):
         )
 
     # pylint: disable=redefined-builtin; had to use the same name as builtin ast module.
-    def postinit(
-        self, value: NodeNG | None = None, slice: NodeNG | None = None
-    ) -> None:
+    def postinit(self, value: NodeNG, slice: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param value: What is being indexed.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3596,44 +3596,14 @@ class TryExcept(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     _astroid_fields = ("body", "handlers", "orelse")
     _multi_line_block_fields = ("body", "handlers", "orelse")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    body: list[NodeNG]
+    """The contents of the block to catch exceptions from."""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
+    handlers: list[ExceptHandler]
+    """The exception handlers."""
 
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.body: list[NodeNG] = []
-        """The contents of the block to catch exceptions from."""
-
-        self.handlers: list[ExceptHandler] = []
-        """The exception handlers."""
-
-        self.orelse: list[NodeNG] = []
-        """The contents of the ``else`` block."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    orelse: list[NodeNG]
+    """The contents of the ``else`` block."""
 
     def postinit(
         self,
@@ -3641,20 +3611,9 @@ class TryExcept(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         handlers: list[ExceptHandler] | None = None,
         orelse: list[NodeNG] | None = None,
     ) -> None:
-        """Do some setup after initialisation.
-
-        :param body: The contents of the block to catch exceptions from.
-
-        :param handlers: The exception handlers.
-
-        :param orelse: The contents of the ``else`` block.
-        """
-        if body is not None:
-            self.body = body
-        if handlers is not None:
-            self.handlers = handlers
-        if orelse is not None:
-            self.orelse = orelse
+        self.body = body or []
+        self.handlers = handlers or []
+        self.orelse = orelse or []
 
     def _infer_name(self, frame, name):
         return name

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4391,24 +4391,8 @@ class Match(_base_nodes.Statement):
 
     _astroid_fields = ("subject", "cases")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        self.subject: NodeNG
-        self.cases: list[MatchCase]
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    subject: NodeNG
+    cases: list[MatchCase]
 
     def postinit(
         self,

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1732,6 +1732,18 @@ class Comprehension(NodeNG):
     'for x in some_values'
     """
 
+    target: NodeNG
+    """What is assigned to by the comprehension."""
+
+    iter: NodeNG
+    """What is iterated over by the comprehension."""
+
+    ifs: list[NodeNG]
+    """The contents of any if statements that filter the comprehension."""
+
+    is_async: bool
+    """Whether this is an asynchronous comprehension or not."""
+
     _astroid_fields = ("target", "iter", "ifs")
     _other_fields = ("is_async",)
 
@@ -1747,27 +1759,15 @@ class Comprehension(NodeNG):
         """
         :param parent: The parent node in the syntax tree.
         """
-        self.target: NodeNG | None = None
-        """What is assigned to by the comprehension."""
-
-        self.iter: NodeNG | None = None
-        """What is iterated over by the comprehension."""
-
-        self.ifs: list[NodeNG] = []
-        """The contents of any if statements that filter the comprehension."""
-
-        self.is_async: bool | None = None
-        """Whether this is an asynchronous comprehension or not."""
-
         super().__init__(parent=parent)
 
     # pylint: disable=redefined-builtin; same name as builtin ast module.
     def postinit(
         self,
-        target: NodeNG | None = None,
-        iter: NodeNG | None = None,
+        target: NodeNG,
+        iter: NodeNG,
+        is_async: bool,
         ifs: list[NodeNG] | None = None,
-        is_async: bool | None = None,
     ) -> None:
         """Do some setup after initialisation.
 
@@ -1782,8 +1782,7 @@ class Comprehension(NodeNG):
         """
         self.target = target
         self.iter = iter
-        if ifs is not None:
-            self.ifs = ifs
+        self.ifs = ifs or []
         self.is_async = is_async
 
     assigned_stmts: ClassVar[AssignedStmtsCall[Comprehension]]

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2898,54 +2898,24 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
     <If l.1 at 0x7f23b2e9dd30>
     """
 
+    test: NodeNG
+    """The condition that the statement tests."""
+
+    body: list[NodeNG]
+    """The contents of the block."""
+
+    orelse: list[NodeNG]
+    """The contents of the ``else`` block."""
+
+    is_orelse: bool
+    """Whether the if-statement is the orelse-block of another if statement."""
+
     _astroid_fields = ("test", "body", "orelse")
     _multi_line_block_fields = ("body", "orelse")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.test: NodeNG | None = None
-        """The condition that the statement tests."""
-
-        self.body: list[NodeNG] = []
-        """The contents of the block."""
-
-        self.orelse: list[NodeNG] = []
-        """The contents of the ``else`` block."""
-
-        self.is_orelse: bool = False
-        """Whether the if-statement is the orelse-block of another if statement."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
-
     def postinit(
         self,
-        test: NodeNG | None = None,
+        test: NodeNG,
         body: list[NodeNG] | None = None,
         orelse: list[NodeNG] | None = None,
     ) -> None:
@@ -2958,12 +2928,9 @@ class If(_base_nodes.MultiLineWithElseBlockNode, _base_nodes.Statement):
         :param orelse: The contents of the ``else`` block.
         """
         self.test = test
-        if body is not None:
-            self.body = body
-        if orelse is not None:
-            self.orelse = orelse
-        if isinstance(self.parent, If) and self in self.parent.orelse:
-            self.is_orelse = True
+        self.body = body or []
+        self.orelse = orelse or []
+        self.is_orelse = isinstance(self.parent, If) and self in self.parent.orelse
 
     @cached_property
     def blockstart_tolineno(self):

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1194,52 +1194,22 @@ class Assign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     <Assign l.1 at 0x7effe1db8550>
     """
 
+    targets: list[NodeNG]
+    """What is being assigned to."""
+
+    value: NodeNG
+    """The value being assigned to the variables."""
+
+    type_annotation: NodeNG | None
+    """If present, this will contain the type annotation passed by a type comment"""
+
     _astroid_fields = ("targets", "value")
     _other_other_fields = ("type_annotation",)
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.targets: list[NodeNG] = []
-        """What is being assigned to."""
-
-        self.value: NodeNG | None = None
-        """The value being assigned to the variables."""
-
-        self.type_annotation: NodeNG | None = None  # can be None
-        """If present, this will contain the type annotation passed by a type comment"""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
-
     def postinit(
         self,
+        value: NodeNG,
         targets: list[NodeNG] | None = None,
-        value: NodeNG | None = None,
         type_annotation: NodeNG | None = None,
     ) -> None:
         """Do some setup after initialisation.
@@ -1248,8 +1218,7 @@ class Assign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         :param value: The value being assigned to the variables.
         :param type_annotation:
         """
-        if targets is not None:
-            self.targets = targets
+        self.targets = targets or []
         self.value = value
         self.type_annotation = type_annotation
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -2368,42 +2368,12 @@ class Expr(_base_nodes.Statement):
     <Expr l.1 at 0x7f23b2e35278>
     """
 
+    value: NodeNG
+    """What the expression does."""
+
     _astroid_fields = ("value",)
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.value: NodeNG | None = None
-        """What the expression does."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
-
-    def postinit(self, value: NodeNG | None = None) -> None:
+    def postinit(self, value: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param value: What the expression does.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4910,23 +4910,7 @@ class MatchOr(Pattern):
 
     _astroid_fields = ("patterns",)
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        self.patterns: list[Pattern]
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    patterns: list[Pattern]
 
     def postinit(self, *, patterns: list[Pattern]) -> None:
         self.patterns = patterns

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3123,52 +3123,22 @@ class IfExp(NodeNG):
     <IfExp l.1 at 0x7f23b2e9dbe0>
     """
 
+    test: NodeNG
+    """The condition that the statement tests."""
+
+    body: NodeNG
+    """The contents of the block."""
+
+    orelse: NodeNG
+    """The contents of the ``else`` block."""
+
     _astroid_fields = ("test", "body", "orelse")
-
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.test: NodeNG | None = None
-        """The condition that the statement tests."""
-
-        self.body: NodeNG | None = None
-        """The contents of the block."""
-
-        self.orelse: NodeNG | None = None
-        """The contents of the ``else`` block."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
 
     def postinit(
         self,
-        test: NodeNG | None = None,
-        body: NodeNG | None = None,
-        orelse: NodeNG | None = None,
+        test: NodeNG,
+        body: NodeNG,
+        orelse: NodeNG,
     ) -> None:
         """Do some setup after initialisation.
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1666,50 +1666,20 @@ class Call(NodeNG):
     <Call l.1 at 0x7f23b2e71eb8>
     """
 
+    func: NodeNG
+    """What is being called."""
+
+    args: list[NodeNG]
+    """The positional arguments being given to the call."""
+
+    keywords: list[Keyword]
+    """The keyword arguments being given to the call."""
+
     _astroid_fields = ("func", "args", "keywords")
-
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.func: NodeNG | None = None
-        """What is being called."""
-
-        self.args: list[NodeNG] = []
-        """The positional arguments being given to the call."""
-
-        self.keywords: list[Keyword] = []
-        """The keyword arguments being given to the call."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
 
     def postinit(
         self,
-        func: NodeNG | None = None,
+        func: NodeNG,
         args: list[NodeNG] | None = None,
         keywords: list[Keyword] | None = None,
     ) -> None:
@@ -1722,10 +1692,8 @@ class Call(NodeNG):
         :param keywords: The keyword arguments being given to the call.
         """
         self.func = func
-        if args is not None:
-            self.args = args
-        if keywords is not None:
-            self.keywords = keywords
+        self.args = args or []
+        self.keywords = keywords or []
 
     @property
     def starargs(self) -> list[Starred]:

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1455,13 +1455,22 @@ class BinOp(NodeNG):
     <BinOp l.1 at 0x7f23b2e8cfd0>
     """
 
+    left: NodeNG
+    """What is being applied to the operator on the left side."""
+
+    right: NodeNG
+    """What is being applied to the operator on the right side."""
+
+    op: str
+    """The operator."""
+
     _astroid_fields = ("left", "right")
     _other_fields = ("op",)
 
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: str | None = None,
+        op: str,
         lineno: int | None = None,
         col_offset: int | None = None,
         parent: NodeNG | None = None,
@@ -1484,14 +1493,8 @@ class BinOp(NodeNG):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.left: NodeNG | None = None
-        """What is being applied to the operator on the left side."""
-
-        self.op: str | None = op
+        self.op = op
         """The operator."""
-
-        self.right: NodeNG | None = None
-        """What is being applied to the operator on the right side."""
 
         super().__init__(
             lineno=lineno,
@@ -1501,7 +1504,7 @@ class BinOp(NodeNG):
             parent=parent,
         )
 
-    def postinit(self, left: NodeNG | None = None, right: NodeNG | None = None) -> None:
+    def postinit(self, left: NodeNG, right: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param left: What is being applied to the operator on the left side.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3204,53 +3204,17 @@ class Raise(_base_nodes.Statement):
 
     _astroid_fields = ("exc", "cause")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    exc: NodeNG | None
+    """What is being raised."""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.exc: NodeNG | None = None  # can be None
-        """What is being raised."""
-
-        self.cause: NodeNG | None = None  # can be None
-        """The exception being used to raise this one."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    cause: NodeNG | None
+    """The exception being used to raise this one."""
 
     def postinit(
         self,
         exc: NodeNG | None = None,
         cause: NodeNG | None = None,
     ) -> None:
-        """Do some setup after initialisation.
-
-        :param exc: What is being raised.
-
-        :param cause: The exception being used to raise this one.
-        """
         self.exc = exc
         self.cause = cause
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1343,13 +1343,25 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     <AugAssign l.1 at 0x7effe1db4d68>
     """
 
+    target: NodeNG
+    """What is being assigned to."""
+
+    op: str
+    """The operator that is being combined with the assignment.
+
+    This includes the equals sign.
+    """
+
+    value: NodeNG
+    """The value being assigned to the variable."""
+
     _astroid_fields = ("target", "value")
     _other_fields = ("op",)
 
     @decorators.deprecate_default_argument_values(op="str")
     def __init__(
         self,
-        op: str | None = None,
+        op: str,
         lineno: int | None = None,
         col_offset: int | None = None,
         parent: NodeNG | None = None,
@@ -1373,17 +1385,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
         :param end_col_offset: The end column this node appears on in the
             source code. Note: This is after the last symbol.
         """
-        self.target: NodeNG | None = None
-        """What is being assigned to."""
-
-        self.op: str | None = op
-        """The operator that is being combined with the assignment.
-
-        This includes the equals sign.
-        """
-
-        self.value: NodeNG | None = None
-        """The value being assigned to the variable."""
+        self.op = op
 
         super().__init__(
             lineno=lineno,
@@ -1393,9 +1395,7 @@ class AugAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
             parent=parent,
         )
 
-    def postinit(
-        self, target: NodeNG | None = None, value: NodeNG | None = None
-    ) -> None:
+    def postinit(self, target: NodeNG, value: NodeNG) -> None:
         """Do some setup after initialisation.
 
         :param target: What is being assigned to.

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1251,50 +1251,20 @@ class AnnAssign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
     <AnnAssign l.1 at 0x7effe1d4c630>
     """
 
+    target: NodeNG
+    """What is being assigned to."""
+
+    annotation: NodeNG
+    """The type annotation of what is being assigned to."""
+
+    value: NodeNG | None
+    """The value being assigned to the variables."""
+
+    simple: int
+    """Whether :attr:`target` is a pure name or a complex statement."""
+
     _astroid_fields = ("target", "annotation", "value")
     _other_fields = ("simple",)
-
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
-
-        :param col_offset: The column that this node appears on in the
-            source code.
-
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.target: NodeNG | None = None
-        """What is being assigned to."""
-
-        self.annotation: NodeNG | None = None
-        """The type annotation of what is being assigned to."""
-
-        self.value: NodeNG | None = None  # can be None
-        """The value being assigned to the variables."""
-
-        self.simple: int | None = None
-        """Whether :attr:`target` is a pure name or a complex statement."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
 
     def postinit(
         self,

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -3367,44 +3367,14 @@ class Slice(NodeNG):
 
     _astroid_fields = ("lower", "upper", "step")
 
-    def __init__(
-        self,
-        lineno: int | None = None,
-        col_offset: int | None = None,
-        parent: NodeNG | None = None,
-        *,
-        end_lineno: int | None = None,
-        end_col_offset: int | None = None,
-    ) -> None:
-        """
-        :param lineno: The line that this node appears on in the source code.
+    lower: NodeNG | None
+    """The lower index in the slice."""
 
-        :param col_offset: The column that this node appears on in the
-            source code.
+    upper: NodeNG | None
+    """The upper index in the slice."""
 
-        :param parent: The parent node in the syntax tree.
-
-        :param end_lineno: The last line this node appears on in the source code.
-
-        :param end_col_offset: The end column this node appears on in the
-            source code. Note: This is after the last symbol.
-        """
-        self.lower: NodeNG | None = None  # can be None
-        """The lower index in the slice."""
-
-        self.upper: NodeNG | None = None  # can be None
-        """The upper index in the slice."""
-
-        self.step: NodeNG | None = None  # can be None
-        """The step to take between indexes."""
-
-        super().__init__(
-            lineno=lineno,
-            col_offset=col_offset,
-            end_lineno=end_lineno,
-            end_col_offset=end_col_offset,
-            parent=parent,
-        )
+    step: NodeNG | None
+    """The step to take between indexes."""
 
     def postinit(
         self,
@@ -3412,14 +3382,6 @@ class Slice(NodeNG):
         upper: NodeNG | None = None,
         step: NodeNG | None = None,
     ) -> None:
-        """Do some setup after initialisation.
-
-        :param lower: The lower index in the slice.
-
-        :param upper: The upper index in the slice.
-
-        :param step: The step to take between index.
-        """
         self.lower = lower
         self.upper = upper
         self.step = step

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1013,8 +1013,8 @@ class TreeRebuilder:
         newnode.postinit(
             self.visit(node.target, newnode),
             self.visit(node.iter, newnode),
-            [self.visit(child, newnode) for child in node.ifs],
             bool(node.is_async),
+            [self.visit(child, newnode) for child in node.ifs],
         )
         return newnode
 


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

This is a fun one.

[This comment](https://github.com/PyCQA/astroid/pull/1885#discussion_r1030791292) got me to thinking about required fields. There are many places in the code where a field is assumed to be not none even though the field annotation gives it as optional. Mypy rightly complains about this.

There are three ways to deal with this: (1) not-none assertions (yikes), (2) instance checks (yuck), and (3) annotate the fields as mandatory. This PR attempts (3).

Running Mypy strict, this reduces warnings from **1534** to **1478**, which is pretty good. I'm assuming this also will improve performance slightly.

In many cases, making the fields mandatory means that they aren't set until `postinit`, and so there isn't anything node-specific to do in `__init__`. So the `__init__` method can be deleted altogether since it does nothing but delegate to `super`.