### PR TITLE
Do not require typing_extensions on Python 3.11

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,8 @@ Release date: TBA
 
   Closes #1958
 
+* Remove unnecessary typing_extensions dependency on Python 3.11 and newer
+
 What's New in astroid 2.13.2?
 =============================
 Release date: 2023-01-08

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "wrapt>=1.14,<2;python_version>='3.11'",
     "wrapt>=1.11,<2;python_version<'3.11'",
     "typed-ast>=1.4.0,<2.0;implementation_name=='cpython' and python_version<'3.8'",
-    "typing-extensions>=4.0.0",
+    "typing-extensions>=4.0.0;python_version<'3.11'",
 ]
 dynamic = ["version"]
 

--- a/tests/unittest_scoped_nodes.py
+++ b/tests/unittest_scoped_nodes.py
@@ -1907,11 +1907,14 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         import typing
         import dataclasses
 
-        import typing_extensions
+        if sys.version_info >= (3, 8):
+            from typing import Protocol
+        else:
+            from typing_extensions import Protocol
 
         T = typing.TypeVar("T")
 
-        class MyProtocol(typing_extensions.Protocol): pass
+        class MyProtocol(Protocol): pass
         class EarlyBase(typing.Generic[T], MyProtocol): pass
         class Base(EarlyBase[T], abc.ABC): pass
         class Final(Base[object]): pass


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->
19878a55e61ce8788db530240dba9570706a5aac added an unconditional dependency on typing_extensions to fix tests with Python 3.10 3.11.
This commit fixes this issue by only requiring typing_extensions on Python versions lower than 3.11 and using standard typing on Python 3.11

cc @Pierre-Sassoulas 

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #1944 