### PR TITLE
Update ``FormattedValue.postinit`` and its brain

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ What's New in astroid 2.15.0?
 =============================
 Release date: TBA
 
+* ``Formattedvalue.postinit`` is now keyword only. This is to allow correct typing of the
+  ``Formattedvalue`` class.
+
+  Refs #1516
+
 * ``Astroid`` now supports custom import hooks.
 
   Refs PyCQA/pylint#7306

--- a/astroid/brain/brain_fstrings.py
+++ b/astroid/brain/brain_fstrings.py
@@ -2,13 +2,20 @@
 # For details: https://github.com/PyCQA/astroid/blob/main/LICENSE
 # Copyright (c) https://github.com/PyCQA/astroid/blob/main/CONTRIBUTORS.txt
 
+from __future__ import annotations
+
 import collections.abc
+from typing import TypeVar
 
+from astroid import nodes
 from astroid.manager import AstroidManager
-from astroid.nodes.node_classes import FormattedValue
+
+_NodeT = TypeVar("_NodeT", bound=nodes.NodeNG)
 
 
-def _clone_node_with_lineno(node, parent, lineno):
+def _clone_node_with_lineno(
+    node: _NodeT, parent: nodes.NodeNG, lineno: int | None
+) -> _NodeT:
     cls = node.__class__
     other_fields = node._other_fields
     _astroid_fields = node._astroid_fields
@@ -28,16 +35,22 @@ def _clone_node_with_lineno(node, parent, lineno):
     return new_node
 
 
-def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-statements
+def _transform_formatted_value(  # pylint: disable=inconsistent-return-statements
+    node: nodes.FormattedValue,
+) -> nodes.FormattedValue | None:
     if node.value and node.value.lineno == 1:
         if node.lineno != node.value.lineno:
-            new_node = FormattedValue(
+            new_node = nodes.FormattedValue(
                 lineno=node.lineno, col_offset=node.col_offset, parent=node.parent
             )
             new_value = _clone_node_with_lineno(
                 node=node.value, lineno=node.lineno, parent=new_node
             )
-            new_node.postinit(value=new_value, format_spec=node.format_spec)
+            new_node.postinit(
+                value=new_value,
+                conversion=node.conversion,
+                format_spec=node.format_spec,
+            )
             return new_node
 
 
@@ -45,4 +58,4 @@ def _transform_formatted_value(node):  # pylint: disable=inconsistent-return-sta
 # The problem is that FormattedValue.value, which is a Name node,
 # has wrong line numbers, usually 1. This creates problems for pylint,
 # which expects correct line numbers for things such as message control.
-AstroidManager().register_transform(FormattedValue, _transform_formatted_value)
+AstroidManager().register_transform(nodes.FormattedValue, _transform_formatted_value)

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -4696,20 +4696,18 @@ class FormattedValue(NodeNG):
         self.value: NodeNG
         """The value to be formatted into the string."""
 
-        self.conversion: int | None = None  # can be None
+        self.conversion: int
         """The type of formatting to be applied to the value.
 
         .. seealso::
             :class:`ast.FormattedValue`
         """
 
-        self.format_spec: NodeNG | None = None  # can be None
+        self.format_spec: JoinedStr | None = None
         """The formatting to be applied to the value.
 
         .. seealso::
             :class:`ast.FormattedValue`
-
-        :type: JoinedStr or None
         """
 
         super().__init__(
@@ -4722,9 +4720,10 @@ class FormattedValue(NodeNG):
 
     def postinit(
         self,
+        *,
         value: NodeNG,
-        conversion: int | None = None,
-        format_spec: NodeNG | None = None,
+        conversion: int,
+        format_spec: JoinedStr | None = None,
     ) -> None:
         """Do some setup after initialisation.
 

--- a/astroid/rebuilder.py
+++ b/astroid/rebuilder.py
@@ -1442,9 +1442,9 @@ class TreeRebuilder:
             parent=parent,
         )
         newnode.postinit(
-            self.visit(node.value, newnode),
-            node.conversion,
-            self.visit(node.format_spec, newnode),
+            value=self.visit(node.value, newnode),
+            conversion=node.conversion,
+            format_spec=self.visit(node.format_spec, newnode),
         )
         return newnode
 


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Refs https://github.com/PyCQA/astroid/issues/1516.

Decided to make this a breaking change as it just so much easier to update signatures when these are keyword only. I don't think a small breaking change at the top of the signature matters too much.

Using an `Enum` doesn't make a lot of sense as the `ast` module has it as an `int`. So we would need to of some casting to that `Enum` and that could be the source of nasty crashes,