### PR TITLE
bump minimal version of typing-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "wrapt>=1.14,<2;python_version>='3.11'",
     "wrapt>=1.11,<2;python_version<'3.11'",
     "typed-ast>=1.4.0,<2.0;implementation_name=='cpython' and python_version<'3.8'",
-    "typing-extensions>=3.10;python_version<'3.10'",
+    "typing-extensions>=4.0.0;python_version<'3.10'",
 ]
 dynamic = ["version"]
 

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,4 +1,4 @@
 coverage~=7.0
 pytest
 pytest-cov~=4.0
-typing-extensions>=3.10
+typing-extensions>=4.0.0


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Since using `typing_extensions.Self`(https://github.com/PyCQA/astroid/blob/main/astroid/constraint.py#L19) in `2.13.0`, we need to bump minimal version of `typing_extensions` to `4.0.0`(https://github.com/python/typing_extensions/blob/main/CHANGELOG.md?plain=1#L93). 

Closes https://github.com/PyCQA/astroid/issues/1942
