### PR TITLE
Add some type annotations

### DIFF
--- a/astroid/builder.py
+++ b/astroid/builder.py
@@ -358,12 +358,9 @@ def _find_statement_by_line(node: nodes.NodeNG, line: int) -> nodes.NodeNG | Non
     recursively.
 
     :param node: An astroid node.
-    :type node: astroid.bases.NodeNG
     :param line: The line number of the statement to extract.
-    :type line: int
     :returns: The statement on the line, or None if no statement for the line
       can be found.
-    :rtype:  astroid.bases.NodeNG or None
     """
     if isinstance(node, (nodes.ClassDef, nodes.FunctionDef, nodes.MatchCase)):
         # This is an inaccuracy in the AST: the nodes that can be

--- a/astroid/context.py
+++ b/astroid/context.py
@@ -198,7 +198,6 @@ def bind_context_to_node(context: InferenceContext | None, node) -> InferenceCon
     :type node NodeNG:
 
     :returns: A new context
-    :rtype: InferenceContext
     """
     context = copy_context(context)
     context.boundnode = node

--- a/astroid/decorators.py
+++ b/astroid/decorators.py
@@ -143,7 +143,6 @@ def raise_if_nothing_inferred(func, instance, args, kwargs):
     except StopIteration as error:
         # generator is empty
         if error.args:
