### PR TITLE
Fix a regression in 2.13.2 where a ``RunTimeError`` could be raised unexpectedly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,9 @@ What's New in astroid 2.13.3?
 =============================
 Release date: TBA
 
+* Fix a regression in 2.13.2 where a RunTimeError could be raised unexpectedly.
 
+  Closes #1958
 
 What's New in astroid 2.13.2?
 =============================

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -324,6 +324,17 @@ def _build_from_function(
         object_build_function(node, member, name)
 
 
+def _safe_has_attribute(obj, member: str) -> bool:
+    """Required because unexpected RunTimeError can be raised.
+
+    See https://github.com/PyCQA/astroid/issues/1958
+    """
+    try:
+        return hasattr(obj, member)
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
 class InspectBuilder:
     """class for building nodes from living object
 
@@ -419,7 +430,7 @@ class InspectBuilder:
                 # This should be called for Jython, where some builtin
                 # methods aren't caught by isbuiltin branch.
                 _build_from_function(node, name, member, self._module)
-            elif hasattr(member, "__all__"):
+            elif _safe_has_attribute(member, "__all__"):
                 module = build_module(name)
                 _attach_local_node(node, module, name)
                 # recursion

--- a/tests/testdata/python3/data/fake_module_with_broken_getattr.py
+++ b/tests/testdata/python3/data/fake_module_with_broken_getattr.py
@@ -1,0 +1,7 @@
+class Broken:
+
+    def __getattr__(self, name):
+        raise Exception("boom")
+
+
+broken = Broken()

--- a/tests/unittest_raw_building.py
+++ b/tests/unittest_raw_building.py
@@ -1,6 +1,7 @@
 """
-'tests.testdata.python3.data.fake_module_with_warnings' is a fake module to
-simulate issues in unittest below
+'tests.testdata.python3.data.fake_module_with_warnings' and
+'tests.testdata.python3.data.fake_module_with_warnings' are fake modules
+to simulate issues in unittest below
 """
 
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html

--- a/tests/unittest_raw_building.py
+++ b/tests/unittest_raw_building.py
@@ -1,3 +1,8 @@
+"""
+'tests.testdata.python3.data.fake_module_with_warnings' is a fake module to
+simulate issues in unittest below
+"""
+
 # Licensed under the LGPL: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
@@ -8,7 +13,7 @@ import unittest
 import _io
 import pytest
 
-# A fake module to simulate pandas in unittest below
+import tests.testdata.python3.data.fake_module_with_broken_getattr as fm_getattr
 import tests.testdata.python3.data.fake_module_with_warnings as fm
 from astroid.builder import AstroidBuilder
 from astroid.const import IS_PYPY
@@ -101,6 +106,14 @@ class RawBuildingTC(unittest.TestCase):
 
         # This should not raise an exception
         AstroidBuilder().module_build(m, "test")
+
+    def test_module_object_with_broken_getattr(self) -> None:
+        # Tests https://github.com/PyCQA/astroid/issues/1958
+        # When astroid deep inspection of modules raises
+        # errors when using hasattr().
+
+        # This should not raise an exception
+        AstroidBuilder().inspect_build(fm_getattr, "test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
Fix a regression in 2.13.2 where a RunTimeError could be raised unexpectedly
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Co-authored-by: Florian Bruhin <me@the-compiler.org>

Closes #1958
