### PR TITLE
beginnings of regex module support & tests

### DIFF
--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -50,6 +50,7 @@ register_module_extender(AstroidManager(), "re", _re_transform)
 # Regex module is a re-compatible module with more features and better
 # performance.
 
+
 def _regex_transform() -> nodes.Module:
     # The RegexFlag enum exposes all its entries by updating globals()
     import_compiler = "import regex._regex_core as _compiler"
@@ -92,6 +93,7 @@ def _regex_transform() -> nodes.Module:
     T = TEMPLATE
     """
     )
+
 
 register_module_extender(AstroidManager(), "regex", _regex_transform)
 

--- a/astroid/brain/brain_re.py
+++ b/astroid/brain/brain_re.py
@@ -47,6 +47,55 @@ def _re_transform() -> nodes.Module:
 register_module_extender(AstroidManager(), "re", _re_transform)
 
 
+# Regex module is a re-compatible module with more features and better
+# performance.
+
+def _regex_transform() -> nodes.Module:
+    # The RegexFlag enum exposes all its entries by updating globals()
+    import_compiler = "import regex._regex_core as _compiler"
+    return parse(
+        f"""
+    {import_compiler}
+    ASCII = _compiler.ASCII
+    BESTMATCH = _compiler.BESTMATCH
+    DEBUG = _compiler.DEBUG
+    ENHANCEMATCH = _compiler.ENHANCEMATCH
+    FULLCASE = _compiler.FULLCASE
+    IGNORECASE = _compiler.IGNORECASE
+    LOCALE = _compiler.LOCALE
+    MULTILINE = _compiler.MULTILINE
+    POSIX = _compiler.POSIX
+    REVERSE = _compiler.REVERSE
+    DOTALL = _compiler.DOTALL
+    UNICODE = _compiler.UNICODE
+    VERSION0 = _compiler.VERSION0
+    VERSION1 = _compiler.VERSION1
+    WORD = _compiler.WORD
+    VERBOSE = _compiler.VERBOSE
+    TEMPLATE = _compiler.TEMPLATE
+    A = ASCII
+    B = BESTMATCH
+    D = DEBUG
+    E = ENHANCEMATCH
+    F = FULLCASE
+    I = IGNORECASE
+    L = LOCALE
+    M = MULTILINE
+    P = POSIX
+    R = REVERSE
+    S = DOTALL
+    U = UNICODE
+    V0 = VERSION0
+    V1 = VERSION1
+    W = WORD
+    X = VERBOSE
+    T = TEMPLATE
+    """
+    )
+
+register_module_extender(AstroidManager(), "regex", _regex_transform)
+
+
 CLASS_GETITEM_TEMPLATE = """
 @classmethod
 def __class_getitem__(cls, item):

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -4,6 +4,7 @@ nose
 numpy>=1.17.0; python_version<"3.11"
 python-dateutil
 PyQt6
+regex
 types-python-dateutil
 six
 types-six

--- a/tests/unittest_brain_regex.py
+++ b/tests/unittest_brain_regex.py
@@ -1,3 +1,6 @@
+# Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
+# For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
 import unittest
 
@@ -8,11 +11,7 @@ try:
 except ImportError:
     HAS_REGEX = False
 
-from astroid import MANAGER, builder, nodes, test_utils
-from astroid.exceptions import (
-    AttributeInferenceError,
-    InferenceError,
-)
+from astroid import MANAGER, builder, nodes
 
 
 @unittest.skipUnless(HAS_REGEX, "This test requires the regex library.")

--- a/tests/unittest_brain_regex.py
+++ b/tests/unittest_brain_regex.py
@@ -1,0 +1,47 @@
+
+import unittest
+
+try:
+    import regex
+
+    HAS_REGEX = True
+except ImportError:
+    HAS_REGEX = False
+
+from astroid import MANAGER, builder, nodes, test_utils
+from astroid.exceptions import (
+    AttributeInferenceError,
+    InferenceError,
+)
+
+
+@unittest.skipUnless(HAS_REGEX, "This test requires the regex library.")
+class RegexBrainTest(unittest.TestCase):
+    def test_regex_flags(self) -> None:
+        names = [name for name in dir(regex) if name.isupper()]
+        re_ast = MANAGER.ast_from_module_name("regex")
+        for name in names:
+            self.assertIn(name, re_ast)
+            self.assertEqual(next(re_ast[name].infer()).value, getattr(regex, name))
+
+    def test_re_pattern_subscriptable(self):
+        """Test regex.Pattern and regex.Match are subscriptable in PY39+"""
+        node1 = builder.extract_node(
+            """
+        import regex
+        regex.Pattern[str]
+        """
+        )
+        inferred1 = next(node1.infer())
+        assert isinstance(inferred1, nodes.ClassDef)
+        assert isinstance(inferred1.getattr("__class_getitem__")[0], nodes.FunctionDef)
+
+        node2 = builder.extract_node(
+            """
+        import regex
+        regex.Match[str]
+        """
+        )
+        inferred2 = next(node2.infer())
+        assert isinstance(inferred2, nodes.ClassDef)
+        assert isinstance(inferred2.getattr("__class_getitem__")[0], nodes.FunctionDef)


### PR DESCRIPTION
This change works for me but the tests fail. I just mimicked the existing setup for the standard ``re`` module. The unit tests are mostly just copy/paste from unittest_brain_re.py code. I haven't the slightest idea what is going on with the failures, as I know nothing about asts. Still, hopefully this serves as boilerplate for people smarter than me. I did delete the bit about unsubscriptable ``Pattern`` and ``Match``, as I doubt those tracked Python's versions. It does appear they are subscriptable.

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

Refs #1911 

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #1911 
