### PR TITLE
[Backport maintenance/2.13.x] Update isort to 5.12.0 (#1989)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         exclude: tests/testdata
         args: [--py37-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         exclude: tests/testdata

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,6 +1,6 @@
 black==23.1a1
 pylint==2.15.9
-isort==5.11.4
+isort==5.12.0
 flake8==5.0.4
 flake8-typing-imports==1.14.0
 mypy==0.991


### PR DESCRIPTION
Manual backport of e31c9c48c63943cec9be87a70fe0ef30b38c0ab0 from #1989
(cherry picked from commit e31c9c48c63943cec9be87a70fe0ef30b38c0ab0)