### PR TITLE
Preserve parent `CallContext` when inferring nested functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,8 +14,11 @@ Release date: TBA
 
 * Fix issues with ``typing_extensions.TypeVar``.
 
-
 * Fix ``ClassDef.fromlino`` for PyPy 3.8 (v7.3.11) if class is wrapped by a decorator.
+
+* Preserve parent CallContext when inferring nested functions.
+
+  Closes PyCQA/pylint#8074
 
 
 What's New in astroid 2.13.3?

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -161,13 +161,14 @@ class InferenceContext:
 class CallContext:
     """Holds information for a call site."""
 
-    __slots__ = ("args", "keywords", "callee")
+    __slots__ = ("args", "keywords", "callee", "parent_call_context")
 
     def __init__(
         self,
         args: list[NodeNG],
         keywords: list[Keyword] | None = None,
         callee: NodeNG | None = None,
+        parent_call_context: CallContext | None = None,
     ):
         self.args = args  # Call positional arguments
         if keywords:
@@ -176,6 +177,9 @@ class CallContext:
             arg_value_pairs = []
         self.keywords = arg_value_pairs  # Call keyword arguments
         self.callee = callee  # Function being called
+        self.parent_call_context = (
+            parent_call_context  # Parent CallContext for nested calls
+        )
 
 
 def copy_context(context: InferenceContext | None) -> InferenceContext:

--- a/astroid/inference.py
+++ b/astroid/inference.py
@@ -273,7 +273,10 @@ def infer_call(
         try:
             if hasattr(callee, "infer_call_result"):
                 callcontext.callcontext = CallContext(
-                    args=self.args, keywords=self.keywords, callee=callee
+                    args=self.args,
+                    keywords=self.keywords,
+                    callee=callee,
+                    parent_call_context=callcontext.callcontext,
                 )
                 yield from callee.infer_call_result(caller=self, context=callcontext)
         except InferenceError:

--- a/astroid/protocols.py
+++ b/astroid/protocols.py
@@ -470,7 +470,7 @@ def arguments_assigned_stmts(
         # reset call context/name
         callcontext = context.callcontext
         context = copy_context(context)
-        context.callcontext = None
+        context.callcontext = callcontext.parent_call_context
         args = arguments.CallSite(callcontext, context=context)
         return args.infer_argument(self.parent, node_name, context)
     return _arguments_infer_argname(self, node_name, context)

--- a/tests/unittest_inference_calls.py
+++ b/tests/unittest_inference_calls.py
@@ -146,8 +146,6 @@ def test_inner_call_with_const_argument() -> None:
 def test_inner_call_with_dynamic_argument() -> None:
     """Test function where return value is the result of a separate function call,
     with a dynamic value passed to the inner function.
-
-    Currently, this is Uninferable.
     """
     node = builder.extract_node(
         """
@@ -163,7 +161,8 @@ def test_inner_call_with_dynamic_argument() -> None:
     assert isinstance(node, nodes.NodeNG)
     inferred = node.inferred()
     assert len(inferred) == 1
-    assert inferred[0] is Uninferable
+    assert isinstance(inferred[0], nodes.Const)
+    assert inferred[0].value == 3
 
 
 def test_method_const_instance_attr() -> None:


### PR DESCRIPTION
## Description
Alternative to #1981
At the moment `infer_call` creates a new `CallContext` for each `infer_call_result` call overwriting the current one. Result was that nested functions with dynamic values couldn't be inferred.

Instead of overwriting the `CallContext`, keep it in `parent_call_context` so it can be reused later.
With that nested functions can now be inferred. The custom inference tip for `typing.cast` is thus no longer necessary.

https://github.com/PyCQA/astroid/blob/dfd88f5edc636df80c8cabd61a6b8d6bc8746ca9/astroid/inference.py#L274-L278

```py
def f(x):
    return g(x)

def g(y):
    return y + 2

f(1)  #@
```

Closes https://github.com/PyCQA/pylint/issues/8074
