### PR TITLE
Add support for binary union types - Python 3.10

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,9 @@ Release date: TBA
 
 * Fix issues with ``typing_extensions.TypeVar``.
 
+* Add support for inferring binary union types added in Python 3.10.
+
+  Refs PyCQA/pylint#8119
 
 
 What's New in astroid 2.13.3?

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@ What's New in astroid 2.14.0?
 =============================
 Release date: TBA
 
+* Add support for inferring binary union types added in Python 3.10.
+
+  Refs PyCQA/pylint#8119
 
 
 What's New in astroid 2.13.4?
@@ -14,9 +17,6 @@ Release date: TBA
 
 * Fix issues with ``typing_extensions.TypeVar``.
 
-* Add support for inferring binary union types added in Python 3.10.
-
-  Refs PyCQA/pylint#8119
 
 
 What's New in astroid 2.13.3?

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -121,11 +121,12 @@ class Proxy:
         if proxied is None:
             # This is a hack to allow calling this __init__ during bootstrapping of
             # builtin classes and their docstrings.
-            # For Const and Generator nodes the _proxied attribute is set during bootstrapping
+            # For Const, Generator, and UnionType nodes the _proxied attribute
+            # is set during bootstrapping
             # as we first need to build the ClassDef that they can proxy.
             # Thus, if proxied is None self should be a Const or Generator
             # as that is the only way _proxied will be correctly set as a ClassDef.
-            assert isinstance(self, (nodes.Const, Generator))
+            assert isinstance(self, (nodes.Const, Generator, UnionType))
         else:
             self._proxied = proxied
 
@@ -669,3 +670,36 @@ class AsyncGenerator(Generator):
 
     def __str__(self) -> str:
         return f"AsyncGenerator({self._proxied.name})"
+
+
+class UnionType(BaseInstance):
+    """Special node representing new style typing unions.
+
+    Proxied class is set once for all in raw_building.
+    """
+
+    _proxied: nodes.ClassDef
+
+    def __init__(self, left, right, parent=None):
+        super().__init__()
+        self.parent = parent
+        self.left = left
+        self.right = right
+
+    def callable(self) -> Literal[False]:
+        return False
+
+    def pytype(self) -> Literal["types.UnionType"]:
+        return "types.UnionType"
+
+    def display_type(self) -> str:
+        return "UnionType"
+
+    def bool_value(self, context: InferenceContext | None = None) -> Literal[True]:
+        return True
+
+    def __repr__(self) -> str:
+        return f"<UnionType({self._proxied.name}) l.{self.lineno} at 0x{id(self)}>"
+
+    def __str__(self) -> str:
+        return f"UnionType({self._proxied.name})"

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -694,14 +694,14 @@ class UnionType(BaseInstance):
     def callable(self) -> Literal[False]:
         return False
 
+    def bool_value(self, context: InferenceContext | None = None) -> Literal[True]:
+        return True
+
     def pytype(self) -> Literal["types.UnionType"]:
         return "types.UnionType"
 
     def display_type(self) -> str:
         return "UnionType"
-
-    def bool_value(self, context: InferenceContext | None = None) -> Literal[True]:
-        return True
 
     def __repr__(self) -> str:
         return f"<UnionType({self._proxied.name}) l.{self.lineno} at 0x{id(self)}>"

--- a/astroid/bases.py
+++ b/astroid/bases.py
@@ -680,7 +680,12 @@ class UnionType(BaseInstance):
 
     _proxied: nodes.ClassDef
 
-    def __init__(self, left, right, parent=None):
+    def __init__(
+        self,
+        left: UnionType | nodes.ClassDef | nodes.Const,
+        right: UnionType | nodes.ClassDef | nodes.Const,
+        parent: nodes.NodeNG | None = None,
+    ) -> None:
         super().__init__()
         self.parent = parent
         self.left = left

