### PR TITLE
Fix dev requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,8 +100,8 @@ jobs:
         run: >-
           echo "key=${{ env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{
             hashFiles('pyproject.toml', 'requirements_test.txt',
-          'requirements_test_min.txt', 'requirements_test_brain.txt') }}" >>
-          $GITHUB_OUTPUT
+          'requirements_test_min.txt', 'requirements_test_brain.txt',
+          'requirements_test_pre_commit.txt') }}" >> $GITHUB_OUTPUT
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@v3.2.3

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,6 +1,7 @@
 black==23.1a1
 pylint==2.15.10
-isort==5.12.0
-flake8==5.0.4
-flake8-typing-imports==1.14.0
+isort==5.12.0;python_version>='3.8'
+flake8==6.0.0;python_version>='3.8'
+flake8-typing-imports==1.14.0;python_version>='3.8'
+flake8-bugbear==22.10.27;python_version>='3.8'
 mypy==0.991


### PR DESCRIPTION
## Description
We recently upgraded isort to `5.12.0` without realizing that, similar to flake8, they dropped support for Python 3.7.
The `requirements_test_pre_commit.txt` file wasn't included in the cache  key, thus the old cache was reused without actually installing `5.12.0` into the CI environment.

_Pre-commit.ci uses the version from `pre-commit-config` so that was fine._

This PR also updates the version for `flake8` to get in sync to our pre-commit config.

--
Tbh as more and more tools start to drop `3.7`, I'm not opposed to doing the same. Maybe after the `2.16.0` release?
Pylint could still be used to lint `3.7` code, only run with Python `3.8`.

Failing test from #1992: https://github.com/PyCQA/astroid/actions/runs/4046304756/jobs/6958923838