### PR TITLE
Comment fixup: attempt to improve clarity

### DIFF
--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -953,7 +953,7 @@ def _infer_str_format_call(
     try:
         formatted_string = format_template.format(*pos_values, **keyword_values)
     except (AttributeError, IndexError, KeyError, TypeError, ValueError):
-        # AttributeError: processing a replacement field using the arguments failed
+        # AttributeError: named field in format string was not found in the arguments
         # IndexError: there are too few arguments to interpolate
         # TypeError: Unsupported format string
         # ValueError: Unknown format code


### PR DESCRIPTION
While preparing for an upgrade to `astroid` v2.12.14 in a local working copy of `pylint`, I took a look at the diff from `v2.12.13...v2.12.14` and couldn't understand what my own comment (from only a few weeks ago) here meant.  That's a sign that it should be improved.

Relates to / follows up on #1903.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description
Refs #1903.