### PR TITLE
Inference tip str.format transformation: handle AttributeError during str.format template evaluation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#7868
 
+* Handle ``AttributeError`` during ``str.format`` template inference tip evaluation
+
+  Closes PyCQA/pylint#1902
+
 What's New in astroid 2.12.13?
 ==============================
 Release date: 2022-11-19

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -957,6 +957,8 @@ def _infer_str_format_call(
         # TypeError: Unsupported format string
         # ValueError: Unknown format code
         return iter([util.Uninferable])
+    except AttributeError as exc:
+        raise AstroidTypeError(str(exc)) from exc
 
     return iter([nodes.const_factory(formatted_string)])
 

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -952,13 +952,12 @@ def _infer_str_format_call(
 
     try:
         formatted_string = format_template.format(*pos_values, **keyword_values)
-    except (IndexError, KeyError, TypeError, ValueError):
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+        # AttributeError: processing a replacement field using the arguments failed
         # IndexError: there are too few arguments to interpolate
         # TypeError: Unsupported format string
         # ValueError: Unknown format code
         return iter([util.Uninferable])
-    except AttributeError as exc:
-        raise AstroidTypeError(str(exc)) from exc
 
     return iter([nodes.const_factory(formatted_string)])
 

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -136,5 +136,5 @@ class TestStringNodes:
     )
     def test_string_format_invalid_type(self, format_string: str) -> None:
         node: nodes.Call = _extract_single_node(format_string)
-        with pytest.raises(AstroidTypeError):
-            next(node.infer())
+        inferred = next(node.infer())
+        assert inferred is util.Uninferable

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -109,6 +109,10 @@ class TestStringNodes:
             """
             "My hex format is {:4x}".format('1')
             """,
+            """
+            daniel_age = 12
+            "My name is {0.name}".format(daniel_age)
+            """,
         ],
     )
     def test_string_format_uninferable(self, format_string: str) -> None:
@@ -123,17 +127,3 @@ class TestStringNodes:
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "My name is Daniel, I'm 12.00"
-
-    @pytest.mark.parametrize(
-        "format_string",
-        [
-            """
-            daniel_age = 12
-            "My name is {0.name}".format(daniel_age)
-            """,
-        ],
-    )
-    def test_string_format_invalid_type(self, format_string: str) -> None:
-        node: nodes.Call = _extract_single_node(format_string)
-        inferred = next(node.infer())
-        assert inferred is util.Uninferable

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -10,7 +10,6 @@ import pytest
 
 from astroid import nodes, objects, util
 from astroid.builder import _extract_single_node
-from astroid.exceptions import AstroidTypeError
 
 
 class BuiltinsTest(unittest.TestCase):

--- a/tests/unittest_brain_builtin.py
+++ b/tests/unittest_brain_builtin.py
@@ -10,6 +10,7 @@ import pytest
 
 from astroid import nodes, objects, util
 from astroid.builder import _extract_single_node
+from astroid.exceptions import AstroidTypeError
 
 
 class BuiltinsTest(unittest.TestCase):
@@ -123,3 +124,17 @@ class TestStringNodes:
         inferred = next(node.infer())
         assert isinstance(inferred, nodes.Const)
         assert inferred.value == "My name is Daniel, I'm 12.00"
+
+    @pytest.mark.parametrize(
+        "format_string",
+        [
+            """
+            daniel_age = 12
+            "My name is {0.name}".format(daniel_age)
+            """,
+        ],
+    )
+    def test_string_format_invalid_type(self, format_string: str) -> None:
+        node: nodes.Call = _extract_single_node(format_string)
+        with pytest.raises(AstroidTypeError):
+            next(node.infer())


### PR DESCRIPTION
When evaluating `str.format` references, catch `AttributeError`s and re-raise them as `AstroidTypeError`.

Resolves #1902.

## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a description on what the PR does.

## Description

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue
May resolve #1902.