-            # pylint: disable=not-a-mapping
             raise InferenceError(**error.args[0]) from error
         raise InferenceError(
             "StopIteration raised without any error information."

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -226,7 +226,6 @@ class ZipFinder(Finder):
         super().__init__(path)
         for entry_path in path:
             if entry_path not in sys.path_importer_cache:
-                # pylint: disable=no-member
                 try:
                     sys.path_importer_cache[entry_path] = zipimport.zipimporter(  # type: ignore[assignment]
                         entry_path
@@ -310,7 +309,6 @@ def _is_setuptools_namespace(location: pathlib.Path) -> bool:
 
 def _get_zipimporters() -> Iterator[tuple[str, zipimport.zipimporter]]:
     for filepath, importer in sys.path_importer_cache.items():
-        # pylint: disable-next=no-member
         if isinstance(importer, zipimport.zipimporter):
             yield filepath, importer
 

--- a/astroid/interpreter/_import/spec.py
+++ b/astroid/interpreter/_import/spec.py
@@ -375,7 +375,6 @@ def find_spec(modpath: list[str], path: Sequence[str] | None = None) -> ModuleSp
       optional list of path where the module or package should be
       searched (use sys.path if nothing or None is given)
 
-    :rtype: ModuleSpec
     :return: A module spec, which describes how the module was
              found and where.
     """

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -255,7 +255,6 @@ class AstroidManager:
             except ValueError:
                 continue
             try:
-                # pylint: disable-next=no-member
                 importer = zipimport.zipimporter(eggpath + ext)
                 zmodname = resource.replace(os.path.sep, ".")
                 if importer.is_package(resource):

--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -213,7 +213,7 @@ class MultiLineWithElseBlockNode(MultiLineBlockNode):
     def blockstart_tolineno(self):
         return self.lineno
 
-    def _elsed_block_range(self, lineno, orelse, last=None):
+    def _elsed_block_range(self, lineno, orelse, last=None) -> tuple[int, int]:
         """Handle block line numbers range for try/finally, for, if and while
         statements.
         """

--- a/astroid/nodes/const.py
+++ b/astroid/nodes/const.py
@@ -2,6 +2,8 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 OPS: list[list[str]] = [
     ["Lambda"],  # lambda x: x + 1
     ["IfExp"],  # 1 if True else 2

--- a/astroid/nodes/const.py
+++ b/astroid/nodes/const.py
@@ -21,7 +21,5 @@ OPS: list[list[str]] = [
 ]
 
 OP_PRECEDENCE: dict[str, int] = {
-    op: precedence
-    for precedence, ops in enumerate(OPS)
-    for op in ops
+    op: precedence for precedence, ops in enumerate(OPS) for op in ops
 }

--- a/astroid/nodes/const.py
+++ b/astroid/nodes/const.py
@@ -2,26 +2,26 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
-OP_PRECEDENCE = {
+OPS: list[list[str]] = [
+    ["Lambda"],  # lambda x: x + 1
+    ["IfExp"],  # 1 if True else 2
+    ["or"],
+    ["and"],
+    ["not"],
+    ["Compare"],  # in, not in, is, is not, <, <=, >, >=, !=, ==
+    ["|"],
+    ["^"],
+    ["&"],
+    ["<<", ">>"],
+    ["+", "-"],
+    ["*", "@", "/", "//", "%"],
+    ["UnaryOp"],  # +, -, ~
+    ["**"],
+    ["Await"],
+]
+
+OP_PRECEDENCE: dict[str, int] = {
     op: precedence
-    for precedence, ops in enumerate(
-        [
-            ["Lambda"],  # lambda x: x + 1
-            ["IfExp"],  # 1 if True else 2
-            ["or"],
-            ["and"],
-            ["not"],
-            ["Compare"],  # in, not in, is, is not, <, <=, >, >=, !=, ==
-            ["|"],
-            ["^"],
-            ["&"],
-            ["<<", ">>"],
-            ["+", "-"],
-            ["*", "@", "/", "//", "%"],
-            ["UnaryOp"],  # +, -, ~
-            ["**"],
-            ["Await"],
-        ]
-    )
+    for precedence, ops in enumerate(OPS)
     for op in ops
 }

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -11,7 +11,7 @@ import itertools
 import sys
 import typing
 import warnings
-from collections.abc import Generator, Iterable, Mapping, Iterator
+from collections.abc import Generator, Iterable, Iterator, Mapping
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, TypeVar, Union
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -156,7 +156,6 @@ class NodeNG:
         if self._explicit_inference is not None:
             # explicit_inference is not bound, give it self explicitly
             try:
-                # pylint: disable=not-callable
                 results = list(self._explicit_inference(self, context, **kwargs))
                 if context is not None:
                     context.nodes_inferred += len(results)

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -150,7 +150,6 @@ class NodeNG:
         called instead of the default interface.
 
         :returns: The inferred values.
-        :rtype: iterable
         """
         if context is not None:
             context = context.extra_context.get(self, context)
@@ -424,20 +423,12 @@ class NodeNG:
     # FIXME : should we merge child_sequence and locate_child ? locate_child
     # is only used in are_exclusive, child_sequence one time in pylint.
 
-    def next_sibling(self):
-        """The next sibling statement node.
-
-        :returns: The next sibling statement node.
-        :rtype: NodeNG or None
-        """
+    def next_sibling(self) -> NodeNG | None:
+        """The next sibling statement node."""
         return self.parent.next_sibling()
 
-    def previous_sibling(self):
-        """The previous sibling statement.
-
-        :returns: The previous sibling statement node.
-        :rtype: NodeNG or None
-        """
+    def previous_sibling(self) -> NodeNG | None:
+        """The previous sibling statement."""
         return self.parent.previous_sibling()
 
     # these are lazy because they're relatively expensive to compute for every
@@ -482,16 +473,8 @@ class NodeNG:
                 parent = parent.parent
         return line
 
-    def block_range(self, lineno):
-        """Get a range from the given line number to where this node ends.
-
-        :param lineno: The line number to start the range at.
-        :type lineno: int
-
-        :returns: The range of line numbers that this node belongs to,
-            starting at the given line number.
-        :rtype: tuple(int, int or None)
-        """
+    def block_range(self, lineno: int) -> tuple[int, int]:
+        """Get a range from the given line number to where this node ends."""
         return lineno, self.tolineno
 
     def set_local(self, name: str, stmt: NodeNG) -> None:
@@ -647,40 +630,33 @@ class NodeNG:
 
     def repr_tree(
         self,
-        ids=False,
-        include_linenos=False,
-        ast_state=False,
-        indent="   ",
-        max_depth=0,
-        max_width=80,
+        ids: bool=False,
+        include_linenos: bool=False,
+        ast_state: bool=False,
+        indent: str="   ",
+        max_depth: int=0,
+        max_width: int=80,
     ) -> str:
         """Get a string representation of the AST from this node.
 
         :param ids: If true, includes the ids with the node type names.
-        :type ids: bool
 
         :param include_linenos: If true, includes the line numbers and
             column offsets.
-        :type include_linenos: bool
 
         :param ast_state: If true, includes information derived from
             the whole AST like local and global variables.
-        :type ast_state: bool
 
         :param indent: A string to use to indent the output string.
-        :type indent: str
 
         :param max_depth: If set to a positive integer, won't return
             nodes deeper than max_depth in the string.
-        :type max_depth: int
 
         :param max_width: Attempt to format the output string to stay
             within this number of characters, but can exceed it under some
             circumstances. Only positive integer values are valid, the default is 80.
-        :type max_width: int
 
         :returns: The string representation of the AST.
-        :rtype: str
         """
 
         @_singledispatch
@@ -803,7 +779,7 @@ class NodeNG:
         """
         return util.Uninferable
 
-    def op_precedence(self):
+    def op_precedence(self) -> int:
         # Look up by class name or default to highest precedence
         return OP_PRECEDENCE.get(self.__class__.__name__, len(OP_PRECEDENCE))
 

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -630,12 +630,12 @@ class NodeNG:
 
     def repr_tree(
         self,
-        ids: bool=False,
-        include_linenos: bool=False,
-        ast_state: bool=False,
-        indent: str="   ",
-        max_depth: int=0,
-        max_width: int=80,
+        ids: bool = False,
+        include_linenos: bool = False,
+        ast_state: bool = False,
+        indent: str = "   ",
+        max_depth: int = 0,
+        max_width: int = 80,
     ) -> str:
         """Get a string representation of the AST from this node.
 

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -150,14 +150,14 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         """The names of locals defined in this scoped node."""
         return list(self.locals.keys())
 
-    def values(self) -> list[NodeNG]:
+    def values(self) -> list[nodes.NodeNG]:
         """The nodes that define the locals in this scoped node."""
         # pylint: disable=consider-using-dict-items
         # It look like this class override items/keys/values,
         # probably not worth the headache
         return [self[key] for key in self.keys()]
 
-    def items(self) -> list[tuple[str, NodeNG]]:
+    def items(self) -> list[tuple[str, nodes.NodeNG]]:
         """Get the names of the locals and the node that defines the local."""
         return list(zip(self.keys(), self.values()))
 

--- a/astroid/nodes/scoped_nodes/mixin.py
+++ b/astroid/nodes/scoped_nodes/mixin.py
@@ -34,21 +34,15 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         """Get the 'qualified' name of the node.
 
         For example: module.name, module.class.name ...
-
-        :returns: The qualified name.
-        :rtype: str
         """
+
         # pylint: disable=no-member; github.com/pycqa/astroid/issues/278
         if self.parent is None:
             return self.name
         return f"{self.parent.frame(future=True).qname()}.{self.name}"
 
     def scope(self: _T) -> _T:
-        """The first parent node defining a new scope.
-
-        :returns: The first parent scope node.
-        :rtype: Module or FunctionDef or ClassDef or Lambda or GenExpr
-        """
+        """The first parent node defining a new scope."""
         return self
 
     def scope_lookup(self, node, name: str, offset: int = 0):
@@ -152,41 +146,23 @@ class LocalsDictNodeNG(node_classes.LookupMixIn):
         """
         return iter(self.keys())
 
-    def keys(self):
-        """The names of locals defined in this scoped node.
-
-        :returns: The names of the defined locals.
-        :rtype: list(str)
-        """
+    def keys(self) -> list[str]:
+        """The names of locals defined in this scoped node."""
         return list(self.locals.keys())
 
-    def values(self):
-        """The nodes that define the locals in this scoped node.
-
-        :returns: The nodes that define locals.
-        :rtype: list(NodeNG)
-        """
+    def values(self) -> list[NodeNG]:
+        """The nodes that define the locals in this scoped node."""
         # pylint: disable=consider-using-dict-items
         # It look like this class override items/keys/values,
         # probably not worth the headache
         return [self[key] for key in self.keys()]
 
-    def items(self):
-        """Get the names of the locals and the node that defines the local.
-
-        :returns: The names of locals and their associated node.
-        :rtype: list(tuple(str, NodeNG))
-        """
+    def items(self) -> list[tuple[str, NodeNG]]:
+        """Get the names of the locals and the node that defines the local."""
         return list(zip(self.keys(), self.values()))
 
-    def __contains__(self, name) -> bool:
-        """Check if a local is defined in this scope.
-
-        :param name: The name of the local to check for.
-        :type name: str
-
-        :returns: Whether this node has a local of the given name,
-        """
+    def __contains__(self, name: str) -> bool:
+        """Check if a local is defined in this scope."""
         return name in self.locals
 
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -343,18 +343,14 @@ class Module(LocalsDictNodeNG):
         """
         return self._get_stream()
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from where this node starts to where this node ends.
 
         :param lineno: Unused.
-        :type lineno: int
-
-        :returns: The range of line numbers that this node belongs to.
-        :rtype: tuple(int, int)
         """
         return self.fromlineno, self.tolineno
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(self, node, name: str, offset: int = 0):
         """Lookup where the given variable is assigned.
 
         :param node: The node to look for assignments up to.
@@ -362,10 +358,8 @@ class Module(LocalsDictNodeNG):
         :type node: NodeNG
 
         :param name: The name of the variable to find assignments for.
-        :type name: str
 
         :param offset: The line offset to filter statements up to.
-        :type offset: int
 
         :returns: This scope node and the list of assignments associated to the
             given name according to the scope where it has been found (locals,
@@ -650,7 +644,7 @@ class Module(LocalsDictNodeNG):
         """
         return True
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         yield from self.body
 
     def frame(self: _T, *, future: Literal[None, True] = None) -> _T:
@@ -741,7 +735,7 @@ class GeneratorExp(ComprehensionScope):
         """
         return True
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         yield self.elt
 
         yield from self.generators
@@ -839,7 +833,7 @@ class DictComp(ComprehensionScope):
         """
         return util.Uninferable
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         yield self.key
         yield self.value
 
@@ -924,7 +918,7 @@ class SetComp(ComprehensionScope):
         """
         return util.Uninferable
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         yield self.elt
 
         yield from self.generators
@@ -992,7 +986,7 @@ class ListComp(ComprehensionScope):
         """
         return util.Uninferable
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         yield self.elt
 
         yield from self.generators
@@ -1182,7 +1176,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         # to None due to a strong interaction between Lambda and FunctionDef.
         return self.body.infer(context)
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(self, node, name: str, offset: int=0):
         """Lookup where the given names is assigned.
 
         :param node: The node to look for assignments up to.
@@ -1218,7 +1212,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         """
         return True
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         yield self.args
         yield self.body
 
@@ -1540,24 +1534,19 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         return lineno
 
     @cached_property
-    def blockstart_tolineno(self):
-        """The line on which the beginning of this block ends.
-
-        :type: int
-        """
+    def blockstart_tolineno(self) -> int:
+        """The line on which the beginning of this block ends."""
         return self.args.tolineno
 
     def implicit_parameters(self) -> Literal[0, 1]:
         return 1 if self.is_bound() else 0
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: Unused.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
-        :rtype: tuple(int, int)
         """
         return self.fromlineno, self.tolineno
 
@@ -1742,7 +1731,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
         """
         return True
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         if self.decorators is not None:
             yield self.decorators
 
@@ -2153,24 +2142,20 @@ class ClassDef(
         return super().fromlineno
 
     @cached_property
-    def blockstart_tolineno(self):
+    def blockstart_tolineno(self) -> int:
         """The line on which the beginning of this block ends.
-
-        :type: int
         """
         if self.bases:
             return self.bases[-1].tolineno
 
         return self.fromlineno
 
-    def block_range(self, lineno):
+    def block_range(self, lineno: int) -> tuple[int, int]:
         """Get a range from the given line number to where this node ends.
 
         :param lineno: Unused.
-        :type lineno: int
 
         :returns: The range of line numbers that this node belongs to,
-        :rtype: tuple(int, int)
         """
         return self.fromlineno, self.tolineno
 
@@ -2289,7 +2274,7 @@ class ClassDef(
         else:
             yield self.instantiate_class()
 
-    def scope_lookup(self, node, name, offset=0):
+    def scope_lookup(self, node, name: str, offset: int = 0):
         """Lookup where the given name is assigned.
 
         :param node: The node to look for assignments up to.
@@ -2297,10 +2282,8 @@ class ClassDef(
         :type node: NodeNG
 
         :param name: The name to find assignments for.
-        :type name: str
 
         :param offset: The line offset to filter statements up to.
-        :type offset: int
 
         :returns: This scope node and the list of assignments associated to the
             given name according to the scope where it has been found (locals,
@@ -3050,7 +3033,7 @@ class ClassDef(
         """
         return True
 
-    def get_children(self):
+    def get_children(self) -> Iterator[NodeNG]:
         if self.decorators is not None:
             yield self.decorators
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1176,7 +1176,7 @@ class Lambda(_base_nodes.FilterStmtsBaseNode, LocalsDictNodeNG):
         # to None due to a strong interaction between Lambda and FunctionDef.
         return self.body.infer(context)
 
-    def scope_lookup(self, node, name: str, offset: int=0):
+    def scope_lookup(self, node, name: str, offset: int = 0):
         """Lookup where the given names is assigned.
 
         :param node: The node to look for assignments up to.
@@ -2143,8 +2143,7 @@ class ClassDef(
 
     @cached_property
     def blockstart_tolineno(self) -> int:
-        """The line on which the beginning of this block ends.
-        """
+        """The line on which the beginning of this block ends."""
         if self.bases:
             return self.bases[-1].tolineno
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Add more type annotations, and cut out some unnecessary docstring lines.

Running Mypy strict, this goes from 1479 errors to 1446.