### PR TITLE
Fix crash if numpy doesn't have version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,7 +24,7 @@ Release date: TBA
 
   Closes PyCQA/pylint#5225
 
-* Fix crash if ``numpy`` module doesn't have ``version`` attribute. 
+* Fix crash if ``numpy`` module doesn't have ``version`` attribute.
 
   Refs PyCQA/pylint#7868
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#2567
 
+* Fix crash if `numpy` module doesn't have `version` attribute
+
+  Refs PyCQA/pylint#7868
+
 What's New in astroid 2.12.13?
 ==============================
 Release date: 2022-11-19

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,7 +24,7 @@ Release date: TBA
 
   Closes PyCQA/pylint#5225
 
-* Fix crash if `numpy` module doesn't have `version` attribute
+* Fix crash if ``numpy`` module doesn't have ``version`` attribute. 
 
   Refs PyCQA/pylint#7868
 

--- a/astroid/brain/brain_numpy_utils.py
+++ b/astroid/brain/brain_numpy_utils.py
@@ -31,7 +31,7 @@ def _get_numpy_version() -> tuple[str, str, str]:
         import numpy  # pylint: disable=import-outside-toplevel
 
         return tuple(numpy.version.version.split("."))
-    except ImportError:
+    except (ImportError, AttributeError):
         return ("0", "0", "0")
 
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Resolves https://github.com/PyCQA/pylint/issues/7868
