### PR TITLE
Handle init=False with defaults in dataclasses

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,10 @@ Release date: TBA
 
   Closes PyCQA/pylint#5225
 
+* Handle the effect of ``init=False`` in dataclass fields correctly.
+
+  Closes PyCQA/pylint#7291
+
 
 What's New in astroid 2.12.13?
 ==============================

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -132,7 +132,9 @@ def _get_dataclass_attributes(
 
         # Annotation is never None
         if not init and _is_init_var(assign_node.annotation):  # type: ignore[arg-type]
-            yield assign_node
+            continue
+
+        yield assign_node
 
 
 def _check_generate_dataclass_init(node: nodes.ClassDef) -> bool:


### PR DESCRIPTION


## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Closes PyCQA/pylint#7291

This was a bit of a rabbit hole but this should at least fix some more additional false positives.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


