### PR TITLE
Clear context cache in AstroidManager.clear_cache()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,10 @@ Release date: TBA
 
   Refs PyCQA/pylint#5288
 
+* ``AstroidManager.clear_cache`` now also clears the inference context cache.
+
+  Refs #1780
+
 * ``Astroid`` now retrieves the default values of keyword only arguments and sets them on
   ``Arguments.kw_defaults``.
 

--- a/astroid/manager.py
+++ b/astroid/manager.py
@@ -20,7 +20,7 @@ from typing import Any, ClassVar
 from astroid import nodes
 from astroid._cache import CACHE_MANAGER
 from astroid.const import BRAIN_MODULES_DIRECTORY
-from astroid.context import InferenceContext
+from astroid.context import InferenceContext, _invalidate_cache
 from astroid.exceptions import AstroidBuildingError, AstroidImportError
 from astroid.interpreter._import import spec, util
 from astroid.modutils import (
@@ -407,7 +407,7 @@ class AstroidManager:
         raw_building._astroid_bootstrapping()
 
     def clear_cache(self) -> None:
-        """Clear the underlying cache, bootstrap the builtins module and
+        """Clear the underlying caches, bootstrap the builtins module and
         re-register transforms.
         """
         # import here because of cyclic imports
@@ -418,6 +418,7 @@ class AstroidManager:
         from astroid.nodes.scoped_nodes import ClassDef
 
         clear_inference_tip_cache()
+        _invalidate_cache()  # inference context cache
 
         self.astroid_cache.clear()
         # NB: not a new TransformVisitor()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -430,6 +430,8 @@ class ClearCacheTest(unittest.TestCase):
 
         astroid.MANAGER.clear_cache()  # also calls bootstrap()
 
+        self.assertEqual(astroid.context._INFERENCE_CACHE, {})
+
         # The cache sizes are now as low or lower than the original baseline
         cleared_cache_infos = [lru.cache_info() for lru in lrus]
         for cleared_cache, baseline_cache in zip(


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
We missed one cache when improving `AstroidManager.clear_cache()` in recent releases.

Refs #1580