### PR TITLE
Revert "Set higher recusion limit (2**12) for PyPy"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,9 +20,6 @@ Release date: TBA
 
   Closes PyCQA/pylint#8074
 
-* Set a higher recursion limit at ``2**12`` for PyPy, instead of ``1000``
-  to prevent accidental ``RecursionErrors``.
-
 
 What's New in astroid 2.13.3?
 =============================

--- a/astroid/__init__.py
+++ b/astroid/__init__.py
@@ -31,7 +31,6 @@ Main modules are:
 """
 
 import functools
-import sys
 import tokenize
 from importlib import import_module
 
@@ -49,15 +48,7 @@ from astroid.astroid_manager import MANAGER
 from astroid.bases import BaseInstance, BoundMethod, Instance, UnboundMethod
 from astroid.brain.helpers import register_module_extender
 from astroid.builder import extract_node, parse
-from astroid.const import (
-    BRAIN_MODULES_DIRECTORY,
-    IS_PYPY,
-    PY310_PLUS,
-    Context,
-    Del,
-    Load,
-    Store,
-)
+from astroid.const import BRAIN_MODULES_DIRECTORY, PY310_PLUS, Context, Del, Load, Store
 from astroid.exceptions import (
     AstroidBuildingError,
     AstroidBuildingException,
@@ -199,10 +190,6 @@ if (
     and getattr(tokenize._compile, "__wrapped__", None) is None  # type: ignore[attr-defined]
 ):
     tokenize._compile = functools.lru_cache()(tokenize._compile)  # type: ignore[attr-defined]
-
-if IS_PYPY:
-    # Set a higher recursion limit for PyPy. 1000 is a bit low.
-    sys.setrecursionlimit(2**12)
 
 # load brain plugins
 for module in BRAIN_MODULES_DIRECTORY.iterdir():


### PR DESCRIPTION
Reverts PyCQA/astroid#1984

See discussion here: https://github.com/PyCQA/astroid/pull/1984#issuecomment-1407702477
The issue seems to be with coverage on `PyPy` and the particular recursion test. This isolates the issue when run with PyPy
```
pytest tests/unittest_inference.py --cov -k test_recursion_on_inference_tip
```

The change is thus not necessary. Reverting it to prevent accidental issues. I'll open a followup to skip the particular test on PyPy, shortly.

--
The backport #1985 wasn't merged into the maintenance branch, so it isn't necessary to backport this one.