### PR TITLE
Remove deprecated `ignore-mixin-members` pylint option

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -242,10 +242,6 @@ spelling-store-unknown-words=no
 [TYPECHECK]
 
 ignore-on-opaque-inference=n
-# Tells whether missing members accessed in mixin class should be ignored. A
-
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
 
 # List of module names for which member attributes should not be checked
 

--- a/pylintrc
+++ b/pylintrc
@@ -244,9 +244,7 @@ spelling-store-unknown-words=no
 ignore-on-opaque-inference=n
 
 # List of module names for which member attributes should not be checked
-
 # (useful for modules/projects where namespaces are manipulated during runtime
-
 # and thus existing member attributes cannot be deduced by static analysis
 ignored-modules=typed_ast.ast3
 


### PR DESCRIPTION
Remove deprecated `ignore-mixin-members` pylint option

Refs PyCQA/pylint#6173