### PR TITLE
Add support for keyword only argument default values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@ Release date: TBA
 
   Refs PyCQA/pylint#7306
 
+* ``Astroid`` now retrieves the default values of keyword only arguments and sets them on
+  ``Arguments.kw_defaults``.
+
 * ``Uninferable`` now has the type ``UninferableBase``. This is to facilitate correctly type annotating
   code that uses this singleton.
 

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -650,8 +650,12 @@ class Arguments(_base_nodes.AssignTypeNode):
         self.posonlyargs: list[AssignName] = []
         """The arguments that can only be passed positionally."""
 
-        self.kw_defaults: list[NodeNG | None]
-        """The default values for keyword arguments that cannot be passed positionally."""
+        self.kw_defaults: list[NodeNG | None] | None
+        """
+        The default values for keyword arguments that cannot be passed positionally.
+
+        See .args for why this can be None.
+        """
 
         self.annotations: list[NodeNG | None]
         """The type annotations of arguments that can be passed positionally."""
@@ -695,7 +699,7 @@ class Arguments(_base_nodes.AssignTypeNode):
         args: list[AssignName] | None,
         defaults: list[NodeNG] | None,
         kwonlyargs: list[AssignName],
-        kw_defaults: list[NodeNG | None],
+        kw_defaults: list[NodeNG | None] | None,
         annotations: list[NodeNG | None],
         posonlyargs: list[AssignName] | None = None,
         kwonlyargs_annotations: list[NodeNG | None] | None = None,
@@ -979,7 +983,7 @@ class Arguments(_base_nodes.AssignTypeNode):
             yield from self.defaults
         yield from self.kwonlyargs
 
-        for elt in self.kw_defaults:
+        for elt in self.kw_defaults or ():
             if elt is not None:
                 yield elt
 

--- a/tests/unittest_nodes.py
+++ b/tests/unittest_nodes.py
@@ -869,7 +869,22 @@ class ArgumentsNodeTC(unittest.TestCase):
         """
         )
         args = ast["func"].args
-        self.assertTrue(args.is_argument("x"))
+        assert isinstance(args, nodes.Arguments)
+        assert args.is_argument("x")
+        assert args.kw_defaults == [None]
+
+        ast = builder.parse(
+            """
+            def func(*, x = "default"):
+                pass
+        """
+        )
+        args = ast["func"].args
+        assert isinstance(args, nodes.Arguments)
+        assert args.is_argument("x")
+        assert len(args.kw_defaults) == 1
+        assert isinstance(args.kw_defaults[0], nodes.Const)
+        assert args.kw_defaults[0].value == "default"
 
     @test_utils.require_version(minver="3.8")
     def test_positional_only(self):


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Found these changes laying around in https://github.com/PyCQA/astroid/pull/1593.

I couldn't find an `astroid` or `pylint` issue to reference, although I know this has been an issue previously for certain checks.