### PR TITLE
Fix order of overwritten attributes in inherited dataclasses

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ Release date: TBA
 
   Closes #1958
 
+* Fix overwritten attributes in inherited dataclasses not being ordered correctly.
+
+  Closes PyCQA/pylint#7881
+
 * Fix a false positive when an attribute named ``Enum`` was confused with ``enum.Enum``.
   Calls to ``Enum`` are now inferred & the qualified name is checked.
 

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -334,9 +334,9 @@ def _generate_dataclass_init(  # pylint: disable=too-many-locals
         # Construct the param string to add to the init if necessary
         param_str = name
         if ann_str is not None:
-            param_str += ": " + ann_str
+            param_str += f": {ann_str}"
         if default_str is not None:
-            param_str += " = " + default_str
+            param_str += f" = {default_str}"
 
         # If the field is a kw_only field, we need to add it to the kw_only_params
         # This overwrites whether or not the class is kw_only decorated

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -353,6 +353,7 @@ def _generate_dataclass_init(  # pylint: disable=too-many-locals
             kw_only_params.append(param_str)
         else:
             # If the name was previously seen, overwrite that data
+            # pylint: disable-next=else-if-used
             if name in prev_pos_only_store:
                 prev_pos_only_store[name] = (ann_str, default_str)
             elif name in prev_kw_only_store:

--- a/astroid/brain/brain_dataclasses.py
+++ b/astroid/brain/brain_dataclasses.py
@@ -350,14 +350,18 @@ def _generate_dataclass_init(  # pylint: disable=too-many-locals
                 continue
         # If kw_only decorated, we need to add all parameters to the kw_only_params
         if kw_only_decorated:
-            kw_only_params.append(param_str)
+            if name in prev_kw_only_store:
+                prev_kw_only_store[name] = (ann_str, default_str)
+            else:
+                kw_only_params.append(param_str)
         else:
             # If the name was previously seen, overwrite that data
             # pylint: disable-next=else-if-used
             if name in prev_pos_only_store:
                 prev_pos_only_store[name] = (ann_str, default_str)
             elif name in prev_kw_only_store:
-                prev_kw_only_store[name] = (ann_str, default_str)
+                params = [name] + params
+                prev_kw_only_store.pop(name)
             else:
                 params.append(param_str)
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to astroid!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] For new features or bug fixes, add a ChangeLog entry describing what your PR does.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Closes PyCQA/pylint#7881

Slowly going through all of these `dataclass` issues. Turns out some of the previous tests were actually incorrectly ordered as well.