### PR TITLE
Fix '_infer_str_format_call' crash when the string it analyses are uninferable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,9 @@ What's New in astroid 2.14.2?
 =============================
 Release date: TBA
 
+* '_infer_str_format_call' won't crash anymore when the string it analyses are uninferable.
+
+  Closes PyCQA/pylint#8109
 
 
 What's New in astroid 2.14.1?

--- a/astroid/brain/brain_builtin_inference.py
+++ b/astroid/brain/brain_builtin_inference.py
@@ -930,7 +930,9 @@ def _infer_str_format_call(
     """Return a Const node based on the template and passed arguments."""
     call = arguments.CallSite.from_call(node, context=context)
     if isinstance(node.func.expr, nodes.Name):
-        value: nodes.Const = helpers.safe_infer(node.func.expr)
+        value: nodes.Const | None = helpers.safe_infer(node.func.expr)
+        if value is None:
+            return iter([util.Uninferable])
     else:
         value = node.func.expr
 

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -1350,23 +1350,3 @@ def test_dataclass_with_properties() -> None:
     fourth_init: bases.UnboundMethod = next(fourth.infer())
     assert [a.name for a in fourth_init.args.args] == ["self", "other_attr", "attr"]
     assert [a.name for a in fourth_init.args.defaults] == ["Uninferable"]
-
-
-def test_dataclass_pylint_8109() -> None:
-    """https://github.com/PyCQA/pylint/issues/8109"""
-    function_def = astroid.extract_node(
-        """
-from dataclasses import dataclass
-
-@dataclass
-class Number:
-    amount: int | float
-    round: int = 2
-
-    def __str__(self): #@
-        number_format = "{:,.%sf}" % self.round
-        return number_format.format(self.amount).rstrip("0").rstrip(".")
-"""
-    )
-    inferit = function_def.infer_call_result(function_def, context=None)
-    assert [a.name for a in inferit] == [Uninferable]

--- a/tests/brain/test_dataclasses.py
+++ b/tests/brain/test_dataclasses.py
@@ -1350,3 +1350,23 @@ def test_dataclass_with_properties() -> None:
     fourth_init: bases.UnboundMethod = next(fourth.infer())
     assert [a.name for a in fourth_init.args.args] == ["self", "other_attr", "attr"]
     assert [a.name for a in fourth_init.args.defaults] == ["Uninferable"]
+
+
+def test_dataclass_pylint_8109() -> None:
+    """https://github.com/PyCQA/pylint/issues/8109"""
+    function_def = astroid.extract_node(
+        """
+from dataclasses import dataclass
+
+@dataclass
+class Number:
+    amount: int | float
+    round: int = 2
+
+    def __str__(self): #@
+        number_format = "{:,.%sf}" % self.round
+        return number_format.format(self.amount).rstrip("0").rstrip(".")
+"""
+    )
+    inferit = function_def.infer_call_result(function_def, context=None)
+    assert [a.name for a in inferit] == [Uninferable]


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes PyCQA/pylint#8109
