### PR TITLE
Use codecov and separate flags per OS

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,10 @@
-[paths]
-source =
-   astroid
+[run]
+relative_files = true
 
 [report]
-include =
-    astroid/*
 omit =
     */tests/*
+    */tmp*/*
 exclude_lines =
     # Re-enable default pragma
     pragma: no cover

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 env:
   CACHE_VERSION: 3
   KEY_PREFIX: venv
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.11"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 jobs:
@@ -120,58 +120,12 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
-          pytest --cov --cov-report= tests/
+          pytest --cov
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3.1.1
         with:
-          name: coverage-${{ matrix.python-version }}
+          name: coverage-linux-${{ matrix.python-version }}
           path: .coverage
-
-  coverage:
-    name: tests / process / coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: ["tests-linux"]
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    env:
-      COVERAGERC_FILE: .coveragerc
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v3.2.0
-      - name: Set up Python ${{ matrix.python-version }}
-        id: python
-        uses: actions/setup-python@v4.4.0
-        with:
-          python-version: ${{ matrix.python-version }}
-          check-latest: true
-      - name: Restore Python virtual environment
-        id: cache-venv
-        uses: actions/cache@v3.2.2
-        with:
-          path: venv
-          key:
-            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
-            needs.tests-linux.outputs.python-key }}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python venv from cache"
-          exit 1
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@v3.0.1
-      - name: Combine coverage results
-        run: |
-          . venv/bin/activate
-          coverage combine coverage*/.coverage
-          coverage report --rcfile=${{ env.COVERAGERC_FILE }}
-      - name: Upload coverage to Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          . venv/bin/activate
-          coveralls --rcfile=${{ env.COVERAGERC_FILE }} --service=github
 
   tests-windows:
     name: tests / run / ${{ matrix.python-version }} / Windows
@@ -220,7 +174,12 @@ jobs:
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate
-          pytest tests/
+          pytest --cov
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: coverage-windows-${{ matrix.python-version }}
+          path: .coverage
 
   tests-pypy:
     name: tests / run / ${{ matrix.python-version }} / Linux
@@ -264,4 +223,58 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
-          pytest tests/
+          pytest --cov
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: coverage-pypy-${{ matrix.python-version }}
+          path: .coverage
+
+  coverage:
+    name: tests / process / coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: ["tests-linux", "tests-windows", "tests-pypy"]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.2.0
+      - name: Set up Python 3.11
+        id: python
+        uses: actions/setup-python@v4.4.0
+        with:
+          python-version: "3.11"
+          check-latest: true
+      - name: Install dependencies
+        run: pip install -U -r requirements_test_min.txt
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v3.0.1
+      - name: Combine Linux coverage results
+        run: |
+          coverage combine coverage-linux*/.coverage
+          coverage xml -o coverage-linux.xml
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          flags: linux
+          files: coverage-linux.xml
+      - name: Combine Windows coverage results
+        run: |
+          coverage combine coverage-windows*/.coverage
+          coverage xml -o coverage-windows.xml
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          flags: windows
+          files: coverage-windows.xml
+      - name: Combine PyPy coverage results
+        run: |
+          coverage combine coverage-pypy*/.coverage
+          coverage xml -o coverage-pypy.xml
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          flags: pypy
+          files: coverage-pypy.xml

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 Astroid
 =======
 
-.. image:: https://coveralls.io/repos/github/PyCQA/astroid/badge.svg?branch=main
-    :target: https://coveralls.io/github/PyCQA/astroid?branch=main
-    :alt: Coverage badge from coveralls.io
+.. image:: https://codecov.io/gh/PyCQA/astroid/branch/main/graph/badge.svg?token=Buxy4WptLb
+    :target: https://codecov.io/gh/PyCQA/astroid
+    :alt: Coverage badge from codecov
 
 .. image:: https://readthedocs.org/projects/astroid/badge/?version=latest
     :target: http://astroid.readthedocs.io/en/latest/?badge=latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+    project:
+      default:
+        target: 92%
+comment:
+  layout: "reach, diff, flags, files"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,10 +1,7 @@
 -r requirements_test_min.txt
 -r requirements_test_pre_commit.txt
 contributors-txt>=0.7.4
-coveralls~=3.3
-coverage~=6.5
 pre-commit~=2.21
-pytest-cov~=4.0
 tbump~=6.9.0
 types-typed-ast; implementation_name=="cpython" and python_version<"3.8"
 types-pkg_resources==0.1.3

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,2 +1,4 @@
+coverage~=7.0
 pytest
+pytest-cov~=4.0
 typing-extensions>=3.10


### PR DESCRIPTION
## Steps

- [x] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [x] Write a good description on what the PR does.

## Description

Similar to `pylint`. However, this also uses the flag functionality, which makes it possible to report coverage per OS.
I (finally) got this to work with `pydocstringformatter` today and found out how to do this here as well.

One effect of this is that coverage will only be reported after all tests have run. We can consider making an additional job to only report linux coverage first, but that feels unnecessary. Let's see if this fits our needs for now.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |