### PR TITLE
Restore setting a Call as a base for classes from `six.with_metaclass()`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,12 @@ What's New in astroid 2.15.1?
 =============================
 Release date: TBA
 
+* Restore behavior of setting a Call as a base for classes created using ``six.with_metaclass()``,
+  and harden support for using enums as metaclasses in this case.
+
+  Reverts #1622
+  Refs PyCQA/pylint#5935
+  Refs PyCQA/pylint#7506
 
 
 What's New in astroid 2.15.0?

--- a/astroid/brain/brain_six.py
+++ b/astroid/brain/brain_six.py
@@ -219,7 +219,6 @@ def transform_six_with_metaclass(node):
     """
     call = node.bases[0]
     node._metaclass = call.args[0]
-    node.bases = call.args[1:]
     return node
 
 

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1702,7 +1702,15 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
             metaclass = next(caller.args[0].infer(context), None)
             if isinstance(metaclass, ClassDef):
                 try:
-                    class_bases = [next(arg.infer(context)) for arg in caller.args[1:]]
+                    class_bases = [
+                        # Find the first non-None inferred base value
+                        next(
+                            b
+                            for b in arg.infer(context=context.clone())
+                            if not (isinstance(b, Const) and b.value is None)
+                        )
+                        for arg in caller.args[1:]
+                    ]
                 except StopIteration as e:
                     raise InferenceError(node=caller.args[1:], context=context) from e
                 new_class = ClassDef(name="temporary_class")

--- a/tests/brain/test_six.py
+++ b/tests/brain/test_six.py
@@ -110,8 +110,7 @@ class SixBrainTest(unittest.TestCase):
         inferred = next(ast_node.infer())
         self.assertIsInstance(inferred, nodes.ClassDef)
         self.assertEqual(inferred.name, "B")
-        self.assertIsInstance(inferred.bases[0], nodes.Name)
-        self.assertEqual(inferred.bases[0].name, "C")
+        self.assertIsInstance(inferred.bases[0], nodes.Call)
         ancestors = tuple(inferred.ancestors())
         self.assertIsInstance(ancestors[0], nodes.ClassDef)
         self.assertEqual(ancestors[0].name, "C")
@@ -131,7 +130,7 @@ class SixBrainTest(unittest.TestCase):
             bar = 1
         """
         klass = astroid.extract_node(code)
-        assert list(klass.ancestors())[-1].name == "Enum"
+        assert next(klass.ancestors()).name == "Enum"
 
     def test_six_with_metaclass_with_additional_transform(self) -> None:
         def transform_class(cls: Any) -> ClassDef:

--- a/tests/test_scoped_nodes.py
+++ b/tests/test_scoped_nodes.py
@@ -1403,6 +1403,20 @@ class ClassNodeTest(ModuleLoader, unittest.TestCase):
         self.assertEqual(["object"], [base.name for base in klass.ancestors()])
         self.assertEqual("type", klass.metaclass().name)
 
+    @unittest.skipUnless(HAS_SIX, "These tests require the six library")
+    def test_metaclass_generator_hack_enum_base(self):
+        """Regression test for https://github.com/PyCQA/pylint/issues/5935"""
+        klass = builder.extract_node(
+            """
+            import six
+            from enum import Enum, EnumMeta
+
+            class PetEnumPy2Metaclass(six.with_metaclass(EnumMeta, Enum)): #@
+                DOG = "dog"
+        """
+        )
+        self.assertEqual(list(klass.local_attr_ancestors("DOG")), [])
+
     def test_add_metaclass(self) -> None:
         klass = builder.extract_node(
             """


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Harden support for using enums as metaclasses with `six.with_metaclass(...)` syntax.

Fixes the crash in PyCQA/pylint#5935 by adopting the check for not-none bases as in `ClassDef._inferred_bases` without recausing the false positive reported in PyCQA/pylint#7506, which requires having correct bases. Here is the analogous existing code:

https://github.com/PyCQA/astroid/blob/91fd7b95fc943676f5aafb2d0ee881c4e167fa04/astroid/nodes/scoped_nodes/scoped_nodes.py#L3001-L3006

Essentially reverts #1622 (Sorry! It was my best understanding at the time, and at least we were trading a crash for a false positive.)

Refs PyCQA/pylint#5935 (crash: tested here with test_metaclass_generator_hack_enum_base)
Refs PyCQA/pylint#7506 (false positive: will open a pylint regression test PR shortly)