### PR TITLE
Fix wrong inference cache result for `typing.cast` calls inside functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,8 +14,11 @@ Release date: TBA
 
 * Fix issues with ``typing_extensions.TypeVar``.
 
-
 * Fix ``ClassDef.fromlino`` for PyPy 3.8 (v7.3.11) if class is wrapped by a decorator.
+
+* Fix wrong inference cache result for ``typing.cast`` calls inside functions.
+
+  Closes PyCQA/pylint#8074
 
 
 What's New in astroid 2.13.3?

--- a/astroid/brain/brain_typing.py
+++ b/astroid/brain/brain_typing.py
@@ -419,7 +419,7 @@ AstroidManager().register_transform(
     Subscript, inference_tip(infer_typing_attr), _looks_like_typing_subscript
 )
 AstroidManager().register_transform(
-    Call, inference_tip(infer_typing_cast), _looks_like_typing_cast
+    Call, inference_tip(infer_typing_cast, cached=False), _looks_like_typing_cast
 )
 
 if PY39_PLUS:

--- a/astroid/inference_tip.py
+++ b/astroid/inference_tip.py
@@ -47,12 +47,16 @@ def _inference_tip_cached(
     return iter(result)
 
 
-def inference_tip(infer_function: InferFn, raise_on_overwrite: bool = False) -> InferFn:
+def inference_tip(
+    infer_function: InferFn, raise_on_overwrite: bool = False, *, cached: bool = True
+) -> InferFn:
     """Given an instance specific inference function, return a function to be
     given to AstroidManager().register_transform to set this inference function.
 
     :param bool raise_on_overwrite: Raise an `InferenceOverwriteError`
         if the inference tip will overwrite another. Used for debugging
+    :param cached: Whether to cache the inference function and reuse the result.
+        Set to 'False' if the result is dependents on the caller.
 
     Typical usage
 
@@ -84,7 +88,9 @@ def inference_tip(infer_function: InferFn, raise_on_overwrite: bool = False) -> 
                 )
             )
         # pylint: disable=no-value-for-parameter
-        node._explicit_inference = _inference_tip_cached(infer_function)
+        node._explicit_inference = (
+            _inference_tip_cached(infer_function) if cached else infer_function
+        )
         return node
 
     return transform


### PR DESCRIPTION
## Description
The result for the `typing.cast` inference tip depend could depend on the arguments passed to the parent function.
Those aren't included in the cache key which could cause the first (invalid) inference result to be returned again.

This PR adds a new parameter to `inference_tip` -> `cached`, to be able to opt out of caching for specific inference tips.
In most cases this shouldn't be needed. Therefore the default is set to `True`.

https://github.com/PyCQA/astroid/blob/dfd88f5edc636df80c8cabd61a6b8d6bc8746ca9/astroid/inference_tip.py#L36-L38

```py
from typing import TypeVar, cast
T = TypeVar("T")
def ident(var: T) -> T:
    return cast(T, var)

ident(2)  #@
ident("Hello")  #@
```

Closes https://github.com/PyCQA/pylint/issues/8074
