### PR TITLE
Remove typing_extensions from the tests requirements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,7 +15,7 @@ Release date: TBA
 * Removed version conditions on typing_extensions dependency. Removed typing_extensions from
   our tests requirements as it was preventing issues to appear in our continuous integration.
 
-  Closes #1945 
+  Closes #1945
 
 
 What's New in astroid 2.13.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ What's New in astroid 2.13.2?
 =============================
 Release date: TBA
 
+* Removed version conditions on typing_extensions dependency. Removed typing_extensions from
+  our tests requirements as it was preventing issues to appear in our continuous integration.
+
+  Refs #1944
 
 
 What's New in astroid 2.13.1?

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,7 +15,7 @@ Release date: TBA
 * Removed version conditions on typing_extensions dependency. Removed typing_extensions from
   our tests requirements as it was preventing issues to appear in our continuous integration.
 
-  Refs #1944
+  Closes #1945 
 
 
 What's New in astroid 2.13.1?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "wrapt>=1.14,<2;python_version>='3.11'",
     "wrapt>=1.11,<2;python_version<'3.11'",
     "typed-ast>=1.4.0,<2.0;implementation_name=='cpython' and python_version<'3.8'",
-    "typing-extensions>=4.0.0;python_version<'3.10'",
+    "typing-extensions>=4.0.0",
 ]
 dynamic = ["version"]
 

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,4 +1,3 @@
 coverage~=7.0
 pytest
 pytest-cov~=4.0
-typing-extensions>=4.0.0


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

The tests had their very own version of typing extensions which prevented us from seeing it was a run time dependencies and made the tests useless to actually see this issue. See https://github.com/PyCQA/astroid/issues/1942#issuecomment-1374821887

Closes #1945 
