### PR TITLE
Cache `ClassDef._metaclass_lookup_attribute`

### DIFF
--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -412,6 +412,7 @@ class AstroidManager:
         from astroid.inference_tip import clear_inference_tip_cache
         from astroid.interpreter.objectmodel import ObjectModel
         from astroid.nodes.node_classes import LookupMixIn
+        from astroid.nodes.scoped_nodes import ClassDef
 
         clear_inference_tip_cache()
 
@@ -426,6 +427,7 @@ class AstroidManager:
             _cache_normalize_path_,
             util.is_namespace,
             ObjectModel.attributes,
+            ClassDef._metaclass_lookup_attribute,
         ):
             lru_cache.cache_clear()  # type: ignore[attr-defined]
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -16,6 +16,7 @@ import os
 import sys
 import warnings
 from collections.abc import Generator, Iterator
+from functools import lru_cache
 from typing import TYPE_CHECKING, ClassVar, NoReturn, TypeVar, overload
 
 from astroid import bases
@@ -2555,6 +2556,7 @@ class ClassDef(
 
         return values
 
+    @lru_cache(maxsize=1024)
     def _metaclass_lookup_attribute(self, name, context):
         """Search the given name in the implicit and the explicit metaclass."""
         attrs = set()

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -2556,7 +2556,7 @@ class ClassDef(
 
         return values
 
-    @lru_cache(maxsize=1024)
+    @lru_cache(maxsize=1024)  # noqa
     def _metaclass_lookup_attribute(self, name, context):
         """Search the given name in the implicit and the explicit metaclass."""
         attrs = set()

--- a/tests/unittest_manager.py
+++ b/tests/unittest_manager.py
@@ -16,7 +16,11 @@ import pytest
 import astroid
 from astroid import manager, test_utils
 from astroid.const import IS_JYTHON, IS_PYPY
-from astroid.exceptions import AstroidBuildingError, AstroidImportError
+from astroid.exceptions import (
+    AstroidBuildingError,
+    AstroidImportError,
+    AttributeInferenceError,
+)
 from astroid.interpreter._import import util
 from astroid.modutils import EXT_LIB_DIRS, is_standard_module
 from astroid.nodes import Const
@@ -398,6 +402,7 @@ class ClearCacheTest(unittest.TestCase):
             astroid.modutils._cache_normalize_path_,
             util.is_namespace,
             astroid.interpreter.objectmodel.ObjectModel.attributes,
+            ClassDef._metaclass_lookup_attribute,
         )
 
         # Get a baseline for the size of the cache after simply calling bootstrap()
@@ -408,6 +413,8 @@ class ClearCacheTest(unittest.TestCase):
         is_standard_module("unittest", std_path=["garbage_path"])
         util.is_namespace("unittest")
         astroid.interpreter.objectmodel.ObjectModel().attributes()
+        with pytest.raises(AttributeInferenceError):
+            ClassDef().getattr("garbage")
 
         # Did the hits or misses actually happen?
         incremented_cache_infos = [lru.cache_info() for lru in lrus]


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
When linting `import returns.result` from the `returns` library, generates 93,315 cache hits to 443 misses, cutting the total linting time from 50s to 12s.

Closes PyCQA/pylint#4750