--- a/astroid/raw_building.py
+++ b/astroid/raw_building.py
@@ -550,6 +550,24 @@ def _astroid_bootstrapping() -> None:
         )
         bases.AsyncGenerator._proxied = _AsyncGeneratorType
         builder.object_build(bases.AsyncGenerator._proxied, types.AsyncGeneratorType)
+
+    if hasattr(types, "UnionType"):
+        _UnionTypeType = nodes.ClassDef(types.UnionType.__name__)
+        _UnionTypeType.parent = astroid_builtin
+        union_type_doc_node = (
+            nodes.Const(value=types.UnionType.__doc__)
+            if types.UnionType.__doc__
+            else None
+        )
+        _UnionTypeType.postinit(
+            bases=[],
+            body=[],
+            decorators=None,
+            doc_node=union_type_doc_node,
+        )
+        bases.UnionType._proxied = _UnionTypeType
+        builder.object_build(bases.UnionType._proxied, types.UnionType)
+
     builtin_types = (
         types.GetSetDescriptorType,
         types.GeneratorType,

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1225,6 +1225,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             assert n.inferred() == [util.Uninferable]
 
         code = """
+        from typing import List
+
         class A: ...
         class B: ...
 
@@ -1233,7 +1235,8 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
         int | str | None  #@
         A | B  #@
         A | None  #@
-        list[int] | int  #@
+        List[int] | int  #@
+        tuple | int  #@
         """
         ast_nodes = extract_node(code)
         if not PY310_PLUS:
@@ -1273,10 +1276,17 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             i5 = ast_nodes[5].inferred()[0]
             assert isinstance(i5, UnionType)
             assert isinstance(i5.left, nodes.ClassDef)
-            assert i5.left.name == "list"
+            assert i5.left.name == "List"
+
+            i6 = ast_nodes[6].inferred()[0]
+            assert isinstance(i6, UnionType)
+            assert isinstance(i6.left, nodes.ClassDef)
+            assert i6.left.name == "tuple"
 
         code = """
-        Alias1 = list[int]
+        from typing import List
+
+        Alias1 = List[int]
         Alias2 = str | int
 
         Alias1 | int  #@
@@ -1291,7 +1301,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             i0 = ast_nodes[0].inferred()[0]
             assert isinstance(i0, UnionType)
             assert isinstance(i0.left, nodes.ClassDef)
-            assert i0.left.name == "list"
+            assert i0.left.name == "List"
 
             i1 = ast_nodes[1].inferred()[0]
             assert isinstance(i1, UnionType)
@@ -1302,7 +1312,7 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             i2 = ast_nodes[2].inferred()[0]
             assert isinstance(i2, UnionType)
             assert isinstance(i2.left, nodes.ClassDef)
-            assert i2.left.name == "list"
+            assert i2.left.name == "List"
             assert isinstance(i2.right, UnionType)
 
     def test_nonregr_lambda_arg(self) -> None:

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -1250,6 +1250,14 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
             assert isinstance(i0.right, nodes.Const)
             assert i0.right.value is None
 
+            # Assert basic UnionType properties and methods
+            assert i0.callable() is False
+            assert i0.bool_value() is True
+            assert i0.pytype() == "types.UnionType"
+            assert i0.display_type() == "UnionType"
+            assert str(i0) == "UnionType(UnionType)"
+            assert repr(i0) == f"<UnionType(UnionType) l.None at 0x{id(i0)}>"
+
             i1 = ast_nodes[1].inferred()[0]
             assert isinstance(i1, UnionType)
 

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -21,9 +21,9 @@ from astroid import Slice, arguments
 from astroid import decorators as decoratorsmod
 from astroid import helpers, nodes, objects, test_utils, util
 from astroid.arguments import CallSite
-from astroid.bases import BoundMethod, Instance, UnboundMethod
+from astroid.bases import BoundMethod, Instance, UnboundMethod, UnionType
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import PY38_PLUS, PY39_PLUS
+from astroid.const import PY38_PLUS, PY39_PLUS, PY310_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -1208,6 +1208,102 @@ class InferenceTest(resources.SysPathSetup, unittest.TestCase):
                 "Const.int(value=5,\n          kind=None)",
             ],
         )
+
+    def test_binary_op_or_union_type(self) -> None:
+        """Binary or union is only defined for Python 3.10+."""
+        code = """
+        class A: ...
+
+        int | 2  #@
+        int | "Hello"  #@
+        int | ...  #@
+        int | A()  #@
+        int | None | 2  #@
+        """
+        ast_nodes = extract_node(code)
+        for n in ast_nodes:
+            assert n.inferred() == [util.Uninferable]
+
+        code = """
+        class A: ...
+        class B: ...
+
+        int | None  #@
+        int | str  #@
+        int | str | None  #@
+        A | B  #@
+        A | None  #@
+        list[int] | int  #@
+        """
+        ast_nodes = extract_node(code)
+        if not PY310_PLUS:
+            for n in ast_nodes:
+                assert n.inferred() == [util.Uninferable]
+        else:
+            i0 = ast_nodes[0].inferred()[0]
+            assert isinstance(i0, UnionType)
+            assert isinstance(i0.left, nodes.ClassDef)
+            assert i0.left.name == "int"
+            assert isinstance(i0.right, nodes.Const)
+            assert i0.right.value is None
+
+            i1 = ast_nodes[1].inferred()[0]
+            assert isinstance(i1, UnionType)
+
+            i2 = ast_nodes[2].inferred()[0]
+            assert isinstance(i2, UnionType)
+            assert isinstance(i2.left, UnionType)
+            assert isinstance(i2.left.left, nodes.ClassDef)
+            assert i2.left.left.name == "int"
+            assert isinstance(i2.left.right, nodes.ClassDef)
+            assert i2.left.right.name == "str"
+            assert isinstance(i2.right, nodes.Const)
+            assert i2.right.value is None
+
+            i3 = ast_nodes[3].inferred()[0]
+            assert isinstance(i3, UnionType)
+            assert isinstance(i3.left, nodes.ClassDef)
+            assert i3.left.name == "A"
+            assert isinstance(i3.right, nodes.ClassDef)
+            assert i3.right.name == "B"
+
+            i4 = ast_nodes[4].inferred()[0]
+            assert isinstance(i4, UnionType)
+
+            i5 = ast_nodes[5].inferred()[0]
+            assert isinstance(i5, UnionType)
+            assert isinstance(i5.left, nodes.ClassDef)
+            assert i5.left.name == "list"
+
+        code = """
+        Alias1 = list[int]
+        Alias2 = str | int
+
+        Alias1 | int  #@
+        Alias2 | int  #@
+        Alias1 | Alias2  #@
+        """
+        ast_nodes = extract_node(code)
+        if not PY310_PLUS:
+            for n in ast_nodes:
+                assert n.inferred() == [util.Uninferable]
+        else:
+            i0 = ast_nodes[0].inferred()[0]
+            assert isinstance(i0, UnionType)
+            assert isinstance(i0.left, nodes.ClassDef)
+            assert i0.left.name == "list"
+
+            i1 = ast_nodes[1].inferred()[0]
+            assert isinstance(i1, UnionType)
+            assert isinstance(i1.left, UnionType)
+            assert isinstance(i1.left.left, nodes.ClassDef)
+            assert i1.left.left.name == "str"
+
+            i2 = ast_nodes[2].inferred()[0]
+            assert isinstance(i2, UnionType)
+            assert isinstance(i2.left, nodes.ClassDef)
+            assert i2.left.name == "list"
+            assert isinstance(i2.right, UnionType)
 
     def test_nonregr_lambda_arg(self) -> None:
         code = """


### PR DESCRIPTION
## Description
Add basic inference support for runtime binary or unions added in Python 3.10.
Not completely sure this is 100% the right approach for it, but it works. We can always iterate on it later if we want / need to.

At runtime `int | None` is represented as an instance of `types.UnionType`.

Refs https://github.com/PyCQA/pylint/issues/8119

--
After this is merged, I think it would make sense to do a new release so we can include it in pylint `2.16.0`.