### PR TITLE
Change `_get_assign_nodes()` to `cached_property`

### DIFF
--- a/astroid/nodes/_base_nodes.py
+++ b/astroid/nodes/_base_nodes.py
@@ -14,7 +14,6 @@ import sys
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar
 
-from astroid import decorators
 from astroid.exceptions import AttributeInferenceError
 from astroid.nodes.node_ng import NodeNG
 
@@ -196,10 +195,10 @@ class MultiLineBlockNode(NodeNG):
                     continue
                 yield from child_node._get_yield_nodes_skip_lambdas()
 
-    @decorators.cached
-    def _get_assign_nodes(self):
+    @cached_property
+    def _assign_nodes_in_scope(self) -> list[nodes.Assign]:
         children_assign_nodes = (
-            child_node._get_assign_nodes()
+            child_node._assign_nodes_in_scope
             for block in self._multi_line_blocks
             for child_node in block
         )

--- a/astroid/nodes/node_classes.py
+++ b/astroid/nodes/node_classes.py
@@ -1271,9 +1271,9 @@ class Assign(_base_nodes.AssignTypeNode, _base_nodes.Statement):
 
         yield self.value
 
-    @decorators.cached
-    def _get_assign_nodes(self):
-        return [self] + list(self.value._get_assign_nodes())
+    @cached_property
+    def _assign_nodes_in_scope(self) -> list[nodes.Assign]:
+        return [self] + self.value._assign_nodes_in_scope
 
     def _get_yield_nodes_skip_lambdas(self):
         yield from self.value._get_yield_nodes_skip_lambdas()

--- a/astroid/nodes/node_ng.py
+++ b/astroid/nodes/node_ng.py
@@ -21,7 +21,7 @@ from typing import (
     overload,
 )
 
-from astroid import decorators, util
+from astroid import util
 from astroid.context import InferenceContext
 from astroid.exceptions import (
     AstroidError,
@@ -575,8 +575,8 @@ class NodeNG:
                 continue
             yield from child_node.nodes_of_class(klass, skip_klass)
 
-    @decorators.cached
-    def _get_assign_nodes(self):
+    @cached_property
+    def _assign_nodes_in_scope(self) -> list[nodes.Assign]:
         return []
 
     def _get_name_nodes(self):

--- a/astroid/nodes/scoped_nodes/scoped_nodes.py
+++ b/astroid/nodes/scoped_nodes/scoped_nodes.py
@@ -1434,7 +1434,7 @@ class FunctionDef(_base_nodes.MultiLineBlockNode, _base_nodes.Statement, Lambda)
             return []
 
         decorators: list[node_classes.Call] = []
-        for assign in frame._get_assign_nodes():
+        for assign in frame._assign_nodes_in_scope:
             if isinstance(assign.value, node_classes.Call) and isinstance(
                 assign.value.func, node_classes.Name
             ):
@@ -3065,10 +3065,10 @@ class ClassDef(
             yield from self.keywords
         yield from self.body
 
-    @decorators_mod.cached
-    def _get_assign_nodes(self):
+    @cached_property
+    def _assign_nodes_in_scope(self):
         children_assign_nodes = (
-            child_node._get_assign_nodes() for child_node in self.body
+            child_node._assign_nodes_in_scope for child_node in self.body
         )
         return list(itertools.chain.from_iterable(children_assign_nodes))
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
`cached_property` does a much better job cleaning up after itself than we're doing.

Refs #1780
