### PR TITLE
Update isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         exclude: tests/testdata
         args: [--py37-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         exclude: tests/testdata

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,6 +1,6 @@
 black==23.1a1
 pylint==2.15.10
-isort==5.11.4
+isort==5.12.0
 flake8==5.0.4
 flake8-typing-imports==1.14.0
 mypy==0.991


### PR DESCRIPTION
## Description
Release notes: https://github.com/PyCQA/isort/releases/tag/5.12.0
Compare view: https://github.com/PyCQA/isort/compare/5.11.4...5.12.0

Necessary to fix isort with pre-commit.
https://results.pre-commit.ci/run/github/47649855/1675040451.XdcHB7Z0RYKbFFupcocPng

--
Pylint: https://github.com/PyCQA/pylint/pull/8130