### PR TITLE
Set higher recusion limit (2**12) for PyPy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,9 @@ Release date: TBA
 
   Closes PyCQA/pylint#8074
 
+* Set a higher recursion limit at ``2**12``, instead of ``1000``
+  to prevent accidental ``RecursionErrors``.
+
 
 What's New in astroid 2.13.3?
 =============================

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@ Release date: TBA
 
   Closes PyCQA/pylint#8074
 
-* Set a higher recursion limit at ``2**12``, instead of ``1000``
+* Set a higher recursion limit at ``2**12`` for PyPy, instead of ``1000``
   to prevent accidental ``RecursionErrors``.
 
 

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -49,7 +49,15 @@ from astroid.astroid_manager import MANAGER
 from astroid.bases import BaseInstance, BoundMethod, Instance, UnboundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
-from astroid.const import BRAIN_MODULES_DIRECTORY, PY310_PLUS, Context, Del, Load, Store
+from astroid.const import (
+    BRAIN_MODULES_DIRECTORY,
+    IS_PYPY,
+    PY310_PLUS,
+    Context,
+    Del,
+    Load,
+    Store,
+)
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidBuildingException,
@@ -192,8 +200,9 @@ if (
 ):
     tokenize._compile = functools.lru_cache()(tokenize._compile)  # type: ignore[attr-defined]
 
-# Set a higher recursion limit. 10**3 is a bit low. Especially for PyPy.
-sys.setrecursionlimit(2**12)
+if IS_PYPY:
+    # Set a higher recursion limit for PyPy. 1000 is a bit low.
+    sys.setrecursionlimit(2**12)
 
 # load brain plugins
 for module in BRAIN_MODULES_DIRECTORY.iterdir():

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -31,6 +31,7 @@ Main modules are:
 """
 
 import functools
+import sys
 import tokenize
 from importlib import import_module
 
@@ -190,6 +191,9 @@ if (
     and getattr(tokenize._compile, "__wrapped__", None) is None  # type: ignore[attr-defined]
 ):
     tokenize._compile = functools.lru_cache()(tokenize._compile)  # type: ignore[attr-defined]
+
+# Set a higher recursion limit. 10**3 is a bit low. Especially for PyPy.
+sys.setrecursionlimit(2**12)
 
 # load brain plugins
 for module in BRAIN_MODULES_DIRECTORY.iterdir():


### PR DESCRIPTION
## Description
#1982 increases the number of recursions to properly determine all call variables. With the default recursion limit of `1000`, this can sometimes lead to RecursionErrors, especially on `PyPy` which seems to need more steps / function calls compared to CPython.

This PR increases the recursion limit to `2**12` (4096). For comparison, mypy uses `2**14` (16.384).

Failing CI run: https://github.com/PyCQA/astroid/actions/runs/4035944885/jobs/6938193475
Successful rerun: https://github.com/PyCQA/astroid/actions/runs/4035944885/jobs/6938237623

The test causing the error is `tests/unittest_inference.py::test_recursion_on_inference_tip` added in #1392 to test infinite recursion. AFAICT this doesn't happen here, otherwise the test would always fail. The recursion limit is just a bit low.