### PR TITLE
Fix PyPy `ClassDef.fromlino` with decorators

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@ Release date: TBA
 * Fix issues with ``typing_extensions.TypeVar``.
 
 
+* Fix ``ClassDef.fromlino`` for PyPy 3.8 (v7.3.11) if class is wrapped by a decorator.
+
 
 What's New in astroid 2.13.3?
 =============================

--- a/astroid/const.py
+++ b/astroid/const.py
@@ -18,6 +18,9 @@ WIN32 = sys.platform == "win32"
 IS_PYPY = sys.implementation.name == "pypy"
 IS_JYTHON = sys.implementation.name == "jython"
 
+# pylint: disable-next=no-member
+PYPY_7_3_11_PLUS = IS_PYPY and sys.pypy_version_info >= (7, 3, 11)  # type: ignore[attr-defined]
+
 
 class Context(enum.Enum):
     Load = 1

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, ClassVar, NoReturn, TypeVar, overload
 from astroid import bases
 from astroid import decorators as decorators_mod
 from astroid import util
-from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS
+from astroid.const import IS_PYPY, PY38, PY38_PLUS, PY39_PLUS, PYPY_7_3_11_PLUS
 from astroid.context import (
     CallContext,
     InferenceContext,
@@ -2139,9 +2139,10 @@ class ClassDef(
     @cached_property
     def fromlineno(self) -> int | None:
         """The first line that this node appears on in the source code."""
-        if not PY38_PLUS or PY38 and IS_PYPY:
+        if not PY38_PLUS or IS_PYPY and PY38 and not PYPY_7_3_11_PLUS:
             # For Python < 3.8 the lineno is the line number of the first decorator.
             # We want the class statement lineno. Similar to 'FunctionDef.fromlineno'
+            # PyPy (3.8): Fixed with version v7.3.11
             lineno = self.lineno
             if self.decorators is not None:
                 lineno += sum(

--- a/tests/unittest_nodes_position.py
+++ b/tests/unittest_nodes_position.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import textwrap
 
 from astroid import builder, nodes
-from astroid.const import IS_PYPY, PY38
 
 
 class TestNodePosition:
@@ -65,11 +64,9 @@ class TestNodePosition:
         assert isinstance(e, nodes.ClassDef)
         assert e.position == (13, 0, 13, 7)
 
-        if not PY38 or not IS_PYPY:
-            # The new (2022-12) version of pypy 3.8 broke this
-            f = ast_nodes[5]
-            assert isinstance(f, nodes.ClassDef)
-            assert f.position == (18, 0, 18, 7)
+        f = ast_nodes[5]
+        assert isinstance(f, nodes.ClassDef)
+        assert f.position == (18, 0, 18, 7)
 
     @staticmethod
     def test_position_function() -> None:


### PR DESCRIPTION
## Description
Followup to #1910
Never got around to reviewing it in time unfortunately.

The last PyPy release for 3.8 (v7.3.11) actually provided a fix for the ast lineno issue and is now compliant with the cpython implementation.

https://doc.pypy.org/en/latest/release-v7.3.11.html#python-3-8

/CC: @Pierre-Sassoulas 