### PR TITLE
Skip recursion test on PyPy

### DIFF
--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -6828,7 +6828,8 @@ def test_recursion_on_inference_tip() -> None:
 
     Originally reported in https://github.com/PyCQA/pylint/issues/5408.
 
-    When run on PyPy with coverage enabled, the test can sometimes raise a RecursionError.
+    When run on PyPy with coverage enabled, the test can sometimes raise a RecursionError
+    outside of the code that we actually want to test.
     As the issue seems to be with coverage, skip the test on PyPy.
     https://github.com/PyCQA/astroid/pull/1984#issuecomment-1407720311
     """

--- a/tests/unittest_inference.py
+++ b/tests/unittest_inference.py
@@ -23,7 +23,7 @@ from astroid import helpers, nodes, objects, test_utils, util
 from astroid.arguments import CallSite
 from astroid.bases import BoundMethod, Instance, UnboundMethod
 from astroid.builder import AstroidBuilder, _extract_single_node, extract_node, parse
-from astroid.const import PY38_PLUS, PY39_PLUS
+from astroid.const import IS_PYPY, PY38_PLUS, PY39_PLUS
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidTypeError,
@@ -6820,10 +6820,17 @@ def test_imported_module_var_inferable3() -> None:
     assert i_w_val.as_string() == "['w', 'v']"
 
 
+@pytest.mark.skipif(
+    IS_PYPY, reason="Test run with coverage on PyPy sometimes raises a RecursionError"
+)
 def test_recursion_on_inference_tip() -> None:
     """Regression test for recursion in inference tip.
 
     Originally reported in https://github.com/PyCQA/pylint/issues/5408.
+
+    When run on PyPy with coverage enabled, the test can sometimes raise a RecursionError.
+    As the issue seems to be with coverage, skip the test on PyPy.
+    https://github.com/PyCQA/astroid/pull/1984#issuecomment-1407720311
     """
     code = """
     class MyInnerClass:


### PR DESCRIPTION
## Description
Followup to https://github.com/PyCQA/astroid/pull/1984#issuecomment-1407720311 and #1986

Skip recursion test on PyPy, since it can sometimes raise a `RecursionError` when run with coverage enabled.