### PR TITLE
Fix issues with `typing_extensions.TypeVar`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ What's New in astroid 2.13.4?
 =============================
 Release date: TBA
 
+* Fix issues with ``typing_extensions.TypeVar``.
+
 
 
 What's New in astroid 2.13.3?

--- a/astroid/brain/brain_namedtuple_enum.py
+++ b/astroid/brain/brain_namedtuple_enum.py
@@ -40,7 +40,15 @@ ENUM_BASE_NAMES = {
     "enum.IntFlag",
 }
 ENUM_QNAME: Final[str] = "enum.Enum"
-TYPING_NAMEDTUPLE_BASENAMES: Final[set[str]] = {"NamedTuple", "typing.NamedTuple"}
+TYPING_NAMEDTUPLE_QUALIFIED: Final = {
+    "typing.NamedTuple",
+    "typing_extensions.NamedTuple",
+}
+TYPING_NAMEDTUPLE_BASENAMES: Final = {
+    "NamedTuple",
+    "typing.NamedTuple",
+    "typing_extensions.NamedTuple",
+}
 
 
 def _infer_first(node, context):
@@ -542,7 +550,7 @@ def infer_typing_namedtuple(
     except (InferenceError, StopIteration) as exc:
         raise UseInferenceDefault from exc
 
-    if func.qname() != "typing.NamedTuple":
+    if func.qname() not in TYPING_NAMEDTUPLE_QUALIFIED:
         raise UseInferenceDefault
 
     if len(node.args) != 2:

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -34,6 +34,7 @@ from astroid.nodes.node_classes import (
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 from astroid.util import Uninferable
 
+import sys
 if sys.version_info >= (3, 8):
     from typing import Final
 else:

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -35,12 +35,12 @@ from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 from astroid.util import Uninferable
 
 TYPING_TYPEVARS = {"TypeVar", "NewType"}
-TYPING_TYPEVARS_QUALIFIED = {
+TYPING_TYPEVARS_QUALIFIED: Final = {
     "typing.TypeVar",
     "typing.NewType",
     "typing_extensions.TypeVar",
 }
-TYPING_TYPEDDICT_QUALIFIED = {"typing.TypedDict", "typing_extensions.TypedDict"}
+TYPING_TYPEDDICT_QUALIFIED: Final = {"typing.TypedDict", "typing_extensions.TypedDict"}
 TYPING_TYPE_TEMPLATE = """
 class Meta(type):
     def __getitem__(self, item):

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -33,6 +33,10 @@ from astroid.nodes.node_classes import (
 )
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 from astroid.util import Uninferable
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 TYPING_TYPEVARS = {"TypeVar", "NewType"}
 TYPING_TYPEVARS_QUALIFIED: Final = {

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -34,9 +34,13 @@ from astroid.nodes.node_classes import (
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 from astroid.util import Uninferable
 
-TYPING_NAMEDTUPLE_BASENAMES = {"NamedTuple", "typing.NamedTuple"}
 TYPING_TYPEVARS = {"TypeVar", "NewType"}
-TYPING_TYPEVARS_QUALIFIED = {"typing.TypeVar", "typing.NewType"}
+TYPING_TYPEVARS_QUALIFIED = {
+    "typing.TypeVar",
+    "typing.NewType",
+    "typing_extensions.TypeVar",
+}
+TYPING_TYPEDDICT_QUALIFIED = {"typing.TypedDict", "typing_extensions.TypedDict"}
 TYPING_TYPE_TEMPLATE = """
 class Meta(type):
     def __getitem__(self, item):
@@ -186,7 +190,7 @@ def _looks_like_typedDict(  # pylint: disable=invalid-name
     node: FunctionDef | ClassDef,
 ) -> bool:
     """Check if node is TypedDict FunctionDef."""
-    return node.qname() in {"typing.TypedDict", "typing_extensions.TypedDict"}
+    return node.qname() in TYPING_TYPEDDICT_QUALIFIED
 
 
 def infer_old_typedDict(  # pylint: disable=invalid-name

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import sys
 import typing
 from collections.abc import Iterator
 from functools import partial
@@ -34,7 +35,6 @@ from astroid.nodes.node_classes import (
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 from astroid.util import Uninferable
 
-import sys
 if sys.version_info >= (3, 8):
     from typing import Final
 else:

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -33,6 +33,7 @@ from astroid.nodes.node_classes import (
 )
 from astroid.nodes.scoped_nodes import ClassDef, FunctionDef
 from astroid.util import Uninferable
+
 if sys.version_info >= (3, 8):
     from typing import Final
 else:

--- a/requirements_test_brain.txt
+++ b/requirements_test_brain.txt
@@ -9,3 +9,4 @@ types-python-dateutil
 six
 types-six
 urllib3
+typing_extensions>=4.4.0

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,4 +1,3 @@
 coverage~=7.0
 pytest
 pytest-cov~=4.0
-typing-extensions>=4.4.0

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,3 +1,4 @@
 coverage~=7.0
 pytest
 pytest-cov~=4.0
+typing-extensions>=4.4.0

--- a/tests/unittest_brain.py
+++ b/tests/unittest_brain.py
@@ -1764,6 +1764,18 @@ class TypingBrain(unittest.TestCase):
             inferred = next(node.infer())
             self.assertIsInstance(inferred, nodes.ClassDef, node.as_string())
 
+    def test_typing_extensions_types(self) -> None:
+        ast_nodes = builder.extract_node(
+            """
+        from typing_extensions import TypeVar
+        TypeVar('MyTypeVar', int, float, complex) #@
+        TypeVar('AnyStr', str, bytes) #@
+        """
+        )
+        for node in ast_nodes:
+            inferred = next(node.infer())
+            self.assertIsInstance(inferred, nodes.ClassDef, node.as_string())
+
     def test_typing_type_without_tip(self):
         """Regression test for https://github.com/PyCQA/pylint/issues/5770"""
         node = builder.extract_node(


### PR DESCRIPTION
## Description
Fix some issues with `typing_extensions.TypeVar` added in `4.4.0`.
Changes for pylint: https://github.com/PyCQA/pylint/pull/8089

While add it, clean up some more code. `typing_extensions` does include it's own copy of `NamedTuple` and `TypedDict` as well. _Although those changes might not actually be necessary, haven't seen a test failure for those yet. The existing tests pass even if the import is changed to `typing_extensions`. So didn't add any new ones._