### PR TITLE
brain tip for numpy masked_invalid

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,9 @@ Release date: TBA
 
   Closes PyCQA/pylint#1902
 
+* Add the ``masked_invalid`` function in the ``numpy.ma`` brain.
+
+  Closes PyCQA/pylint#5715
 
 What's New in astroid 2.12.13?
 ==============================

--- a/astroid/brain/brain_numpy_ma.py
+++ b/astroid/brain/brain_numpy_ma.py
@@ -21,7 +21,7 @@ def numpy_ma_transform():
     import numpy.ma
     def masked_where(condition, a, copy=True):
         return numpy.ma.masked_array(a, mask=[])
-    
+
     def masked_invalid(a, copy=True):
         return numpy.ma.masked_array(a, mask=[])
     """

--- a/astroid/brain/brain_numpy_ma.py
+++ b/astroid/brain/brain_numpy_ma.py
@@ -21,6 +21,9 @@ def numpy_ma_transform():
     import numpy.ma
     def masked_where(condition, a, copy=True):
         return numpy.ma.masked_array(a, mask=[])
+    
+    def masked_invalid(a, copy=True):
+        return numpy.ma.masked_array(a, mask=[])
     """
     )
 

--- a/astroid/brain/brain_numpy_ma.py
+++ b/astroid/brain/brain_numpy_ma.py
@@ -11,7 +11,7 @@ from astroid.manager import AstroidManager
 
 def numpy_ma_transform():
     """
-    Infer the call of the masked_where function
+    Infer the call of various numpy.ma functions
 
     :param node: node to infer
     :param context: inference context

--- a/tests/unittest_brain_numpy_ma.py
+++ b/tests/unittest_brain_numpy_ma.py
@@ -13,8 +13,6 @@ except ImportError:
 
 from astroid import builder
 
-parametrize = pytest.mark.parametrize("alias_import", [True, False])
-
 
 @pytest.mark.skipif(HAS_NUMPY is False, reason="This test requires the numpy library.")
 class TestBrainNumpyMa:
@@ -27,44 +25,24 @@ class TestBrainNumpyMa:
         cls_node = node.inferred()[0]
         assert cls_node.pytype() == "numpy.ma.core.MaskedArray"
 
-    @parametrize
-    def test_numpy_ma_masked_where_returns_maskedarray(self, alias_import):
+    @pytest.mark.parametrize("alias_import", [True, False])
+    @pytest.mark.parametrize("ma_function", ["masked_invalid", "masked_where"])
+    def test_numpy_ma_returns_maskedarray(self, alias_import, ma_function):
         """
-        Test that calls to numpy ma masked_where returns a MaskedArray object.
+        Test that calls to numpy ma functions return a MaskedArray object.
 
-        The "masked_where" node is an Attribute
-        """
-        import_str = (
-            "import numpy as np"
-            if alias_import
-            else "from numpy.ma import masked_where"
-        )
-        func_call = "np.ma.masked_where" if alias_import else "masked_where"
-
-        src = f"""
-        {import_str}
-        data = np.ndarray((1,2))
-        {func_call}([1, 0, 0], data)
-        """
-        self._assert_maskedarray(src)
-
-    @parametrize
-    def test_numpy_ma_masked_invalid_returns_maskedarray(self, alias_import):
-        """
-        Test that calls to numpy ma masked_invalid returns a MaskedArray object.
-
-        The "masked_invalid" node is an Attribute
+        The `ma_function` node is an Attribute or a Name
         """
         import_str = (
             "import numpy as np"
             if alias_import
-            else "from numpy.ma import masked_invalid"
+            else f"from numpy.ma import {ma_function}"
         )
-        func_call = "np.ma.masked_invalid" if alias_import else "masked_invalid"
+        func = f"np.ma.{ma_function}" if alias_import else ma_function
 
         src = f"""
         {import_str}
         data = np.ndarray((1,2))
-        {func_call}([1, 0, 0], data)
+        {func}([1, 0, 0], data)
         """
         self._assert_maskedarray(src)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

This is my first time trying to update astroid's brain so tips are really appreciated. I'm trying to get the following 

```
import numpy as np

DATA = np.array([np.nan, 2, 3])
DATA = np.ma.masked_invalid(DATA)
print(DATA.mask)
assert isinstance(DATA, np.ma.MaskedArray)
```

To not emit `numpy_pylint.py:7:6: E1101: Instance of 'ndarray' has no 'mask' member (no-member)`
I got it to work with the code in this PR but I'm getting ` Redefinition of DATA type from .ndarray to numpy.ma.core.MaskedArray (redefined-variable-type)`. If I don't re-define `DATA` like this: then it works

```
DATA = np.ma.masked_invalid(np.array([np.nan, 2, 3]))
print(DATA.mask)
```

Closes https://github.com/PyCQA/pylint/issues/5715
